### PR TITLE
fix: scope UI architecture docs to selected framework and add Tailwind to React stack

### DIFF
--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -170,7 +170,11 @@
           { "src": "skills/ui/adr-author/", "dest": ".claude/skills/ui-adr-author/" }
         ],
         "shared": [
-          "docs/ui/",
+          "docs/ui/architecture/MVVM_CONTRACT.md",
+          "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
+          "docs/ui/architecture/ADR/",
+          "docs/ui/architecture/react/",
+          "docs/ui/evaluation/",
           "governance/ui/",
           "features/starter_ui/",
           "features/ui_task_dashboard/"
@@ -202,7 +206,11 @@
           { "src": "skills/ui/adr-author/", "dest": ".claude/skills/ui-adr-author/" }
         ],
         "shared": [
-          "docs/ui/",
+          "docs/ui/architecture/MVVM_CONTRACT.md",
+          "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
+          "docs/ui/architecture/ADR/",
+          "docs/ui/architecture/angular/",
+          "docs/ui/evaluation/",
           "governance/ui/",
           "features/starter_ui/",
           "features/ui_task_dashboard/"

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -166,7 +166,11 @@
           { "src": "skills/ui/adr-author/", "dest": ".agents/skills/ui-adr-author/" }
         ],
         "shared": [
-          "docs/ui/",
+          "docs/ui/architecture/MVVM_CONTRACT.md",
+          "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
+          "docs/ui/architecture/ADR/",
+          "docs/ui/architecture/react/",
+          "docs/ui/evaluation/",
           "governance/ui/",
           "features/starter_ui/",
           "features/ui_task_dashboard/"
@@ -196,7 +200,11 @@
           { "src": "skills/ui/adr-author/", "dest": ".agents/skills/ui-adr-author/" }
         ],
         "shared": [
-          "docs/ui/",
+          "docs/ui/architecture/MVVM_CONTRACT.md",
+          "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
+          "docs/ui/architecture/ADR/",
+          "docs/ui/architecture/angular/",
+          "docs/ui/evaluation/",
           "governance/ui/",
           "features/starter_ui/",
           "features/ui_task_dashboard/"

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -132,7 +132,11 @@
           { "src": "prompts/ui/", "dest": ".github/prompts/" }
         ],
         "shared": [
-          "docs/ui/",
+          "docs/ui/architecture/MVVM_CONTRACT.md",
+          "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
+          "docs/ui/architecture/ADR/",
+          "docs/ui/architecture/react/",
+          "docs/ui/evaluation/",
           "governance/ui/",
           "features/starter_ui/",
           "features/ui_task_dashboard/"
@@ -156,7 +160,11 @@
           { "src": "prompts/ui/", "dest": ".github/prompts/" }
         ],
         "shared": [
-          "docs/ui/",
+          "docs/ui/architecture/MVVM_CONTRACT.md",
+          "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
+          "docs/ui/architecture/ADR/",
+          "docs/ui/architecture/angular/",
+          "docs/ui/evaluation/",
           "governance/ui/",
           "features/starter_ui/",
           "features/ui_task_dashboard/"

--- a/docs/ui/architecture/react/TECH_STACK.md
+++ b/docs/ui/architecture/react/TECH_STACK.md
@@ -13,7 +13,18 @@
 
 ---
 
-## 2. State Management
+## 2. Styling
+
+| Concern | Tool | Version |
+|---|---|---|
+| CSS framework | Tailwind CSS | 3+ |
+| Component variants | `clsx` + `tailwind-merge` | latest |
+
+No custom global stylesheets. All styles via Tailwind utility classes. Use `clsx`/`twMerge` for conditional class composition in components.
+
+---
+
+## 3. State Management
 
 | Concern | Tool |
 |---|---|
@@ -25,7 +36,7 @@ See `STATE_MANAGEMENT.md` for usage rules.
 
 ---
 
-## 3. Testing
+## 4. Testing
 
 | Concern | Tool |
 |---|---|
@@ -36,7 +47,7 @@ See `STATE_MANAGEMENT.md` for usage rules.
 
 ---
 
-## 4. Observability
+## 5. Observability
 
 | Concern | Tool |
 |---|---|
@@ -48,7 +59,7 @@ OpenTelemetry instrumentation lives in `src/shared/observability/`. Features mus
 
 ---
 
-## 5. HTTP
+## 6. HTTP
 
 | Concern | Tool |
 |---|---|
@@ -59,7 +70,7 @@ No Axios. Use the shared base client in `src/shared/api/client.ts`.
 
 ---
 
-## 6. Quality Gates (CI)
+## 7. Quality Gates (CI)
 
 | Gate | Tool |
 |---|---|
@@ -72,7 +83,7 @@ No Axios. Use the shared base client in `src/shared/api/client.ts`.
 
 ---
 
-## 7. Governance
+## 8. Governance
 
 | Concern | Location |
 |---|---|


### PR DESCRIPTION
## What
Fixes govkit so that installing with `--ui react` only delivers React architecture docs (not Angular), and vice versa — and adds Tailwind CSS to the React tech stack.

## Why
The `docs/ui/` shared path was used by both framework variants, causing both the `react/` and `angular/` architecture subfolders to land in every target project regardless of which UI was selected.

## Changes
- **All 3 manifests** (claude-code, copilot, codex): replaced the blanket `"docs/ui/"` shared path with granular entries — shared files (`MVVM_CONTRACT.md`, `ACCESSIBILITY_STANDARDS.md`, `ADR/`, `evaluation/`) go to both variants; `docs/ui/architecture/react/` only to the react variant; `docs/ui/architecture/angular/` only to the angular variant
- **`docs/ui/architecture/react/TECH_STACK.md`**: added Section 2 (Styling) with Tailwind CSS 3+ and `clsx`/`tailwind-merge`; renumbered subsequent sections 3–8

## Testing
- Run `govkit apply --agent claude-code --ui react --target <tmp>` and confirm only `docs/ui/architecture/react/` is present (no `angular/` folder)
- Run same with `--ui angular` and confirm only `docs/ui/architecture/angular/` is present
- Verify `docs/ui/architecture/react/TECH_STACK.md` in target contains the Styling section