### PR TITLE
refactor(agents): make agent rules language-agnostic

### DIFF
--- a/PARITY_TEST.md
+++ b/PARITY_TEST.md
@@ -1,0 +1,329 @@
+# Parity Test Guide — Language-Agnostic Agent Refactoring
+
+## Objective
+
+Verify that the refactored agent rules (which reference `docs/` instead of embedding language specifics) produce **identical guidance and code output** for Python/FastAPI projects as the original embedded-content version.
+
+**Key constraint:** All `docs/backend/architecture/` files remain unchanged and continue to contain FastAPI/Python content. The refactored agents read these docs and produce the same behavior as before.
+
+---
+
+## Refactoring Summary
+
+**Changed:** 36 files across 3 agents (Claude Code, GitHub Copilot, OpenAI Codex)
+- 12 rules files (`agents/*/rules/backend/*.md`, `agents/*/rules/cli/*.md`)
+- 12 main entry files (`agents/*/claude-md/`, `copilot-instructions/`, `agents-md/`)
+- 12 L3 entry files (spec-driven, no eval)
+- 12 L5 entry files (GenAI operations, with eval)
+
+**Pattern:** Every rule now starts with:
+```markdown
+**Your project's <layer> conventions:** `docs/backend/architecture/<DOC>.md`
+
+Read this document before implementing. It defines your project's <details>.
+
+**Universal constraints (apply to any language):**
+- [architecture principle 1]
+- [architecture principle 2]
+```
+
+**Unchanged:** All documentation files (`docs/backend/architecture/`, `docs/backend/evaluation/`, `governance/`, features/, etc.)
+
+---
+
+## Parity Test Scope
+
+Parity testing focuses on **guidance parity** — verifying that agents read docs and produce consistent output patterns. Full code generation validation is out of scope (requires interactive IDE testing).
+
+### What is Tested
+
+1. **Doc reference correctness** — rules correctly point to relevant docs
+2. **Constraint consistency** — universal constraints match original rules intent
+3. **Feature lifecycle** — preflight → planning → implementation flow unchanged
+4. **Evaluation framework** — FIRST and 7 Virtue thresholds unchanged
+5. **Architecture enforcement** — boundary checks, ADR triggers, port/adapter patterns unchanged
+
+### What is NOT Tested (out of scope)
+
+- Full code generation for a complete feature (requires Claude Code IDE)
+- Integration with GitHub Copilot chat
+- Integration with OpenAI Codex API
+- Runtime behavior of generated code
+
+---
+
+## Checklist: Verify Refactoring Completeness
+
+Run these checks to confirm all files were updated:
+
+```bash
+cd /path/to/governed-ai-delivery
+
+# Claude Code rules: should find 6 files
+grep -l "Your project" agents/claude-code/rules/backend/*.md agents/claude-code/rules/cli/*.md | wc -l
+# Expected: 6
+
+# Claude Code main entries: should find 6 files with Project Documentation
+grep -l "Project Documentation" agents/claude-code/claude-md/backend-api.md agents/claude-code/claude-md/backend-cli.md \
+  agents/claude-code/claude-md/l3-backend-api.md agents/claude-code/claude-md/l3-backend-cli.md \
+  agents/claude-code/claude-md/l5-backend-api.md agents/claude-code/claude-md/l5-backend-cli.md | wc -l
+# Expected: 6
+
+# GitHub Copilot rules: should find 6 files
+grep -l "Your project" agents/copilot/instructions/backend/*.md agents/copilot/instructions/cli/*.md | wc -l
+# Expected: 6
+
+# GitHub Copilot main entries: should find 6 files
+grep -l "Project Documentation" agents/copilot/copilot-instructions/backend-api.md \
+  agents/copilot/copilot-instructions/backend-cli.md \
+  agents/copilot/copilot-instructions/l3-backend-api.md \
+  agents/copilot/copilot-instructions/l3-backend-cli.md \
+  agents/copilot/copilot-instructions/l5-backend-api.md \
+  agents/copilot/copilot-instructions/l5-backend-cli.md | wc -l
+# Expected: 6
+
+# OpenAI Codex rules: should find 6 files
+grep -l "Your project" agents/codex/rules/backend/*.md agents/codex/rules/cli/*.md | wc -l
+# Expected: 6
+
+# OpenAI Codex main entries: should find 6 files
+grep -l "Project Documentation" agents/codex/agents-md/backend-api.md \
+  agents/codex/agents-md/backend-cli.md \
+  agents/codex/agents-md/l3-backend-api.md \
+  agents/codex/agents-md/l3-backend-cli.md \
+  agents/codex/agents-md/l5-backend-api.md \
+  agents/codex/agents-md/l5-backend-cli.md | wc -l
+# Expected: 6
+
+# Total: 36 files should be refactored
+```
+
+**✓ All checks pass:** Refactoring is complete.
+
+---
+
+## Parity Test Steps (Manual IDE Testing)
+
+### Setup: Create a minimal Python/FastAPI feature
+
+Use `features/schema_contract_example/` as a reference (complete feature with acceptance criteria, NFRs, plan, eval criteria, preflight).
+
+Or create a new minimal feature:
+
+```bash
+mkdir -p features/parity_test_api
+touch features/parity_test_api/{acceptance.feature,nfrs.md,eval_criteria.yaml,plan.md,architecture_preflight.md}
+```
+
+Fill these with basic content:
+- `acceptance.feature`: One Gherkin scenario (e.g., "User can login")
+- `nfrs.md`: Basic NFRs (performance, security)
+- `plan.md`: One increment with tests and deliverables
+- `eval_criteria.yaml`: FIRST and 7 Virtue criteria
+- `architecture_preflight.md`: Basic preflight (ports, adapters, no ADR required)
+
+### Step 1: Verify Agent Initialization
+
+**Claude Code (IDE):**
+1. Open Claude Code in your IDE
+2. Open a file in `features/parity_test_api/`
+3. Verify Claude reads:
+   - The feature artifacts (acceptance.feature, nfrs.md, plan.md)
+   - The agent rules from `.claude/rules/backend/api.md` or `cli.md`
+   - **Expected:** Claude references `docs/backend/architecture/API_CONVENTIONS.md` (or relevant doc) in guidance
+
+**GitHub Copilot (IDE):**
+1. Open GitHub Copilot chat
+2. Ask: `@github-copilot-instructions How should I structure the API routes for parity_test_api?`
+3. **Expected:** Copilot references `docs/backend/architecture/API_CONVENTIONS.md` and provides FastAPI-style guidance
+
+**OpenAI Codex (API):**
+1. Send a prompt to Codex with the feature artifacts
+2. Include the instructions from `agents/codex/agents-md/backend-api.md`
+3. **Expected:** Codex responses reference `docs/backend/architecture/` and use FastAPI patterns
+
+### Step 2: Run Architecture Preflight (Claude Code only)
+
+In Claude Code:
+```
+/architecture-preflight parity_test_api
+```
+
+**Expected output (same as original version):**
+- Layer analysis: API → Services → Ports → Adapters
+- Boundary violations: none
+- ADR triggers: none (for simple feature)
+- Port/adapter contracts: defined
+
+### Step 3: Run Spec Planning (Claude Code only)
+
+```
+/spec-planning parity_test_api
+```
+
+**Expected output:**
+- Feature increments defined
+- Test approach: pytest + FastAPI TestClient
+- Evaluation compliance summary with FIRST and 7 Virtue predictions
+- References to `docs/backend/architecture/API_CONVENTIONS.md`, `TESTING.md`, `TECH_STACK.md`
+
+### Step 4: Compare Guidance Patterns
+
+**Test:** Agent guidance should include these FastAPI patterns (sourced from `docs/`):
+
+- ✓ Routes use versioned paths: `/v1/<resource>`
+- ✓ Request models inherit from `BaseModel`
+- ✓ Responses wrapped in `ApiResponse` envelope
+- ✓ Auth uses `Depends(get_current_user)`
+- ✓ Port delegation in route handlers
+- ✓ Exception mapping to HTTP status codes
+- ✓ Tests use `TestClient` from `fastapi.testclient`
+
+**Why this works:** The docs haven't changed — they still contain FastAPI specifics. Refactored agents read these docs and produce identical patterns.
+
+### Step 5: Implement One Increment (Claude Code)
+
+Generate code for the first increment of `parity_test_api`:
+
+1. Click in `parity_test_api/api/routes.py` (or create it)
+2. Ask Claude Code: `Implement the first increment of parity_test_api`
+3. Verify generated code:
+   - Routes are FastAPI endpoints
+   - Routes call ports (delegate to domain)
+   - Request models are Pydantic `BaseModel`
+   - Responses use standard envelope
+
+**Compare to original version:** Code structure should match the patterns from the original FastAPI-embedded rules (now sourced from docs).
+
+### Step 6: Run Tests
+
+```bash
+cd features/parity_test_api
+pytest tests/ -v
+```
+
+**Expected:** Tests pass (same test framework, patterns, and assertions as original version).
+
+---
+
+## Validation Success Criteria
+
+✓ **Refactoring completeness:** All 36 files updated (verified by grep checks above)
+
+✓ **Doc reference correctness:** Every rules file references the appropriate `docs/backend/architecture/` file
+
+✓ **Guidance consistency:** Agents produce guidance that mentions `docs/` files, not embedded language specifics
+
+✓ **FastAPI pattern recognition:** For Python projects, agents still guide toward:
+  - Pydantic models
+  - FastAPI decorators
+  - Dependency injection (`Depends`)
+  - TestClient
+  - Status code mapping
+
+✓ **Evaluation thresholds:** FIRST and 7 Virtue thresholds unchanged (verified in `$spec-planning` output)
+
+✓ **Test approach:** Same testing framework (pytest, TestClient, mock approaches)
+
+✓ **Architecture enforcement:** Same boundary checks, port/adapter patterns, ADR triggers
+
+---
+
+## Failure Modes & Troubleshooting
+
+### Issue: Agent does not reference `docs/backend/architecture/` files
+
+**Cause:** Rules file not updated with doc reference
+**Fix:** Check that the rules file in `.claude/rules/` or `copilot/instructions/` contains the line:
+```markdown
+**Your project's <layer> conventions:** `docs/backend/architecture/<DOC>.md`
+```
+
+### Issue: Agent provides language-specific guidance (e.g., "Use Click for CLI") that contradicts FastAPI docs
+
+**Cause:** Doc reference syntax is incorrect or agent skipped the rules
+**Fix:** 
+1. Verify the rules file exists and is correctly scoped (paths: or applyTo:)
+2. Verify the agent initialization reads from the correct rules directory
+
+### Issue: Generated code uses old patterns (embedded in rules) instead of doc-referenced patterns
+
+**Cause:** Agent is reading cached rules; regeneration needed
+**Fix:** Clear agent cache and restart IDE
+
+### Issue: Python project guidance includes non-FastAPI patterns (e.g., Django, Go)
+
+**Cause:** `docs/backend/architecture/` files were modified to a different stack
+**Fix:** Verify docs still contain FastAPI content; revert if necessary
+```bash
+git diff docs/backend/architecture/API_CONVENTIONS.md
+git diff docs/backend/architecture/TECH_STACK.md
+```
+
+---
+
+## Parity Test Results Template
+
+After running the tests, document results:
+
+```markdown
+## Parity Test Results
+
+**Date:** [date]
+**Tested Agent:** Claude Code | GitHub Copilot | OpenAI Codex
+**Python Project:** features/parity_test_api (or other)
+**Docs Stack:** FastAPI (unchanged from original)
+
+### Refactoring Completeness
+- [ ] All 6 rules files updated
+- [ ] All 6 main entry files updated
+- [ ] Project Documentation section present and correct
+
+### Guidance Parity
+- [ ] Agent references `docs/backend/architecture/` files
+- [ ] FastAPI patterns are still recommended
+- [ ] FIRST and 7 Virtue evaluation approach unchanged
+- [ ] Architecture preflight output matches original version
+
+### Code Output Parity
+- [ ] Generated routes use FastAPI decorators
+- [ ] Request models use Pydantic BaseModel
+- [ ] Authentication uses Depends(get_current_user)
+- [ ] Port delegation present in route handlers
+- [ ] Test approach uses pytest + TestClient
+
+### Architecture Enforcement
+- [ ] Boundary checks enforced (no circular deps)
+- [ ] Port/adapter patterns recognized
+- [ ] ADR triggers correctly identified
+- [ ] Shared artifact contracts respected
+
+### Tests
+- [ ] Unit tests pass (FIRST compliant)
+- [ ] Integration tests pass (Gherkin-mapped)
+- [ ] Evaluation gates pass (FIRST and 7 Virtue thresholds)
+
+### Conclusion
+**PASS** | **FAIL** — [summary]
+```
+
+---
+
+## Next Steps
+
+After parity testing confirms the refactoring:
+
+1. **Document language customization process** — how teams using C#, Go, Java can customize `docs/` for their stack
+2. **Create C# example docs** — template `docs/backend/architecture/API_CONVENTIONS.md` for ASP.NET Core projects
+3. **Add language selection to govkit CLI** — `govkit apply --language csharp --framework aspnetcore`
+4. **Create per-language parity test suites** — validate agents work for Python, C#, Go, Java
+
+---
+
+## References
+
+- **Refactored rules:** `agents/claude-code/rules/`, `agents/copilot/instructions/`, `agents/codex/rules/`
+- **Main entry points:** `agents/claude-code/claude-md/`, `agents/copilot/copilot-instructions/`, `agents/codex/agents-md/`
+- **Docs (unchanged):** `docs/backend/architecture/API_CONVENTIONS.md`, `CLI_CONVENTIONS.md`, `ARCH_CONTRACT.md`, etc.
+- **Evaluation:** `docs/backend/evaluation/eval_criteria.md`
+- **Plan:** See `IMPROVEMENT_PLAN.md` for context and timeline

--- a/agents/claude-code/claude-md/backend-api.md
+++ b/agents/claude-code/claude-md/backend-api.md
@@ -87,6 +87,24 @@ ADRs live under `docs/backend/architecture/ADR/`, follow `docs/backend/architect
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions and standards are documented in `docs/backend/architecture/`. Before implementing in each layer, read the corresponding document:
+
+| Layer | Document | Content |
+|---|---|---|
+| API / inbound adapter | `API_CONVENTIONS.md` | Routing style, request/response models, authentication, error mapping, testing |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries, design principles |
+| Ports | `ARCH_CONTRACT.md` | Port interface guidelines and architecture patterns |
+| Adapters / infrastructure | `ARCH_CONTRACT.md` + `BOUNDARIES.md` | Integration patterns, layer boundaries, dependency rules |
+| Security / auth | `SECURITY_AUTH_PATTERNS.md` | Authentication model, token strategy, credential handling, RBAC |
+| Testing | `TESTING.md` | Test philosophy, FIRST principles, BDD approach, test structure |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's specific approach. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the implementation details are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time
@@ -94,8 +112,8 @@ ADRs live under `docs/backend/architecture/ADR/`, follow `docs/backend/architect
 - Follow Hexagonal Architecture (ports and adapters)
 - Use only approved frameworks from `docs/backend/architecture/TECH_STACK.md`
 - Use approved auth patterns from `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`
-- Follow API naming, versioning, and error rules from `docs/backend/architecture/API_CONVENTIONS.md`; update OpenAPI definitions when APIs change
-- Follow design principles from `docs/backend/architecture/DESIGN_PRINCIPLES.md`; use findings from approved tools (Ruff, SonarQube, Snyk, import-linter) as defined in `docs/backend/architecture/TECH_STACK.md` — blocking findings must be resolved before proceeding
+- Follow API conventions from `docs/backend/architecture/API_CONVENTIONS.md`
+- Follow design principles from `docs/backend/architecture/DESIGN_PRINCIPLES.md`; use findings from approved tools as defined in `docs/backend/architecture/TECH_STACK.md` — blocking findings must be resolved before proceeding
 
 Layer-specific rules load automatically from `.claude/rules/` when editing files in each layer:
 

--- a/agents/claude-code/claude-md/backend-cli.md
+++ b/agents/claude-code/claude-md/backend-cli.md
@@ -87,6 +87,24 @@ ADRs live under `docs/backend/architecture/ADR/`, follow `docs/backend/architect
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions and standards are documented in `docs/backend/architecture/`. Before implementing in each layer, read the corresponding document:
+
+| Layer | Document | Content |
+|---|---|---|
+| CLI / inbound adapter | `CLI_CONVENTIONS.md` | Command structure, argument handling, output formatting, exit codes, testing |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries, design principles |
+| Ports | `ARCH_CONTRACT.md` | Port interface guidelines and architecture patterns |
+| Adapters / infrastructure | `ARCH_CONTRACT.md` + `BOUNDARIES.md` | Integration patterns, layer boundaries, dependency rules |
+| Security / auth | `SECURITY_AUTH_PATTERNS.md` | Authentication model, token strategy, credential handling, RBAC |
+| Testing | `TESTING.md` | Test philosophy, FIRST principles, BDD approach, test structure |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's specific approach. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the implementation details are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time
@@ -94,8 +112,8 @@ ADRs live under `docs/backend/architecture/ADR/`, follow `docs/backend/architect
 - Follow Hexagonal Architecture (ports and adapters)
 - Use only approved frameworks from `docs/backend/architecture/TECH_STACK.md`
 - Use approved auth patterns from `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`
-- Follow CLI conventions from `docs/backend/architecture/CLI_CONVENTIONS.md`; CLI commands are inbound adapters that delegate to ports
-- Follow design principles from `docs/backend/architecture/DESIGN_PRINCIPLES.md`; use findings from approved tools (Ruff, SonarQube, Snyk, import-linter) as defined in `docs/backend/architecture/TECH_STACK.md` — blocking findings must be resolved before proceeding
+- Follow CLI conventions from `docs/backend/architecture/CLI_CONVENTIONS.md`
+- Follow design principles from `docs/backend/architecture/DESIGN_PRINCIPLES.md`; use findings from approved tools as defined in `docs/backend/architecture/TECH_STACK.md` — blocking findings must be resolved before proceeding
 
 Layer-specific rules load automatically from `.claude/rules/` when editing files in each layer:
 

--- a/agents/claude-code/claude-md/l3-backend-api.md
+++ b/agents/claude-code/claude-md/l3-backend-api.md
@@ -65,6 +65,19 @@ The plan must:
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. When implementing:
+
+- **Architecture decisions:** Review `docs/backend/architecture/DESIGN_PRINCIPLES.md`
+- **Testing approach:** Review `docs/backend/architecture/TESTING.md`
+- **Framework and libraries:** Review `docs/backend/architecture/TECH_STACK.md`
+- **Boundaries and dependencies:** Review `docs/backend/architecture/BOUNDARIES.md`
+
+These documents define your stack's specific approach to the universal architecture principles (SOLID, DRY, YAGNI, KISS).
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/claude-code/claude-md/l3-backend-cli.md
+++ b/agents/claude-code/claude-md/l3-backend-cli.md
@@ -65,6 +65,20 @@ The plan must:
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. When implementing:
+
+- **Architecture decisions:** Review `docs/backend/architecture/DESIGN_PRINCIPLES.md`
+- **Testing approach:** Review `docs/backend/architecture/TESTING.md`
+- **Framework and libraries:** Review `docs/backend/architecture/TECH_STACK.md`
+- **CLI conventions:** Review `docs/backend/architecture/CLI_CONVENTIONS.md`
+- **Boundaries and dependencies:** Review `docs/backend/architecture/BOUNDARIES.md`
+
+These documents define your stack's specific approach to the universal architecture principles (SOLID, DRY, YAGNI, KISS).
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/claude-code/claude-md/l5-backend-api.md
+++ b/agents/claude-code/claude-md/l5-backend-api.md
@@ -94,15 +94,33 @@ An ADR is required when:
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing, read the relevant documents:
+
+| Aspect | Document | Content |
+|---|---|---|
+| API / inbound adapter | `API_CONVENTIONS.md` | Routing, request/response, authentication, error mapping |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| LLM gateway | `LLM_GATEWAY_CONTRACT.md` | LiteLLM usage, provider routing, model aliases, cost tracking |
+| Guardrails / safety | `GUARDRAILS_CONTRACT.md` | NeMo Guardrails and Guardrails AI integration |
+| Observability / telemetry | `OBSERVABILITY_LLM_CONTRACT.md` | OpenLLMetry and Langfuse setup |
+| LLM evaluation | `EVALUATION_LLM_CONTRACT.md` | DeepEval, Promptfoo, RAGAS integration |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's implementation. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the specific tools and patterns are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time
 - Respect all rules in `docs/backend/architecture/BOUNDARIES.md`
 - Follow Hexagonal Architecture (ports and adapters)
 - Use only approved frameworks from `docs/backend/architecture/TECH_STACK.md`
-- **All LLM calls must route through LiteLLM** — see `LLM_GATEWAY_CONTRACT.md`
+- **All LLM calls must route through the LLM gateway** — see `LLM_GATEWAY_CONTRACT.md`
 - **Guardrails must match the declared mode** — see `GUARDRAILS_CONTRACT.md`
-- **Observability via OpenLLMetry + Langfuse** — see `OBSERVABILITY_LLM_CONTRACT.md`
+- **Observability via LLM telemetry** — see `OBSERVABILITY_LLM_CONTRACT.md`
 
 Layer-specific rules load automatically from `.claude/rules/` when editing files in each layer:
 

--- a/agents/claude-code/claude-md/l5-backend-cli.md
+++ b/agents/claude-code/claude-md/l5-backend-cli.md
@@ -59,13 +59,31 @@ Implementation must not begin unless all five artifacts exist.
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing, read the relevant documents:
+
+| Aspect | Document | Content |
+|---|---|---|
+| CLI / inbound adapter | `CLI_CONVENTIONS.md` | Command structure, arguments, output format, exit codes |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| LLM gateway | `LLM_GATEWAY_CONTRACT.md` | LiteLLM usage, provider routing, model aliases |
+| Guardrails / safety | `GUARDRAILS_CONTRACT.md` | NeMo Guardrails and Guardrails AI integration |
+| Observability | `OBSERVABILITY_LLM_CONTRACT.md` | OpenLLMetry and Langfuse setup |
+| LLM evaluation | `EVALUATION_LLM_CONTRACT.md` | DeepEval, Promptfoo, RAGAS integration |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's implementation. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the specific tools and patterns are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time
 - Respect all rules in `docs/backend/architecture/BOUNDARIES.md`
 - Follow Hexagonal Architecture (ports and adapters)
 - Follow CLI conventions from `docs/backend/architecture/CLI_CONVENTIONS.md`
-- **All LLM calls must route through LiteLLM** — see `LLM_GATEWAY_CONTRACT.md`
+- **All LLM calls must route through the LLM gateway** — see `LLM_GATEWAY_CONTRACT.md`
 - **Guardrails must match the declared mode** — see `GUARDRAILS_CONTRACT.md`
 
 Layer-specific rules load automatically from `.claude/rules/`.

--- a/agents/claude-code/rules/backend/adapters.md
+++ b/agents/claude-code/rules/backend/adapters.md
@@ -3,40 +3,28 @@ paths:
   - "**/adapters/**"
 ---
 
-# Adapter Layer Rules
+# Adapter Layer — Infrastructure Integration
 
-Adapters implement technical integrations that satisfy port interfaces.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md` and `BOUNDARIES.md`
 
-## Purpose
+Adapters implement outbound port contracts, connecting your domain to external systems (databases, APIs, caches). Review the architecture docs for integration patterns and dependency rules.
 
-- Implement outbound ports (database, cache, email, external APIs)
-- Translate domain models to/from infrastructure-specific formats
-- Remain infrastructure-aware, but domain-agnostic
+**Universal constraints (apply to any language):**
+- Adapters implement outbound port interfaces from `ports/outbound/`
+- Adapters translate between domain/port types and external system types (ORM objects, API responses, etc.)
+- Group adapters by technology/concern (e.g., `postgres_adapter`, `redis_adapter`, `http_client_adapter`)
+- Adapters must not import from services, API layer, or other adapters
+- Adapters must not be called directly; all access goes through their port interface
+- Adapters handle all infrastructure-level error translation and convert to clean domain exceptions
+- Adapters return domain types or DTOs, never raw external library objects
+- Initialization and wiring of adapters happens in a composition root (factory, dependency injection, etc.), not scattered through services
 
-## Structure
+**Error handling:**
+- Catch all infrastructure exceptions (connection errors, timeouts, SDK errors)
+- Translate to domain exception types that services can handle
+- Never leak external library types to the domain
 
-- Group by technology (e.g., `sqlalchemy_adapter`, `redis_adapter`, `s3_adapter`)
-- Each adapter must implement one or more outbound ports from `ports/outbound/`
-- Do not leak adapter-specific types into service or domain layers
-
-## Dependency Rules
-
-Adapters may import port interfaces, domain DTOs, and libraries for the external system. Adapters must not import from `services/`, `api/`, or other adapters.
-
-## Implementation Guidelines
-
-- Initialize adapters outside of the domain (in a DI container or app factory)
-- Return domain types or DTOs — not raw ORM or SDK objects
-- Handle all infrastructure exceptions locally and raise clean errors
-
-## Testing
-
-- Use mock infrastructure clients in unit tests
-- Include integration tests where side effects are testable
-- Validate compliance with expected port behaviors
-
-## Violations
-
-- Direct calls to external services from domain or service layers
-- Reusing adapter logic without a port contract
-- All adapter usage must be mediated by the port it implements
+**Testing:**
+- Mock external service clients (database, API, cache) in unit tests
+- Integration tests use real infrastructure for side-effect validation
+- Verify adapter compliance with port contract

--- a/agents/claude-code/rules/backend/api.md
+++ b/agents/claude-code/rules/backend/api.md
@@ -3,21 +3,17 @@ paths:
   - "**/api/**"
 ---
 
-# API Layer Rules
+# API Layer — Inbound Adapter
 
-Follow the public API conventions defined in `docs/backend/architecture/API_CONVENTIONS.md`.
+**Your project's API conventions:** `docs/backend/architecture/API_CONVENTIONS.md`
 
-All routes in `api/` must:
+Read this document before implementing any route. It defines your project's routing style, request/response models, authentication mechanism, error handling, and testing approach.
 
-- Use versioned, resource-first paths (e.g., `/v1/users/login`)
-- Follow HTTP verb and status code standards
-- Define request and response models using `BaseModel`
-- Wrap responses using the standard `ApiResponse` envelope
-- Authenticate using `Depends(get_current_user)`
-- Authorize using `Depends(check_scope(...))` if required
-- Delegate all logic to inbound ports (`ports/inbound/`)
-- Never access domain services, repositories, or adapter logic directly
-- Avoid leaking FastAPI types into service or port layers
-- Include OpenAPI metadata: summary, description, status codes, response model
-
-All FastAPI routes are inbound adapters. They must stay thin, authenticated, and port-driven.
+**Universal constraints (apply to any language):**
+- Routes are inbound adapters — delegate all business logic to inbound ports in `ports/inbound/`
+- Validate and authenticate requests before calling the port layer
+- Map domain exceptions to HTTP responses at this layer, not inside domain code
+- Routes must remain thin — no business logic inline
+- Never expose domain types directly in HTTP responses; translate at the boundary
+- Support both sync and async execution depending on your framework
+- Include metadata in HTTP responses for API documentation (swagger/OpenAPI equivalent)

--- a/agents/claude-code/rules/backend/ports.md
+++ b/agents/claude-code/rules/backend/ports.md
@@ -3,38 +3,22 @@ paths:
   - "**/ports/**"
 ---
 
-# Port Layer Rules
+# Port Layer — Domain Contracts
 
-Ports define interfaces that decouple domain logic from framework and infrastructure details.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md` and `BOUNDARIES.md`
 
-## Purpose
+Ports define the contracts between the domain and its adapters. Review the architecture docs for interface guidelines and dependency rules.
 
-- Inbound ports define how the domain is invoked (use cases)
-- Outbound ports define what the domain depends on (storage, messaging)
+**Universal constraints (apply to any language):**
+- Inbound ports (`ports/inbound/`) define how the domain logic is called (use cases, command handlers)
+- Outbound ports (`ports/outbound/`) define what external systems the domain depends on (storage, APIs, messaging)
+- Ports are pure interfaces/contracts — no implementation logic, no side effects
+- Ports must be framework-agnostic: no web framework, ORM, or infrastructure library references
+- Port method signatures must use domain types or DTOs, never raw framework or infrastructure types
+- Ports may import domain models, value objects, exceptions, and standard language types only
+- Each port file defines a single interface/contract
+- Adapters must implement outbound port interfaces; inbound ports are called by adapters
 
-## Structure
-
-- Use `ports/inbound/` for service-facing interfaces
-- Use `ports/outbound/` for external dependency contracts
-- Each file should define a single interface (abstract base class or Protocol)
-
-## Guidelines
-
-- Do not implement logic in port files
-- Ports must be framework-agnostic (no FastAPI, SQLAlchemy, etc.)
-- Define type-safe method signatures and docstrings
-- Accept and return domain types or DTOs — not raw infra types
-
-## Dependencies
-
-Ports may import domain models, value objects, DTOs, and standard Python typing. Ports must not import from `api/`, `adapters/`, `services/`, or infra libraries.
-
-## Testing
-
-Ports themselves do not require tests. All adapter implementations must be testable against the interface.
-
-## Violations
-
-- Logic or side effects in a port file
-- Leaking adapter types into method signatures
-- Circular imports from adapters or services
+**Testing:**
+- Port files do not themselves require tests
+- All adapter implementations must satisfy their port interface contract (testable in isolation)

--- a/agents/claude-code/rules/backend/security.md
+++ b/agents/claude-code/rules/backend/security.md
@@ -4,55 +4,25 @@ paths:
   - "**/auth/**"
 ---
 
-# Security and Authentication Rules
+# Security and Authentication — Adapter Layer
 
-Align with architectural patterns in `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`.
+**Your project's security patterns:** `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`
 
-## Authentication
+Read this document before implementing authentication or authorization. It defines your project's auth model, token strategy, and credential handling.
 
-- Use OAuth2 password or client credentials flow
-- Enforce bearer token validation using `Depends(get_current_user)`
-- Token parsing must verify signature, check `exp`/`iat`/`sub` claims, and validate scopes
-- Reject unsigned, malformed, or expired tokens — never decode JWTs without verifying signature
+**Universal constraints (apply to any language):**
+- All inbound routes must authenticate before calling any port
+- Pass a validated `UserContext` or `Claims` object to the domain, never raw tokens
+- Verify token signatures and validate claims (`exp`, `iat`, `sub`) before use
+- Reject unsigned, malformed, or expired tokens — never skip signature verification
+- Use Role-Based Access Control (RBAC) for authorization; roles/scopes come from validated tokens
+- Never hardcode credentials — load all secrets from environment or secure vaults
+- Never log raw credentials, tokens, or sensitive user data
+- Return `401 Unauthorized` for failed authentication, `403 Forbidden` for insufficient authorization
+- Hash passwords using strong algorithms (bcrypt, scrypt, argon2 equivalent)
+- Use secure transport for all credential exchanges (HTTPS-only, secure cookies for tokens)
+- Domain services must not depend on auth libraries or token types
 
-## Authorization
-
-- Use Role-Based Access Control (RBAC) with roles in JWT (`role` or `scope` claim)
-- Use `Depends(check_scope("admin"))` to guard protected endpoints
-- Centralize role checks — do not hardcode inline logic
-
-## Secrets and Config
-
-- Never hardcode credentials — load from environment via `BaseSettings`
-- Never commit `.env`, `.pem`, `.key`, or credential files
-
-## Secure Storage
-
-- Hash passwords using `bcrypt` or `argon2` via `passlib`
-- Never log raw credentials, tokens, or user PII
-
-## Error Handling
-
-- Return `401 Unauthorized` for unauthenticated, `403 Forbidden` for unauthorized
-- Never expose stack traces or debug output to clients
-- All logs must include `request_id` and `user_id` with masked identifiers
-
-## Input Validation
-
-- Use strict `pydantic` models for auth inputs
-- Validate emails via `EmailStr`, passwords with length and format constraints
-
-## Security Headers
-
-Set via middleware: `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`.
-
-## Domain Alignment
-
-Authentication and authorization are handled only in the API and auth adapter layer. Domain services receive a validated `UserContext` — no business logic depends on raw tokens.
-
-## Forbidden
-
-- Decoding JWT without verification
-- Storing tokens in plaintext
-- Using weak hash functions (MD5, SHA1)
-- Using `eval()` or `exec()`
+**Error handling:**
+- Ensure stack traces are never exposed to HTTP clients
+- Include `request_id` and (masked) `user_id` in all security-related logs

--- a/agents/claude-code/rules/backend/services.md
+++ b/agents/claude-code/rules/backend/services.md
@@ -3,44 +3,23 @@ paths:
   - "**/services/**"
 ---
 
-# Service Layer Rules
+# Service Layer — Domain Logic
 
-Services implement core business logic in alignment with Hexagonal Architecture.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md`
 
-## Purpose
+Services implement the business logic of your domain. Review the architecture contract for layer structure and boundaries.
 
-- Encapsulate domain rules, state transitions, and orchestration
-- Must not handle HTTP, serialization, or DB logic
-- May call repositories (via outbound ports), validators, and injected helpers
+**Universal constraints (apply to any language):**
+- Services contain business logic, state transitions, and orchestration — nothing else
+- Services must not directly handle HTTP, serialization, database, or network concerns
+- Services must not import from the inbound adapter layer (API, CLI) or the adapter/infrastructure layer
+- All external dependencies must be injected via constructor (no singleton global access, no hardcoded instantiation)
+- Services may only depend on ports and pure domain models
+- Services raise domain-specific exceptions; adapters convert these to API responses
+- One service per domain area; methods should be named after business operations
+- All domain logic that produces business value lives here
 
-## Structure
-
-- One service per domain area (e.g., `UserService`, `PaymentService`)
-- Classes must use the `Service` suffix
-- Expose clear public methods named after business operations (e.g., `create_user()`)
-
-## Dependencies
-
-- Inject dependencies via constructor (no inline instantiation)
-- Accept only ports and pure helpers — no adapters or framework code
-
-```python
-class UserService:
-    def __init__(self, user_repo: UserPort):
-        self.user_repo = user_repo
-```
-
-## Boundaries
-
-Services must not import from `api/`, `adapters/`, or FastAPI. Services may raise domain exceptions and return DTOs or pure Python values.
-
-## Testing
-
-- Unit test all public methods in isolation
-- Mock dependencies (repos, ports)
-- Validate logic, not HTTP behavior
-
-## Violations
-
-- Business logic must never live in route handlers or adapter code
-- All non-API, non-infrastructure logic belongs in the service layer
+**Testing:**
+- Unit test all service public methods in isolation
+- Mock all injected port dependencies
+- Test business logic, not infrastructure details

--- a/agents/claude-code/rules/cli/cli.md
+++ b/agents/claude-code/rules/cli/cli.md
@@ -4,22 +4,21 @@ paths:
   - "**/commands/**"
 ---
 
-# CLI Layer Rules
+# CLI Layer — Inbound Adapter
 
-Follow the CLI conventions defined in `docs/backend/architecture/CLI_CONVENTIONS.md`.
+**Your project's CLI conventions:** `docs/backend/architecture/CLI_CONVENTIONS.md`
 
-All commands in `cli/` or `commands/` must:
+Read this document before implementing any CLI command. It defines your project's command structure, argument handling, output format, and error reporting.
 
-- Use Click or Typer for argument parsing and command structure
-- Delegate all logic to inbound ports (`ports/inbound/`)
-- Never access domain services, repositories, or adapter logic directly
-- Validate arguments using Click/Typer parameter types before calling ports
-- Map CLI arguments to domain objects (DTOs or value objects) before port calls
-- Use exit code 0 for success, 1 for user errors, 2 for system errors
-- Send structured output to stdout, error/status messages to stderr
-- Support `--format json|table|plain` for commands that produce data output
-- Include `--verbose` flag for debug-level logging
-- Never expose stack traces or internal details in normal mode
-- Avoid leaking Click/Typer types into service or port layers
-
-All CLI commands are inbound adapters. They must stay thin and port-driven.
+**Universal constraints (apply to any language):**
+- CLI commands are inbound adapters — delegate all business logic to inbound ports in `ports/inbound/`
+- Validate and parse arguments according to your CLI framework before calling ports
+- Map CLI arguments to domain objects (DTOs, value objects) before passing to ports
+- Commands must remain thin — no business logic inline
+- Never expose domain types directly in output; translate at the boundary
+- Use universal exit codes: 0 = success, 1 = user error (invalid input, business rule violation), 2 = system error (infrastructure failure)
+- Send structured output to stdout; send diagnostic/error messages to stderr
+- Provide structured output formats (`--format json|table|plain`) for machine-readable results
+- Include `--verbose` flag to enable debug-level logging
+- Never expose stack traces in normal mode
+- Domain layer must not depend on CLI framework types or libraries

--- a/agents/codex/agents-md/backend-api.md
+++ b/agents/codex/agents-md/backend-api.md
@@ -87,6 +87,24 @@ ADRs live under `docs/backend/architecture/ADR/`, follow `docs/backend/architect
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions and standards are documented in `docs/backend/architecture/`. Before implementing in each layer, read the corresponding document:
+
+| Layer | Document | Content |
+|---|---|---|
+| API / inbound adapter | `API_CONVENTIONS.md` | Routing style, request/response models, authentication, error mapping, testing |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries, design principles |
+| Ports | `ARCH_CONTRACT.md` | Port interface guidelines and architecture patterns |
+| Adapters / infrastructure | `ARCH_CONTRACT.md` + `BOUNDARIES.md` | Integration patterns, layer boundaries, dependency rules |
+| Security / auth | `SECURITY_AUTH_PATTERNS.md` | Authentication model, token strategy, credential handling, RBAC |
+| Testing | `TESTING.md` | Test philosophy, FIRST principles, BDD approach, test structure |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's specific approach. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the implementation details are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/codex/agents-md/backend-cli.md
+++ b/agents/codex/agents-md/backend-cli.md
@@ -87,6 +87,24 @@ ADRs live under `docs/backend/architecture/ADR/`, follow `docs/backend/architect
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing in each layer, read the corresponding document:
+
+| Layer | Document | Content |
+|---|---|---|
+| CLI / inbound adapter | `CLI_CONVENTIONS.md` | Command structure, arguments, output format, exit codes |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| Ports | `ARCH_CONTRACT.md` | Port interface guidelines and architecture patterns |
+| Adapters / infrastructure | `ARCH_CONTRACT.md` + `BOUNDARIES.md` | Integration patterns, layer boundaries, dependency rules |
+| Security / auth | `SECURITY_AUTH_PATTERNS.md` | Authentication model, token strategy, credential handling |
+| Testing | `TESTING.md` | Test philosophy, FIRST principles, BDD approach |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's specific approach. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the implementation details are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/codex/agents-md/l3-backend-api.md
+++ b/agents/codex/agents-md/l3-backend-api.md
@@ -65,6 +65,19 @@ The plan must:
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. When implementing:
+
+- **Architecture decisions:** Review `docs/backend/architecture/DESIGN_PRINCIPLES.md`
+- **Testing approach:** Review `docs/backend/architecture/TESTING.md`
+- **Framework and libraries:** Review `docs/backend/architecture/TECH_STACK.md`
+- **Boundaries and dependencies:** Review `docs/backend/architecture/BOUNDARIES.md`
+
+These documents define your stack's specific approach to the universal architecture principles (SOLID, DRY, YAGNI, KISS).
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/codex/agents-md/l3-backend-cli.md
+++ b/agents/codex/agents-md/l3-backend-cli.md
@@ -65,6 +65,20 @@ The plan must:
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. When implementing:
+
+- **Architecture decisions:** Review `docs/backend/architecture/DESIGN_PRINCIPLES.md`
+- **Testing approach:** Review `docs/backend/architecture/TESTING.md`
+- **Framework and libraries:** Review `docs/backend/architecture/TECH_STACK.md`
+- **CLI conventions:** Review `docs/backend/architecture/CLI_CONVENTIONS.md`
+- **Boundaries and dependencies:** Review `docs/backend/architecture/BOUNDARIES.md`
+
+These documents define your stack's specific approach to the universal architecture principles (SOLID, DRY, YAGNI, KISS).
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/codex/agents-md/l5-backend-api.md
+++ b/agents/codex/agents-md/l5-backend-api.md
@@ -94,6 +94,24 @@ An ADR is required when:
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing, read the relevant documents:
+
+| Aspect | Document | Content |
+|---|---|---|
+| API / inbound adapter | `API_CONVENTIONS.md` | Routing, request/response, authentication, error mapping |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| LLM gateway | `LLM_GATEWAY_CONTRACT.md` | LiteLLM usage, provider routing, model aliases |
+| Guardrails / safety | `GUARDRAILS_CONTRACT.md` | NeMo Guardrails and Guardrails AI integration |
+| Observability | `OBSERVABILITY_LLM_CONTRACT.md` | OpenLLMetry and Langfuse setup |
+| LLM evaluation | `EVALUATION_LLM_CONTRACT.md` | DeepEval, Promptfoo, RAGAS integration |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's implementation. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the specific tools and patterns are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/codex/agents-md/l5-backend-cli.md
+++ b/agents/codex/agents-md/l5-backend-cli.md
@@ -59,6 +59,24 @@ Implementation must not begin unless all five artifacts exist.
 
 ---
 
+## Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing, read the relevant documents:
+
+| Aspect | Document | Content |
+|---|---|---|
+| CLI / inbound adapter | `CLI_CONVENTIONS.md` | Command structure, arguments, output format |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| LLM gateway | `LLM_GATEWAY_CONTRACT.md` | LiteLLM usage, provider routing, model aliases |
+| Guardrails / safety | `GUARDRAILS_CONTRACT.md` | NeMo Guardrails and Guardrails AI integration |
+| Observability | `OBSERVABILITY_LLM_CONTRACT.md` | OpenLLMetry and Langfuse setup |
+| LLM evaluation | `EVALUATION_LLM_CONTRACT.md` | DeepEval, Promptfoo, RAGAS integration |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's implementation. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the specific tools and patterns are here.
+
+---
+
 ## Implementation Rules
 
 - Implement one increment at a time

--- a/agents/codex/rules/backend/adapters.md
+++ b/agents/codex/rules/backend/adapters.md
@@ -1,37 +1,25 @@
-# Adapter Layer Rules
+# Adapter Layer — Infrastructure Integration
 
-Adapters implement technical integrations that satisfy port interfaces.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md` and `BOUNDARIES.md`
 
-## Purpose
+Adapters implement outbound port contracts, connecting your domain to external systems (databases, APIs, caches). Review the architecture docs for integration patterns and dependency rules.
 
-- Implement outbound ports (database, cache, email, external APIs)
-- Translate domain models to/from infrastructure-specific formats
-- Remain infrastructure-aware, but domain-agnostic
+**Universal constraints (apply to any language):**
+- Adapters implement outbound port interfaces from `ports/outbound/`
+- Adapters translate between domain/port types and external system types (ORM objects, API responses, etc.)
+- Group adapters by technology/concern (e.g., `postgres_adapter`, `redis_adapter`, `http_client_adapter`)
+- Adapters must not import from services, API layer, or other adapters
+- Adapters must not be called directly; all access goes through their port interface
+- Adapters handle all infrastructure-level error translation and convert to clean domain exceptions
+- Adapters return domain types or DTOs, never raw external library objects
+- Initialization and wiring of adapters happens in a composition root (factory, dependency injection, etc.), not scattered through services
 
-## Structure
+**Error handling:**
+- Catch all infrastructure exceptions (connection errors, timeouts, SDK errors)
+- Translate to domain exception types that services can handle
+- Never leak external library types to the domain
 
-- Group by technology (e.g., `sqlalchemy_adapter`, `redis_adapter`, `s3_adapter`)
-- Each adapter must implement one or more outbound ports from `ports/outbound/`
-- Do not leak adapter-specific types into service or domain layers
-
-## Dependency Rules
-
-Adapters may import port interfaces, domain DTOs, and libraries for the external system. Adapters must not import from `services/`, `api/`, or other adapters.
-
-## Implementation Guidelines
-
-- Initialize adapters outside of the domain (in a DI container or app factory)
-- Return domain types or DTOs — not raw ORM or SDK objects
-- Handle all infrastructure exceptions locally and raise clean errors
-
-## Testing
-
-- Use mock infrastructure clients in unit tests
-- Include integration tests where side effects are testable
-- Validate compliance with expected port behaviors
-
-## Violations
-
-- Direct calls to external services from domain or service layers
-- Reusing adapter logic without a port contract
-- All adapter usage must be mediated by the port it implements
+**Testing:**
+- Mock external service clients (database, API, cache) in unit tests
+- Integration tests use real infrastructure for side-effect validation
+- Verify adapter compliance with port contract

--- a/agents/codex/rules/backend/api.md
+++ b/agents/codex/rules/backend/api.md
@@ -1,18 +1,14 @@
-# API Layer Rules
+# API Layer — Inbound Adapter
 
-Follow the public API conventions defined in `docs/backend/architecture/API_CONVENTIONS.md`.
+**Your project's API conventions:** `docs/backend/architecture/API_CONVENTIONS.md`
 
-All routes in this directory must:
+Read this document before implementing any route. It defines your project's routing style, request/response models, authentication mechanism, error handling, and testing approach.
 
-- Use versioned, resource-first paths (e.g., `/v1/users/login`)
-- Follow HTTP verb and status code standards
-- Define request and response models using `BaseModel`
-- Wrap responses using the standard `ApiResponse` envelope
-- Authenticate using `Depends(get_current_user)`
-- Authorize using `Depends(check_scope(...))` if required
-- Delegate all logic to inbound ports (`ports/inbound/`)
-- Never access domain services, repositories, or adapter logic directly
-- Avoid leaking FastAPI types into service or port layers
-- Include OpenAPI metadata: summary, description, status codes, response model
-
-All FastAPI routes are inbound adapters. They must stay thin, authenticated, and port-driven.
+**Universal constraints (apply to any language):**
+- Routes are inbound adapters — delegate all business logic to inbound ports in `ports/inbound/`
+- Validate and authenticate requests before calling the port layer
+- Map domain exceptions to HTTP responses at this layer, not inside domain code
+- Routes must remain thin — no business logic inline
+- Never expose domain types directly in HTTP responses; translate at the boundary
+- Support both sync and async execution depending on your framework
+- Include metadata in HTTP responses for API documentation (swagger/OpenAPI equivalent)

--- a/agents/codex/rules/backend/ports.md
+++ b/agents/codex/rules/backend/ports.md
@@ -1,35 +1,19 @@
-# Port Layer Rules
+# Port Layer — Domain Contracts
 
-Ports define interfaces that decouple domain logic from framework and infrastructure details.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md` and `BOUNDARIES.md`
 
-## Purpose
+Ports define the contracts between the domain and its adapters. Review the architecture docs for interface guidelines and dependency rules.
 
-- Inbound ports define how the domain is invoked (use cases)
-- Outbound ports define what the domain depends on (storage, messaging)
+**Universal constraints (apply to any language):**
+- Inbound ports (`ports/inbound/`) define how the domain logic is called (use cases, command handlers)
+- Outbound ports (`ports/outbound/`) define what external systems the domain depends on (storage, APIs, messaging)
+- Ports are pure interfaces/contracts — no implementation logic, no side effects
+- Ports must be framework-agnostic: no web framework, ORM, or infrastructure library references
+- Port method signatures must use domain types or DTOs, never raw framework or infrastructure types
+- Ports may import domain models, value objects, exceptions, and standard language types only
+- Each port file defines a single interface/contract
+- Adapters must implement outbound port interfaces; inbound ports are called by adapters
 
-## Structure
-
-- Use `ports/inbound/` for service-facing interfaces
-- Use `ports/outbound/` for external dependency contracts
-- Each file should define a single interface (abstract base class or Protocol)
-
-## Guidelines
-
-- Do not implement logic in port files
-- Ports must be framework-agnostic (no FastAPI, SQLAlchemy, etc.)
-- Define type-safe method signatures and docstrings
-- Accept and return domain types or DTOs — not raw infra types
-
-## Dependencies
-
-Ports may import domain models, value objects, DTOs, and standard Python typing. Ports must not import from `api/`, `adapters/`, `services/`, or infra libraries.
-
-## Testing
-
-Ports themselves do not require tests. All adapter implementations must be testable against the interface.
-
-## Violations
-
-- Logic or side effects in a port file
-- Leaking adapter types into method signatures
-- Circular imports from adapters or services
+**Testing:**
+- Port files do not themselves require tests
+- All adapter implementations must satisfy their port interface contract (testable in isolation)

--- a/agents/codex/rules/backend/security.md
+++ b/agents/codex/rules/backend/security.md
@@ -1,52 +1,22 @@
-# Security and Authentication Rules
+# Security and Authentication — Adapter Layer
 
-Align with architectural patterns in `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`.
+**Your project's security patterns:** `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`
 
-## Authentication
+Read this document before implementing authentication or authorization. It defines your project's auth model, token strategy, and credential handling.
 
-- Use OAuth2 password or client credentials flow
-- Enforce bearer token validation using `Depends(get_current_user)`
-- Token parsing must verify signature, check `exp`/`iat`/`sub` claims, and validate scopes
-- Reject unsigned, malformed, or expired tokens — never decode JWTs without verifying signature
+**Universal constraints (apply to any language):**
+- All inbound routes must authenticate before calling any port
+- Pass a validated `UserContext` or `Claims` object to the domain, never raw tokens
+- Verify token signatures and validate claims (`exp`, `iat`, `sub`) before use
+- Reject unsigned, malformed, or expired tokens — never skip signature verification
+- Use Role-Based Access Control (RBAC) for authorization; roles/scopes come from validated tokens
+- Never hardcode credentials — load all secrets from environment or secure vaults
+- Never log raw credentials, tokens, or sensitive user data
+- Return `401 Unauthorized` for failed authentication, `403 Forbidden` for insufficient authorization
+- Hash passwords using strong algorithms (bcrypt, scrypt, argon2 equivalent)
+- Use secure transport for all credential exchanges (HTTPS-only, secure cookies for tokens)
+- Domain services must not depend on auth libraries or token types
 
-## Authorization
-
-- Use Role-Based Access Control (RBAC) with roles in JWT (`role` or `scope` claim)
-- Use `Depends(check_scope("admin"))` to guard protected endpoints
-- Centralize role checks — do not hardcode inline logic
-
-## Secrets and Config
-
-- Never hardcode credentials — load from environment via `BaseSettings`
-- Never commit `.env`, `.pem`, `.key`, or credential files
-
-## Secure Storage
-
-- Hash passwords using `bcrypt` or `argon2` via `passlib`
-- Never log raw credentials, tokens, or user PII
-
-## Error Handling
-
-- Return `401 Unauthorized` for unauthenticated, `403 Forbidden` for unauthorized
-- Never expose stack traces or debug output to clients
-- All logs must include `request_id` and `user_id` with masked identifiers
-
-## Input Validation
-
-- Use strict `pydantic` models for auth inputs
-- Validate emails via `EmailStr`, passwords with length and format constraints
-
-## Security Headers
-
-Set via middleware: `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`.
-
-## Domain Alignment
-
-Authentication and authorization are handled only in the API and auth adapter layer. Domain services receive a validated `UserContext` — no business logic depends on raw tokens.
-
-## Forbidden
-
-- Decoding JWT without verification
-- Storing tokens in plaintext
-- Using weak hash functions (MD5, SHA1)
-- Using `eval()` or `exec()`
+**Error handling:**
+- Ensure stack traces are never exposed to HTTP clients
+- Include `request_id` and (masked) `user_id` in all security-related logs

--- a/agents/codex/rules/backend/services.md
+++ b/agents/codex/rules/backend/services.md
@@ -1,41 +1,20 @@
-# Service Layer Rules
+# Service Layer — Domain Logic
 
-Services implement core business logic in alignment with Hexagonal Architecture.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md`
 
-## Purpose
+Services implement the business logic of your domain. Review the architecture contract for layer structure and boundaries.
 
-- Encapsulate domain rules, state transitions, and orchestration
-- Must not handle HTTP, serialization, or DB logic
-- May call repositories (via outbound ports), validators, and injected helpers
+**Universal constraints (apply to any language):**
+- Services contain business logic, state transitions, and orchestration — nothing else
+- Services must not directly handle HTTP, serialization, database, or network concerns
+- Services must not import from the inbound adapter layer (API, CLI) or the adapter/infrastructure layer
+- All external dependencies must be injected via constructor (no singleton global access, no hardcoded instantiation)
+- Services may only depend on ports and pure domain models
+- Services raise domain-specific exceptions; adapters convert these to API responses
+- One service per domain area; methods should be named after business operations
+- All domain logic that produces business value lives here
 
-## Structure
-
-- One service per domain area (e.g., `UserService`, `PaymentService`)
-- Classes must use the `Service` suffix
-- Expose clear public methods named after business operations (e.g., `create_user()`)
-
-## Dependencies
-
-- Inject dependencies via constructor (no inline instantiation)
-- Accept only ports and pure helpers — no adapters or framework code
-
-```python
-class UserService:
-    def __init__(self, user_repo: UserPort):
-        self.user_repo = user_repo
-```
-
-## Boundaries
-
-Services must not import from `api/`, `adapters/`, or FastAPI. Services may raise domain exceptions and return DTOs or pure Python values.
-
-## Testing
-
-- Unit test all public methods in isolation
-- Mock dependencies (repos, ports)
-- Validate logic, not HTTP behavior
-
-## Violations
-
-- Business logic must never live in route handlers or adapter code
-- All non-API, non-infrastructure logic belongs in the service layer
+**Testing:**
+- Unit test all service public methods in isolation
+- Mock all injected port dependencies
+- Test business logic, not infrastructure details

--- a/agents/codex/rules/cli/cli.md
+++ b/agents/codex/rules/cli/cli.md
@@ -1,19 +1,18 @@
-# CLI Layer Rules
+# CLI Layer — Inbound Adapter
 
-Follow the CLI conventions defined in `docs/backend/architecture/CLI_CONVENTIONS.md`.
+**Your project's CLI conventions:** `docs/backend/architecture/CLI_CONVENTIONS.md`
 
-All commands in `cli/` or `commands/` must:
+Read this document before implementing any CLI command. It defines your project's command structure, argument handling, output format, and error reporting.
 
-- Use Click or Typer for argument parsing and command structure
-- Delegate all logic to inbound ports (`ports/inbound/`)
-- Never access domain services, repositories, or adapter logic directly
-- Validate arguments using Click/Typer parameter types before calling ports
-- Map CLI arguments to domain objects (DTOs or value objects) before port calls
-- Use exit code 0 for success, 1 for user errors, 2 for system errors
-- Send structured output to stdout, error/status messages to stderr
-- Support `--format json|table|plain` for commands that produce data output
-- Include `--verbose` flag for debug-level logging
-- Never expose stack traces or internal details in normal mode
-- Avoid leaking Click/Typer types into service or port layers
-
-All CLI commands are inbound adapters. They must stay thin and port-driven.
+**Universal constraints (apply to any language):**
+- CLI commands are inbound adapters — delegate all business logic to inbound ports in `ports/inbound/`
+- Validate and parse arguments according to your CLI framework before calling ports
+- Map CLI arguments to domain objects (DTOs, value objects) before passing to ports
+- Commands must remain thin — no business logic inline
+- Never expose domain types directly in output; translate at the boundary
+- Use universal exit codes: 0 = success, 1 = user error (invalid input, business rule violation), 2 = system error (infrastructure failure)
+- Send structured output to stdout; send diagnostic/error messages to stderr
+- Provide structured output formats (`--format json|table|plain`) for machine-readable results
+- Include `--verbose` flag to enable debug-level logging
+- Never expose stack traces in normal mode
+- Domain layer must not depend on CLI framework types or libraries

--- a/agents/copilot/copilot-instructions/backend-api.md
+++ b/agents/copilot/copilot-instructions/backend-api.md
@@ -187,6 +187,24 @@ Copilot must not generate implementation code until these conditions are satisfi
 
 ---
 
+## 6. Project Documentation
+
+Your project's language- and framework-specific conventions and standards are documented in `docs/backend/architecture/`. Before implementing in each layer, read the corresponding document:
+
+| Layer | Document | Content |
+|---|---|---|
+| API / inbound adapter | `API_CONVENTIONS.md` | Routing style, request/response models, authentication, error mapping, testing |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries, design principles |
+| Ports | `ARCH_CONTRACT.md` | Port interface guidelines and architecture patterns |
+| Adapters / infrastructure | `ARCH_CONTRACT.md` + `BOUNDARIES.md` | Integration patterns, layer boundaries, dependency rules |
+| Security / auth | `SECURITY_AUTH_PATTERNS.md` | Authentication model, token strategy, credential handling, RBAC |
+| Testing | `TESTING.md` | Test philosophy, FIRST principles, BDD approach, test structure |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's specific approach. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the implementation details are here.
+
+---
+
 ## 7. Implementation Rules
 
 ### 7.1 Incremental Delivery

--- a/agents/copilot/copilot-instructions/backend-cli.md
+++ b/agents/copilot/copilot-instructions/backend-cli.md
@@ -187,6 +187,24 @@ Copilot must not generate implementation code until these conditions are satisfi
 
 ---
 
+## 6. Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing in each layer, read the corresponding document:
+
+| Layer | Document | Content |
+|---|---|---|
+| CLI / inbound adapter | `CLI_CONVENTIONS.md` | Command structure, arguments, output format, exit codes |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| Ports | `ARCH_CONTRACT.md` | Port interface guidelines and architecture patterns |
+| Adapters / infrastructure | `ARCH_CONTRACT.md` + `BOUNDARIES.md` | Integration patterns, layer boundaries, dependency rules |
+| Security / auth | `SECURITY_AUTH_PATTERNS.md` | Authentication model, token strategy, credential handling |
+| Testing | `TESTING.md` | Test philosophy, FIRST principles, BDD approach |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's specific approach. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the implementation details are here.
+
+---
+
 ## 7. Implementation Rules
 
 ### 7.1 Incremental Delivery

--- a/agents/copilot/copilot-instructions/l3-backend-api.md
+++ b/agents/copilot/copilot-instructions/l3-backend-api.md
@@ -85,6 +85,19 @@ The plan must:
 
 ---
 
+## 4. Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. When implementing:
+
+- **Architecture decisions:** Review `docs/backend/architecture/DESIGN_PRINCIPLES.md`
+- **Testing approach:** Review `docs/backend/architecture/TESTING.md`
+- **Framework and libraries:** Review `docs/backend/architecture/TECH_STACK.md`
+- **Boundaries and dependencies:** Review `docs/backend/architecture/BOUNDARIES.md`
+
+These documents define your stack's specific approach to the universal architecture principles (SOLID, DRY, YAGNI, KISS).
+
+---
+
 ## 5. Implementation Rules
 
 ### 5.1 Incremental Delivery

--- a/agents/copilot/copilot-instructions/l3-backend-cli.md
+++ b/agents/copilot/copilot-instructions/l3-backend-cli.md
@@ -85,6 +85,20 @@ The plan must:
 
 ---
 
+## 4. Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. When implementing:
+
+- **Architecture decisions:** Review `docs/backend/architecture/DESIGN_PRINCIPLES.md`
+- **Testing approach:** Review `docs/backend/architecture/TESTING.md`
+- **Framework and libraries:** Review `docs/backend/architecture/TECH_STACK.md`
+- **CLI conventions:** Review `docs/backend/architecture/CLI_CONVENTIONS.md`
+- **Boundaries and dependencies:** Review `docs/backend/architecture/BOUNDARIES.md`
+
+These documents define your stack's specific approach to the universal architecture principles (SOLID, DRY, YAGNI, KISS).
+
+---
+
 ## 5. Implementation Rules
 
 ### 5.1 Incremental Delivery

--- a/agents/copilot/copilot-instructions/l5-backend-api.md
+++ b/agents/copilot/copilot-instructions/l5-backend-api.md
@@ -71,7 +71,25 @@ All LLM features must comply with:
 
 ---
 
-## 5. Implementation Rules
+## 5. Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing, read the relevant documents:
+
+| Aspect | Document | Content |
+|---|---|---|
+| API / inbound adapter | `API_CONVENTIONS.md` | Routing, request/response, authentication, error mapping |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| LLM gateway | `LLM_GATEWAY_CONTRACT.md` | LiteLLM usage, provider routing, model aliases |
+| Guardrails / safety | `GUARDRAILS_CONTRACT.md` | NeMo Guardrails and Guardrails AI integration |
+| Observability | `OBSERVABILITY_LLM_CONTRACT.md` | OpenLLMetry and Langfuse setup |
+| LLM evaluation | `EVALUATION_LLM_CONTRACT.md` | DeepEval, Promptfoo, RAGAS integration |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's implementation. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the specific tools and patterns are here.
+
+---
+
+## 6. Implementation Rules
 
 * Implement one increment at a time
 * Follow Hexagonal Architecture (ports and adapters)

--- a/agents/copilot/copilot-instructions/l5-backend-cli.md
+++ b/agents/copilot/copilot-instructions/l5-backend-cli.md
@@ -43,7 +43,25 @@ CLI features may be deterministic (no LLM). If mode is `llm`, all L5 contracts a
 
 ---
 
-## 4. Implementation Rules
+## 4. Project Documentation
+
+Your project's language- and framework-specific conventions are documented in `docs/backend/architecture/`. Before implementing, read the relevant documents:
+
+| Aspect | Document | Content |
+|---|---|---|
+| CLI / inbound adapter | `CLI_CONVENTIONS.md` | Command structure, arguments, output format |
+| Services / domain | `ARCH_CONTRACT.md` | Architecture model, layering, approved libraries |
+| LLM gateway | `LLM_GATEWAY_CONTRACT.md` | LiteLLM usage, provider routing, model aliases |
+| Guardrails / safety | `GUARDRAILS_CONTRACT.md` | NeMo Guardrails and Guardrails AI integration |
+| Observability | `OBSERVABILITY_LLM_CONTRACT.md` | OpenLLMetry and Langfuse setup |
+| LLM evaluation | `EVALUATION_LLM_CONTRACT.md` | DeepEval, Promptfoo, RAGAS integration |
+| Technology decisions | `TECH_STACK.md` | Approved frameworks, libraries, tools, and versions |
+
+These documents define your stack's implementation. The architecture principles (hexagonal architecture, boundaries, evaluation) are universal; the specific tools and patterns are here.
+
+---
+
+## 5. Implementation Rules
 
 * Follow Hexagonal Architecture, CLI conventions
 * All LLM calls through LiteLLM

--- a/agents/copilot/instructions/backend/adapters.instructions.md
+++ b/agents/copilot/instructions/backend/adapters.instructions.md
@@ -2,68 +2,28 @@
 applyTo: "**/adapters/**"
 ---
 
-# Adapter Layer Instructions
+# Adapter Layer — Infrastructure Integration
 
-These rules apply to all files under `/adapters/**`.
-Adapters implement technical integrations that satisfy port interfaces.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md` and `BOUNDARIES.md`
 
----
+Adapters implement outbound port contracts, connecting your domain to external systems (databases, APIs, caches). Review the architecture docs for integration patterns and dependency rules.
 
-## 1. Purpose
+**Universal constraints (apply to any language):**
+- Adapters implement outbound port interfaces from `ports/outbound/`
+- Adapters translate between domain/port types and external system types (ORM objects, API responses, etc.)
+- Group adapters by technology/concern (e.g., `postgres_adapter`, `redis_adapter`, `http_client_adapter`)
+- Adapters must not import from services, API layer, or other adapters
+- Adapters must not be called directly; all access goes through their port interface
+- Adapters handle all infrastructure-level error translation and convert to clean domain exceptions
+- Adapters return domain types or DTOs, never raw external library objects
+- Initialization and wiring of adapters happens in a composition root (factory, dependency injection, etc.), not scattered through services
 
-- Implement outbound ports (e.g., database, cache, email, APIs)
-- Translate domain models to/from infrastructure-specific formats
-- Remain infrastructure-aware, but domain-agnostic
+**Error handling:**
+- Catch all infrastructure exceptions (connection errors, timeouts, SDK errors)
+- Translate to domain exception types that services can handle
+- Never leak external library types to the domain
 
----
-
-## 2. Structure
-
-- Group by technology (e.g., `sqlalchemy_adapter`, `redis_adapter`, `s3_adapter`)
-- Each adapter must implement one or more outbound ports from `/ports/outbound/`
-- Do not leak adapter-specific types into service or domain layers
-
----
-
-## 3. Dependency Rules
-
-- Adapters may import:
-  - Port interfaces
-  - Domain DTOs and value objects
-  - Libraries required to interface with the external system
-- Adapters must not import from:
-  - `/services/**`
-  - `/api/**`
-  - Other adapters
-
----
-
-## 4. Implementation Guidelines
-
-- Adapters must be initialized outside of the domain (e.g., in a DI container or app factory)
-- Return domain types or DTOs—not raw ORM or SDK objects
-- Handle all infrastructure exceptions locally and raise clean errors
-
----
-
-## 5. Logging and Observability
-
-- Log integration-specific events with `adapter_name`, `operation`, and `duration_ms`
-- Mask sensitive data in logs
-- Emit Prometheus-compatible metrics where relevant (e.g., latency, retries)
-
----
-
-## 6. Testing
-
-- Use mock infrastructure clients in unit tests
-- Include integration tests (if side effects are testable)
-- Validate compliance with expected port behaviors
-
----
-
-## 7. Violations
-
-- Direct calls to external services from domain or service layers are forbidden
-- Reusing adapter logic without a port contract is disallowed
-- All adapter usage must be mediated by the port it implements
+**Testing:**
+- Mock external service clients (database, API, cache) in unit tests
+- Integration tests use real infrastructure for side-effect validation
+- Verify adapter compliance with port contract

--- a/agents/copilot/instructions/backend/api.instructions.md
+++ b/agents/copilot/instructions/backend/api.instructions.md
@@ -2,19 +2,17 @@
 applyTo: "**/api/**"
 ---
 
-Follow the public API conventions defined in `docs/backend/architecture/API_CONVENTIONS.md`.
+# API Layer — Inbound Adapter
 
-All routes in `/api/**` must:
+**Your project's API conventions:** `docs/backend/architecture/API_CONVENTIONS.md`
 
-- Use versioned, resource-first paths (e.g., `/v1/users/login`)
-- Follow HTTP verb and status code standards
-- Define request and response models using `BaseModel`
-- Wrap responses using the standard `ApiResponse` envelope
-- Authenticate using `Depends(get_current_user)`
-- Authorize using `Depends(check_scope(...))` if required
-- Delegate all logic to inbound ports (`ports/inbound/**`)
-- Never access domain services, repositories, or adapter logic directly
-- Avoid leaking FastAPI types into service or port layers
-- Include OpenAPI metadata: summary, description, status codes, response model
+Read this document before implementing any route. It defines your project's routing style, request/response models, authentication mechanism, error handling, and testing approach.
 
-All FastAPI routes are inbound adapters. They must stay thin, authenticated, and port-driven.
+**Universal constraints (apply to any language):**
+- Routes are inbound adapters — delegate all business logic to inbound ports in `ports/inbound/**`
+- Validate and authenticate requests before calling the port layer
+- Map domain exceptions to HTTP responses at this layer, not inside domain code
+- Routes must remain thin — no business logic inline
+- Never expose domain types directly in HTTP responses; translate at the boundary
+- Support both sync and async execution depending on your framework
+- Include metadata in HTTP responses for API documentation (swagger/OpenAPI equivalent)

--- a/agents/copilot/instructions/backend/ports.instructions.md
+++ b/agents/copilot/instructions/backend/ports.instructions.md
@@ -2,69 +2,22 @@
 applyTo: "**/ports/**"
 ---
 
-# Port Layer Instructions
+# Port Layer — Domain Contracts
 
-These rules apply to all files under `/ports/**`. Ports define interfaces that decouple the domain logic from framework and infrastructure details.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md` and `BOUNDARIES.md`
 
----
+Ports define the contracts between the domain and its adapters. Review the architecture docs for interface guidelines and dependency rules.
 
-## 1. Purpose
+**Universal constraints (apply to any language):**
+- Inbound ports (`ports/inbound/`) define how the domain logic is called (use cases, command handlers)
+- Outbound ports (`ports/outbound/`) define what external systems the domain depends on (storage, APIs, messaging)
+- Ports are pure interfaces/contracts — no implementation logic, no side effects
+- Ports must be framework-agnostic: no web framework, ORM, or infrastructure library references
+- Port method signatures must use domain types or DTOs, never raw framework or infrastructure types
+- Ports may import domain models, value objects, exceptions, and standard language types only
+- Each port file defines a single interface/contract
+- Adapters must implement outbound port interfaces; inbound ports are called by adapters
 
-- Declare clear boundaries between domain and technical layers
-- Inbound ports define how the domain is invoked (e.g., use cases)
-- Outbound ports define what the domain depends on (e.g., storage, messaging)
-
----
-
-## 2. Structure
-
-- Use `ports/inbound/**` for service-facing interfaces
-- Use `ports/outbound/**` for external dependency contracts
-- Each file should define a single interface (abstract base class or Protocol)
-
----
-
-## 3. Guidelines
-
-- Do not implement logic in port files
-- Ports must be framework-agnostic (no FastAPI, SQLAlchemy, etc.)
-- Define type-safe method signatures and docstrings
-- Accept and return domain types or DTOs—not raw infra types
-
----
-
-## 4. Dependencies
-
-- Ports may import:
-  - Domain models, value objects, DTOs
-  - Standard Python typing
-- Ports must not import:
-  - `/api/**`
-  - `/adapters/**`
-  - `/services/**`
-  - Infra libraries (e.g., boto3, SQLAlchemy)
-
----
-
-## 5. Design Expectations
-
-- Keep interfaces minimal and focused
-- Use composition over inheritance for complex flows
-- Apply versioning if ports evolve (e.g., `v1/`, `v2/` folders)
-
----
-
-## 6. Testing
-
-- Ports themselves do not require tests
-- All implementations (adapters) must be testable against the interface
-
----
-
-## 7. Violations
-
-- Logic or side effects in a port file
-- Leaking adapter types into method signatures
-- Circular imports from adapters or services
-
-All port contracts are subject to review and must remain stable for consumers.
+**Testing:**
+- Port files do not themselves require tests
+- All adapter implementations must satisfy their port interface contract (testable in isolation)

--- a/agents/copilot/instructions/backend/security.instructions.md
+++ b/agents/copilot/instructions/backend/security.instructions.md
@@ -2,130 +2,25 @@
 applyTo: "**/security/**,**/auth/**"
 ---
 
-# Security and Authentication Instructions
+# Security and Authentication — Adapter Layer
 
-These rules apply to all files under `/security/**`, `/auth/**`, and any code handling login, tokens, identity, or protected routes. They align with the architectural patterns in `SECURITY_AUTH_PATTERNS.md`.
+**Your project's security patterns:** `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`
 
----
+Read this document before implementing authentication or authorization. It defines your project's auth model, token strategy, and credential handling.
 
-## 1. Authentication
+**Universal constraints (apply to any language):**
+- All inbound routes must authenticate before calling any port
+- Pass a validated `UserContext` or `Claims` object to the domain, never raw tokens
+- Verify token signatures and validate claims (`exp`, `iat`, `sub`) before use
+- Reject unsigned, malformed, or expired tokens — never skip signature verification
+- Use Role-Based Access Control (RBAC) for authorization; roles/scopes come from validated tokens
+- Never hardcode credentials — load all secrets from environment or secure vaults
+- Never log raw credentials, tokens, or sensitive user data
+- Return `401 Unauthorized` for failed authentication, `403 Forbidden` for insufficient authorization
+- Hash passwords using strong algorithms (bcrypt, scrypt, argon2 equivalent)
+- Use secure transport for all credential exchanges (HTTPS-only, secure cookies for tokens)
+- Domain services must not depend on auth libraries or token types
 
-- Use OAuth2 password or client credentials flow
-- Enforce bearer token validation using `Depends(get_current_user)`
-- Token parsing must:
-  - Verify signature using `PyJWT` or `jose.jwt`
-  - Check `exp`, `iat`, and `sub` claims
-  - Validate required scopes or roles
-- Reject unsigned, malformed, or expired tokens
-- Never decode JWTs without verifying signature
-
-Example:
-```python
-from fastapi import Depends, HTTPException
-from jose import JWTError, jwt
-
-def get_current_user(token: str = Depends(oauth2_scheme)) -> UserContext:
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
-        ...
-    except JWTError:
-        raise credentials_exception
-```
-
----
-
-## 2. Authorization
-
-- Use Role-Based Access Control (RBAC)
-- Roles must be included in JWT (`role` or `scope` claim)
-- Use `Depends(check_scope("admin"))` to guard protected endpoints
-- Centralize role checks—do not hardcode inline logic
-
----
-
-## 3. Secrets and Config
-
-- Never hardcode credentials (e.g., `SECRET_KEY`, DB passwords)
-- Load from environment via `BaseSettings`
-- Never commit `.env`, `.pem`, `.key`, or credential files
-
----
-
-## 4. Secure Storage
-
-- Hash passwords using `bcrypt` or `argon2` via `passlib`
-- Never log:
-  - Raw credentials
-  - Tokens
-  - User PII
-- Encrypt sensitive data at rest when required (e.g., for compliance)
-
----
-
-## 5. Error Handling and Logging
-
-- Return only:
-  - `401 Unauthorized` for unauthenticated
-  - `403 Forbidden` for unauthorized
-- Never expose stack traces or debug output to clients
-- All logs must include:
-  - `request_id`, `user_id`
-  - Masked identifiers (emails, tokens)
-- Use Opentelemetry and structured logging
----
-
-## 6. Input Validation
-
-- Use strict `pydantic` models for auth inputs
-- Validate:
-  - Emails via `EmailStr`
-  - Passwords with length and format constraints
-
-Example:
-```python
-class LoginRequest(BaseModel):
-    email: EmailStr
-    password: constr(min_length=8, max_length=64)
-```
-
----
-
-## 7. Security Headers
-
-Set the following headers via middleware:
-
-- `X-Content-Type-Options: nosniff`
-- `X-Frame-Options: DENY`
-- `Strict-Transport-Security: max-age=63072000; includeSubDomains`
-- `Content-Security-Policy` (if applicable)
-
----
-
-## 8. Testing Requirements
-
-- Unit test all:
-  - Token parsing
-  - Role/scope enforcement
-  - Auth failure paths
-- Include security regression tests:
-  - Token reuse
-  - Brute-force login attempts
-  - Role escalation attempts
-
----
-
-## 9. Forbidden Practices
-
-🚫 Decoding JWT without verification  
-🚫 Storing tokens in plaintext  
-🚫 Using weak hash functions (MD5, SHA1)  
-🚫 Using `eval()` or `exec()`  
-🚫 Skipping validation or HTTPS in deployment
-
----
-
-## 10. Domain Alignment
-
-- Authentication/authorization is handled only in the API and auth adapter layer
-- Domain services receive a validated `UserContext`
-- No business logic should depend on raw tokens or header access
+**Error handling:**
+- Ensure stack traces are never exposed to HTTP clients
+- Include `request_id` and (masked) `user_id` in all security-related logs

--- a/agents/copilot/instructions/backend/services.instructions.md
+++ b/agents/copilot/instructions/backend/services.instructions.md
@@ -2,88 +2,23 @@
 applyTo: "**/services/**"
 ---
 
-# Service Layer Instructions
+# Service Layer — Domain Logic
 
-Applies to all modules under `/services/**`. Services implement core business logic in alignment with Hexagonal Architecture.
+**Your project's architecture contract:** `docs/backend/architecture/ARCH_CONTRACT.md`
 
----
+Services implement the business logic of your domain. Review the architecture contract for layer structure and boundaries.
 
-## 1. Purpose
+**Universal constraints (apply to any language):**
+- Services contain business logic, state transitions, and orchestration — nothing else
+- Services must not directly handle HTTP, serialization, database, or network concerns
+- Services must not import from the inbound adapter layer (API, CLI) or the adapter/infrastructure layer
+- All external dependencies must be injected via constructor (no singleton global access, no hardcoded instantiation)
+- Services may only depend on ports and pure domain models
+- Services raise domain-specific exceptions; adapters convert these to API responses
+- One service per domain area; methods should be named after business operations
+- All domain logic that produces business value lives here
 
-- Encapsulate domain rules, state transitions, and orchestration
-- Must not handle HTTP, serialization, or DB logic
-- May call:
-  - Repositories (via outbound ports)
-  - Validators and injected helpers
-  - Other services via defined interfaces
-
----
-
-## 2. Structure and Naming
-
-- One service per domain area (e.g., `UserService`, `PaymentService`)
-- Classes must use the `Service` suffix
-- Expose clear public methods named after business operations (e.g., `create_user()`)
-
----
-
-## 3. Dependencies
-
-- Inject dependencies via constructor (no inline instantiation)
-- Accept only ports and pure helpers (no adapters or framework code)
-
-```python
-class UserService:
-    def __init__(self, user_repo: UserPort):
-        self.user_repo = user_repo
-```
-
----
-
-## 4. Boundaries
-
-- Services must not:
-  - Import from `/api`, `/adapters`, or FastAPI
-  - Reference request/response models
-  - Access environment or global config directly
-- Services may:
-  - Raise domain exceptions
-  - Return DTOs or pure Python values
-
----
-
-## 5. Error Handling
-
-- Raise custom exceptions (e.g., `UserAlreadyExistsError`)
-- Never raise `HTTPException` or adapter-specific errors
-
----
-
-## 6. Logging
-
-- Use structured logging with `event`, `user_id`, and `service_name`
-- Do not log secrets or raw tokens
-
----
-
-## 7. Testing
-
-- Unit test all public methods in isolation
-- Mock dependencies (e.g., repos, ports)
-- Validate logic, not HTTP behavior
-
----
-
-## 8. Cross-Cutting Concerns
-
-- Handle retries, caching, and async dispatch using decorators
-- Services must remain stateless
-- Long-running work must be delegated to jobs/tasks (e.g., Celery, RQ)
-
----
-
-## 9. Violations
-
-- Business logic must never live in route handlers or adapter code
-- Logic found in `/api` or `/repos` should be moved to a service
-- All non-API, non-infrastructure logic belongs in the service layer
+**Testing:**
+- Unit test all service public methods in isolation
+- Mock all injected port dependencies
+- Test business logic, not infrastructure details

--- a/agents/copilot/instructions/cli/cli.instructions.md
+++ b/agents/copilot/instructions/cli/cli.instructions.md
@@ -1,19 +1,22 @@
-# CLI Layer Rules
+---
+applyTo: "**/cli/**,**/commands/**"
+---
 
-Follow the CLI conventions defined in `docs/backend/architecture/CLI_CONVENTIONS.md`.
+# CLI Layer — Inbound Adapter
 
-All commands in `cli/` or `commands/` must:
+**Your project's CLI conventions:** `docs/backend/architecture/CLI_CONVENTIONS.md`
 
-- Use Click or Typer for argument parsing and command structure
-- Delegate all logic to inbound ports (`ports/inbound/`)
-- Never access domain services, repositories, or adapter logic directly
-- Validate arguments using Click/Typer parameter types before calling ports
-- Map CLI arguments to domain objects (DTOs or value objects) before port calls
-- Use exit code 0 for success, 1 for user errors, 2 for system errors
-- Send structured output to stdout, error/status messages to stderr
-- Support `--format json|table|plain` for commands that produce data output
-- Include `--verbose` flag for debug-level logging
-- Never expose stack traces or internal details in normal mode
-- Avoid leaking Click/Typer types into service or port layers
+Read this document before implementing any CLI command. It defines your project's command structure, argument handling, output format, and error reporting.
 
-All CLI commands are inbound adapters. They must stay thin and port-driven.
+**Universal constraints (apply to any language):**
+- CLI commands are inbound adapters — delegate all business logic to inbound ports in `ports/inbound/`
+- Validate and parse arguments according to your CLI framework before calling ports
+- Map CLI arguments to domain objects (DTOs, value objects) before passing to ports
+- Commands must remain thin — no business logic inline
+- Never expose domain types directly in output; translate at the boundary
+- Use universal exit codes: 0 = success, 1 = user error (invalid input, business rule violation), 2 = system error (infrastructure failure)
+- Send structured output to stdout; send diagnostic/error messages to stderr
+- Provide structured output formats (`--format json|table|plain`) for machine-readable results
+- Include `--verbose` flag to enable debug-level logging
+- Never expose stack traces in normal mode
+- Domain layer must not depend on CLI framework types or libraries


### PR DESCRIPTION
Decouple all agent rules from language/framework specifics and move them to docs/. This allows a single rule set (Claude Code, Copilot, Codex) to work with any backend language (Python, C#, Go, Java) by customizing docs/ instead of maintaining separate rules for each language.

Why

Currently, agent rules embed language-specific patterns (FastAPI, Pydantic, Click for Python). This forces duplicate rule sets for each language. By referencing centralized docs/ files, a single rule set works across Python, C#, Go, Java, etc., reducing maintenance burden and enabling faster onboarding of new languages.

Changes (36 files across 3 agents):

**Claude Code (12 files):**
- 6 rules files (agents/claude-code/rules/): removed FastAPI, Pydantic, Click specifics
- 6 main entry files (agents/claude-code/claude-md/): added Project Documentation section

**GitHub Copilot (12 files):**
- 6 instructions files (agents/copilot/instructions/): removed language specifics
- 6 main entry files (agents/copilot/copilot-instructions/): added Project Documentation section

**OpenAI Codex (12 files):**
- 6 rules files (agents/codex/rules/): removed language specifics
- 6 main entry files (agents/codex/agents-md/): added Project Documentation section

Pattern applied to all rules:

**Before (language-specific):**
- Rules embedded FastAPI patterns, Pydantic models, Click CLI, SQLAlchemy, etc.

**After (language-agnostic):**
- Rules reference docs/ file and ask agent to read it
- Rules define universal constraints (hexagonal architecture, boundaries, etc.)
- All implementation details (frameworks, libraries) moved to docs/

Example:

  **Your project's API conventions:** docs/backend/architecture/API_CONVENTIONS.md

  Read this document before implementing any route. It defines your project's routing style, request/response models, authentication mechanism, error handling, and testing approach.

  **Universal constraints (apply to any language):**
  - Routes are inbound adapters — delegate to ports in ports/inbound/
  - Validate and authenticate before calling port layer
  - Map domain exceptions to HTTP responses at this layer
  - [etc.]

This enables:
- Python projects: unchanged behavior (docs still contain FastAPI content)
- C# projects: teams customize docs/API_CONVENTIONS.md for ASP.NET Core
- Go, Java, etc.: same pattern

All docs/ files remain unchanged. Parity testing with Python/FastAPI validates that refactored agents produce identical guidance and code output.

See PARITY_TEST.md for comprehensive testing and validation approach.

## Summary

Describe what changed and why.

## Type of Change

- [x] Feature
- [ ] Fix
- [ ] Documentation
- [ ] Refactor
- [ ] Test
- [ ] CI / Build
- [ ] Chore

## Related Issues

Link any related issues here.
