### PR TITLE
feat: add multi-agent governance layer and govkit upgrade command

### DIFF
--- a/MULTI_AGENT_GOVERNANCE_PLAN.md
+++ b/MULTI_AGENT_GOVERNANCE_PLAN.md
@@ -1,0 +1,360 @@
+# Multi-Agent Governance Plan
+
+**Status:** Pending approval  
+**Scope:** All three coding agents — claude-code, copilot, codex  
+**Level:** L5 only (opt-in via `multi_agent: true` in `eval_criteria.yaml`)
+
+---
+
+## Why This Change
+
+The current govkit framework governs single-LLM features well: LiteLLM gateway, LangGraph node rules, DeepEval/Promptfoo evaluation. But it has no governance for *multi-agent orchestration* — the pattern where an orchestrating system prompt routes tasks to specialized agents, each with defined responsibilities, typed state contracts, and their own system prompts.
+
+The core insight: in a multi-agent system, the **agent topology graph is the business logic** and **system prompts are the source code**. Both need governance discipline — contracts, ADRs for changes, evaluation for quality — just like code. Neither is governed today.
+
+`docs/backend/architecture/AGENT_ARCHITECTURE.md` already exists and is the right home. It defines LangGraph usage, typed state, prompt versioning, and ADR triggers. This plan extends it with multi-agent topology governance rather than introducing a new contract file.
+
+Multi-agent governance is **opt-in at L5**, triggered by declaring `multi_agent: true` in `eval_criteria.yaml`. Not all L5 features are multi-agent. The pattern follows the existing `mode: llm` conditional-check design.
+
+---
+
+## Agent Structure Reference
+
+| Concern | claude-code | copilot | codex |
+|---|---|---|---|
+| Root instructions | `claude-md/l5-*.md` → `CLAUDE.md` | `copilot-instructions/l5-*.md` → `.github/copilot-instructions.md` | `agents-md/l5-*.md` → `AGENTS.md` |
+| Layer rules | `rules/backend/*.md` → `.claude/rules/` | `instructions/backend/*.instructions.md` → `.github/instructions/` | `rules/backend/*.md` → nested `AGENTS.md` per layer |
+| Skills | `skills/backend/*/SKILL.md` → `.claude/skills/` | `skills/backend/*/SKILL.md` → `.github/skills/` | `skills/backend/*/SKILL.md` → `.agents/skills/` |
+| Skill invocation | `/skill-name` | `/skill-name` | `$skill-name` |
+| Manifest | `agents/claude-code/manifest.json` | `agents/copilot/manifest.json` | `agents/codex/manifest.json` |
+
+Skills use identical SKILL.md content across all three agents. Only the deployment path and invocation prefix differ, both managed by the manifest.
+
+---
+
+## New Files (9)
+
+### Shared
+
+**`ci/github/multi-agent-gate.yml`**  
+GitHub Actions gate. Triggers when `multi_agent: true` appears in any feature's `eval_criteria.yaml`. Two jobs:
+- `topology-check` — validates `agent_topology.md` exists and contains: `## Orchestrator`, `## Specialist Agents`, `## Routing Logic`, `## Failure Modes`
+- `system-prompt-check` — reads `agent_topology.md`, extracts all `system_prompt:` path declarations, verifies each file exists in the repo
+
+**`ci/azure/multi-agent-gate.yml`**  
+Azure DevOps mirror of the GitHub gate. Same logic, Azure pipeline syntax (stages/jobs).
+
+**`features/starter_backend_l5/agent_topology.md`**  
+Starter template showing a concrete orchestrator + 2 specialists pattern. Shipped as part of the L5 starter so `govkit init` gives developers a real working example.
+
+### claude-code agent
+
+**`agents/claude-code/rules/backend/multi-agent.md`**  
+Path-scoped rule. Fires on `**/agents/**`, `**/graphs/**`, `**/orchestrators/**`.
+
+Rules:
+- Graph definitions belong in `services/graphs/` — not in adapters or API layer
+- State must be typed as `TypedDict` — no untyped dicts passed between nodes
+- All LLM calls in graph nodes route through `LLMPort` — no direct provider SDK calls
+- System prompts loaded from file at runtime — no inline strings in Python code
+- No direct agent-to-agent calls — all routing goes through graph edges
+
+Prohibited:
+- Untyped state passed between nodes
+- Hardcoded system prompt strings in graph node functions
+- Direct imports of `openai`, `anthropic`, or other provider SDKs in graph files
+- Agent-to-agent calls bypassing the LangGraph graph
+
+**`agents/claude-code/skills/backend/multi-agent-design/SKILL.md`**  
+Pre-planning skill invoked via `/multi-agent-design <feature_name>`. Must run before `/architecture-preflight` for multi-agent features. Forces the developer to answer:
+- Does this feature actually require multiple agents? (justify or stop)
+- What is the orchestrator's role?
+- What are the specialist agents? For each: role, input state fields, output state fields, system prompt path (`src/agents/<name>/system_prompt.md`), LLM model alias
+- What is the routing logic? (conditions for each graph edge)
+- What is the handoff protocol? (which state fields transfer, how missing fields are handled)
+- What are the failure modes? (per-node timeout, graph-level fallback)
+- What cross-agent eval metrics are needed?
+
+Output: writes `features/<feature_name>/agent_topology.md`
+
+### copilot agent
+
+**`agents/copilot/instructions/backend/multi-agent.instructions.md`**  
+Copilot equivalent of the claude-code rule. Same content, with `applyTo: "**/agents/**, **/graphs/**, **/orchestrators/**"` frontmatter per copilot instructions convention.
+
+**`agents/copilot/skills/backend/multi-agent-design/SKILL.md`**  
+Identical SKILL.md content to the claude-code version. Deployed to `.github/skills/multi-agent-design/` via manifest. Skill invoked via `/multi-agent-design`.
+
+### codex agent
+
+**`agents/codex/rules/backend/multi-agent.md`**  
+Same content as the claude-code rule. Deployed as a nested `AGENTS.md` in the `agents/`, `graphs/`, and `orchestrators/` directories of the target project via manifest.
+
+**`agents/codex/skills/backend/multi-agent-design/SKILL.md`**  
+Identical SKILL.md content to the claude-code version. Deployed to `.agents/skills/multi-agent-design/` via manifest. Skill invoked via `$multi-agent-design`.
+
+---
+
+## Modified Files (22)
+
+### Shared
+
+**`docs/backend/architecture/AGENT_ARCHITECTURE.md`**  
+Extend the existing contract with four targeted additions:
+
+- **New Section 17: Multi-Agent Topology** — defines `agent_topology.md` as a required governance artifact when `multi_agent: true` in `eval_criteria.yaml`; specifies required sections (Orchestrator definition with role and system prompt path; Specialist Agents each with role, input/output state fields, system prompt path, and model alias; Routing Logic with explicit edge conditions; Failure Modes with per-node timeout and graph-level fallback)
+
+- **Extend Section 5 (Prompt Management)** — make system prompt path a mandatory field in each agent's entry in `agent_topology.md`; clarify the file convention: `src/agents/<agent_name>/system_prompt.md`; system prompts loaded at runtime, never hardcoded
+
+- **Extend Section 10 (Evaluation Integration)** — add cross-agent eval tier: system-level evaluation measures the composed output of the full graph, not individual node outputs; reference the `multi_agent_evaluation` block in `eval_criteria.yaml`; cross-agent eval runs in CI via `multi-agent-gate.yml`
+
+- **Extend Section 14 (ADR Requirements)** — add explicit ADR triggers for multi-agent topology changes: adding or removing graph nodes, rerouting edges, changing a node's state schema, making material changes to a system prompt
+
+**`cli/validate.py`**  
+Add 2 new check functions and register them in `_build_checks` for L5.
+
+New constant:
+```python
+_AGENT_TOPOLOGY_MD = "agent_topology.md"
+_RE_MULTI_AGENT = r"^multi_agent:\s*true"
+```
+
+New helper:
+```python
+def _is_multi_agent(feature_dir: Path) -> bool | None:
+    """Returns True if multi_agent: true in eval_criteria.yaml, None if file missing."""
+    eval_path = feature_dir / _EVAL_CRITERIA_YAML
+    if not eval_path.exists():
+        return None
+    return bool(re.search(_RE_MULTI_AGENT, eval_path.read_text(encoding="utf-8"), re.MULTILINE))
+```
+
+New check 1:
+```python
+def check_agent_topology_exists(feature_dir: Path) -> tuple[bool, str]:
+    """When multi_agent: true, agent_topology.md must exist and be non-empty."""
+    if not _is_multi_agent(feature_dir):
+        return True, "multi_agent not declared — agent topology check not applicable"
+    path = feature_dir / _AGENT_TOPOLOGY_MD
+    if not path.exists():
+        return False, f"{_AGENT_TOPOLOGY_MD} missing — required when multi_agent: true"
+    if path.stat().st_size == 0:
+        return False, f"{_AGENT_TOPOLOGY_MD} is empty"
+    return True, f"{_AGENT_TOPOLOGY_MD} present"
+```
+
+New check 2:
+```python
+def check_agent_topology_sections(feature_dir: Path) -> tuple[bool, str]:
+    """When multi_agent: true, agent_topology.md must have all required sections."""
+    if not _is_multi_agent(feature_dir):
+        return True, "multi_agent not declared — agent topology sections check not applicable"
+    path = feature_dir / _AGENT_TOPOLOGY_MD
+    if not path.exists():
+        return False, f"{_AGENT_TOPOLOGY_MD} not found"
+    text = path.read_text(encoding="utf-8")
+    required = [
+        (r"^##\s+Orchestrator", "Orchestrator"),
+        (r"^##\s+Specialist Agents", "Specialist Agents"),
+        (r"^##\s+Routing Logic", "Routing Logic"),
+        (r"^##\s+Failure Modes", "Failure Modes"),
+    ]
+    missing = [name for pattern, name in required
+               if not re.search(pattern, text, re.MULTILINE)]
+    if missing:
+        return False, f"{_AGENT_TOPOLOGY_MD} missing sections: {', '.join(missing)}"
+    return True, f"{_AGENT_TOPOLOGY_MD} has all required sections"
+```
+
+In `_build_checks`, add both functions to the L5 check list after `check_l5_preflight_sections`.
+
+**`tests/test_validate.py`**  
+Add `TestMultiAgentValidation` class:
+- `check_agent_topology_exists`: multi_agent true + file missing → fail; file present → pass; not declared → skip (True); empty file → fail
+- `check_agent_topology_sections`: all sections present → pass; one missing → fail with section name; not declared → skip; file missing → fail
+- Integration: L5 `_build_checks` includes both new checks in the correct position
+
+**`governance/schemas/evaluation_prediction.schema.json`**  
+Add optional `multi_agent_evaluation` object inside `evaluation_prediction`:
+```json
+"multi_agent_evaluation": {
+  "type": "object",
+  "properties": {
+    "topology_validated":            { "type": "boolean" },
+    "system_prompt_governed":        { "type": "boolean" },
+    "cross_agent_coherence":         { "$ref": "#/definitions/score_entry" },
+    "orchestrator_routing_accuracy": { "$ref": "#/definitions/score_entry" }
+  },
+  "required": ["topology_validated", "system_prompt_governed"]
+}
+```
+
+**`features/starter_backend_l5/eval_criteria.yaml`**  
+Add commented-out `multi_agent` block showing the flag and cross-agent eval dimensions. Developers uncomment when building a multi-agent feature:
+```yaml
+# Uncomment when building a multi-agent feature:
+# multi_agent: true
+# multi_agent_evaluation:
+#   topology_validated: false
+#   system_prompt_governed: false
+#   cross_agent_coherence:
+#     score: null
+#     evidence: ""
+#   orchestrator_routing_accuracy:
+#     score: null
+#     evidence: ""
+```
+
+**`governance/backend/templates/l5-plan.md`**  
+Add a **Multi-Agent Configuration** section (conditional, appears when `multi_agent: true`):
+- Agent topology reference: `features/<feature>/agent_topology.md`
+- State schema path: `services/graphs/<feature>_state.py`
+- System prompt paths per agent (table: agent name → file path)
+- Cross-agent eval prediction block using `multi_agent_evaluation` schema fields
+
+**`governance/backend/templates/l5-architecture-preflight.md`**  
+Add **Section 15: Agent Topology** at the end. Only required when `multi_agent: true`. Template text:
+- Is `agent_topology.md` present and complete?
+- Does each agent have a typed state contract?
+- Does each system prompt file exist at its declared path?
+- Is an ADR required for this topology? (Yes if this is a new multi-agent feature or topology change)
+- Section 15 status: Approved / Blocked
+
+---
+
+### claude-code agent
+
+**`agents/claude-code/skills/backend/architecture-preflight/SKILL.md`**  
+Add **Section 15: Agent Topology Check** at the end of the preflight checklist:
+```
+## 15. Agent Topology (multi-agent features only)
+
+Check if `features/$ARGUMENTS/eval_criteria.yaml` declares `multi_agent: true`.
+
+If yes:
+- [ ] `agent_topology.md` exists — HALT and request `/multi-agent-design $ARGUMENTS` if missing
+- [ ] Orchestrator role and system prompt path are declared
+- [ ] Each specialist agent has: role, typed input/output state, system prompt path, model alias
+- [ ] Routing logic covers all edge conditions
+- [ ] Failure modes specify per-node timeout and graph-level fallback
+- [ ] ADR status confirmed for this topology
+
+Section 15 status: Approved / Blocked
+```
+
+**`agents/claude-code/skills/backend/genai-preflight/SKILL.md`**  
+Add **Section 6: Multi-Agent Validation** (runs only when `multi_agent: true`):
+- Confirm each agent's system prompt file exists at the declared path in `agent_topology.md`
+- Confirm graph state schema is a `TypedDict` in `services/graphs/`
+- Confirm `eval_criteria.yaml` includes `multi_agent_evaluation` block with `topology_validated` and `system_prompt_governed`
+- Confirm LangGraph is approved in `docs/backend/architecture/TECH_STACK.md`
+- Block if any item fails; update Section 15 of `architecture_preflight.md`
+
+**`agents/claude-code/claude-md/l5-backend-api.md`**  
+Add three targeted additions:
+1. Under architecture contracts: "If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17 before planning."
+2. Under ADR rules: "Agent topology changes (adding/removing/rerouting nodes, material system prompt changes, state schema changes) require an ADR."
+3. Under feature lifecycle: "For multi-agent features: run `/multi-agent-design` before `/architecture-preflight`."
+
+**`agents/claude-code/claude-md/l5-backend-cli.md`**  
+Same three additions as `l5-backend-api.md`.
+
+**`agents/claude-code/manifest.json`**  
+In both `type.api.level_5` and `type.cli.level_5` overrides:
+- Add to `files`: `{ "src": "rules/backend/multi-agent.md", "dest": ".claude/rules/multi-agent.md" }`
+- Add to `files`: `{ "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/multi-agent-design/" }`
+- Add to `ci.github.level_5.shared`: `"ci/github/multi-agent-gate.yml"`
+- Add to `ci.azure.level_5.shared`: `"ci/azure/multi-agent-gate.yml"`
+
+---
+
+### copilot agent
+
+**`agents/copilot/skills/backend/architecture-preflight/SKILL.md`**  
+Same Section 15 addition as claude-code version.
+
+**`agents/copilot/skills/backend/genai-preflight/SKILL.md`**  
+Same Section 6 addition as claude-code version.
+
+**`agents/copilot/copilot-instructions/l5-backend-api.md`**  
+Same three additions as claude-code `l5-backend-api.md`.
+
+**`agents/copilot/copilot-instructions/l5-backend-cli.md`**  
+Same three additions as claude-code `l5-backend-cli.md`.
+
+**`agents/copilot/manifest.json`**  
+In both `type.api.level_5` and `type.cli.level_5` overrides:
+- Add to `files`: `{ "src": "instructions/backend/multi-agent.instructions.md", "dest": ".github/instructions/multi-agent.instructions.md" }`
+- Add to `files`: `{ "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/multi-agent-design/" }`
+- Add to `ci.github.level_5.shared`: `"ci/github/multi-agent-gate.yml"`
+- Add to `ci.azure.level_5.shared`: `"ci/azure/multi-agent-gate.yml"`
+
+---
+
+### codex agent
+
+**`agents/codex/skills/backend/architecture-preflight/SKILL.md`**  
+Same Section 15 addition as claude-code version. Skill invocation style uses `$architecture-preflight`.
+
+**`agents/codex/skills/backend/genai-preflight/SKILL.md`**  
+Same Section 6 addition as claude-code version. Skill invocation style uses `$genai-preflight`.
+
+**`agents/codex/agents-md/l5-backend-api.md`**  
+Same three additions as claude-code `l5-backend-api.md`. Skill references use `$multi-agent-design`.
+
+**`agents/codex/agents-md/l5-backend-cli.md`**  
+Same three additions as claude-code `l5-backend-cli.md`. Skill references use `$multi-agent-design`.
+
+**`agents/codex/manifest.json`**  
+In both `type.api.level_5` and `type.cli.level_5` overrides:
+- Add to `files`: `{ "src": "rules/backend/multi-agent.md", "dest": "agents/AGENTS.md" }` (or per codex nested AGENTS.md convention — confirm path pattern from existing L5 rules)
+- Add to `files`: `{ "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/multi-agent-design/" }`
+- Add to `ci.github.level_5.shared`: `"ci/github/multi-agent-gate.yml"`
+- Add to `ci.azure.level_5.shared`: `"ci/azure/multi-agent-gate.yml"`
+
+---
+
+## Implementation Sequence
+
+These must be done in order:
+
+1. Extend `AGENT_ARCHITECTURE.md` — establishes the contract everything else references
+2. `agent_topology.md` starter template — concrete working example of Section 17
+3. Rule/instruction files for all 3 agents — code-level enforcement
+4. `multi-agent-design` SKILL.md for all 3 agents — the skill that produces `agent_topology.md`
+5. Architecture preflight + genai preflight updates for all 3 agents — checks topology exists and is valid
+6. Root instruction updates for all 3 agents — wires the skill into the L5 lifecycle
+7. `validate.py` + tests — runtime enforcement via `govkit validate`
+8. `manifest.json` updates for all 3 agents — deploys rule and skill via `govkit apply`
+9. CI gates — enforces topology and system prompt checks in pipeline
+10. Schema + template updates — evaluation prediction schema and plan/preflight templates
+
+---
+
+## File Count Summary
+
+| Category | New | Modified |
+|---|---|---|
+| Shared (docs, CI, validation, templates) | 3 | 7 |
+| claude-code agent | 2 | 5 |
+| copilot agent | 2 | 5 |
+| codex agent | 2 | 5 |
+| **Total** | **9** | **22** |
+
+**31 files total.**
+
+---
+
+## Verification
+
+After implementation:
+
+1. `pytest tests/test_validate.py -v` — all existing tests pass; new `TestMultiAgentValidation` tests pass
+2. Create a test feature with `multi_agent: true` in `eval_criteria.yaml`, no `agent_topology.md` → `govkit validate --level 5` exits 1 with clear error
+3. Same feature with `agent_topology.md` missing sections → exits 1, names the missing sections
+4. Same feature with a complete `agent_topology.md` → exits 0
+5. `govkit apply --agent claude-code --level 5 --target <tmpdir>` → verify `.claude/rules/multi-agent.md` and `.claude/skills/multi-agent-design/SKILL.md` are present
+6. `govkit apply --agent copilot --level 5 --target <tmpdir>` → verify `.github/instructions/multi-agent.instructions.md` and `.github/skills/multi-agent-design/SKILL.md` are present
+7. `govkit apply --agent codex --level 5 --target <tmpdir>` → verify codex-equivalent paths contain the new rule and skill
+8. Inspect all three manifests to confirm new L5 entries reference valid source paths
+9. Review `AGENT_ARCHITECTURE.md` Section 17 and extended sections 5, 10, 14 for clarity and completeness

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ govkit apply --agent copilot --type api --ui none --ci github --target .
 govkit apply --agent codex --type api --ui react --ci github --target .
 ```
 
-A `.govkit` marker file is written to your project root, tracking the applied level and options. This enables `govkit init` and `govkit validate` to auto-detect your level.
+A `.govkit` marker file is written to your project root, tracking the agent, level, options, and govkit version. This enables `govkit init`, `govkit validate`, and `govkit upgrade` to auto-detect your configuration without re-specifying flags.
 
 When using interactive mode (no `--type`, `--ui`, `--ci` flags), you'll see prompts like:
 
@@ -168,7 +168,38 @@ Before writing a single line of feature code, review and update the following to
 
 These files are the source of truth for your AI agent. The agent reads them before every planning and implementation step. Keep them accurate and up to date as your project evolves.
 
-### 6. Validate governance compliance
+### 6. Keep governance contracts up to date
+
+When you upgrade govkit, run `govkit upgrade` to refresh the files that govkit owns — architecture contracts, CI gate pipelines, plan templates — without touching the files your team owns.
+
+```bash
+pip install --upgrade govkit
+govkit upgrade --target .
+```
+
+govkit distinguishes three categories of files:
+
+| Category | Examples | `apply` | `upgrade` |
+|---|---|---|---|
+| **Agent config** | `CLAUDE.md`, `.claude/rules/`, `.agents/skills/` | Always overwrite | Always overwrite |
+| **Governed contracts** | `docs/backend/architecture/`, `governance/backend/templates/`, `ci/github/` | Write once (skip if present) | **Overwrite** |
+| **Project artifacts** | `features/starter_*/`, your ADRs, filled-in feature files | Write once (skip if present) | Skip |
+
+After upgrading, review the diff and commit:
+
+```bash
+git diff
+git add -p
+git commit -m "chore: upgrade govkit governance contracts to vX.Y.Z"
+```
+
+Use `--force` to re-apply even when the version is already current — useful for resetting a contract file to govkit defaults after an accidental edit:
+
+```bash
+govkit upgrade --target . --force
+```
+
+### 7. Validate governance compliance
 
 ```bash
 govkit validate --target .

--- a/agents/claude-code/claude-md/l5-backend-api.md
+++ b/agents/claude-code/claude-md/l5-backend-api.md
@@ -24,6 +24,7 @@ Before planning or generating code:
   - `docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md`
   - `docs/backend/architecture/GUARDRAILS_CONTRACT.md`
   - `docs/backend/architecture/EVALUATION_LLM_CONTRACT.md`
+- If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17
 - Apply architecture, testing, technology, evaluation, and GenAI contracts as binding constraints
 - Confirm required feature artifacts exist
 
@@ -53,6 +54,7 @@ Before proceeding to Architecture Preflight or planning:
 
 ## Feature Lifecycle (Mandatory Order — no steps may be skipped)
 
+0. **Multi-agent features only:** run `/multi-agent-design` before architecture preflight to produce `agent_topology.md`
 1. Architecture Preflight → run `/architecture-preflight`
 2. GenAI Preflight → run `/genai-preflight` (validates L5-specific decisions)
 3. ADR creation (if required by preflight)
@@ -91,6 +93,9 @@ An ADR is required when:
 - A new LLM provider is added to the routing table
 - The guardrail mode is changed for a production feature
 - LiteLLM is bypassed for any LLM call
+- A multi-agent graph node is added, removed, or rerouted
+- An agent's system prompt is materially changed
+- The shared graph state schema is changed
 
 ---
 

--- a/agents/claude-code/claude-md/l5-backend-cli.md
+++ b/agents/claude-code/claude-md/l5-backend-cli.md
@@ -24,6 +24,7 @@ Before planning or generating code:
   - `docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md`
   - `docs/backend/architecture/GUARDRAILS_CONTRACT.md`
   - `docs/backend/architecture/EVALUATION_LLM_CONTRACT.md`
+- If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17
 - Apply all contracts as binding constraints
 - Confirm required feature artifacts exist
 
@@ -47,6 +48,7 @@ Implementation must not begin unless all five artifacts exist.
 
 ## Feature Lifecycle (Mandatory Order — no steps may be skipped)
 
+0. **Multi-agent features only:** run `/multi-agent-design` before architecture preflight to produce `agent_topology.md`
 1. Architecture Preflight → run `/architecture-preflight`
 2. GenAI Preflight → run `/genai-preflight` (if feature uses LLM)
 3. ADR creation (if required by preflight)
@@ -112,3 +114,5 @@ Layer-specific rules load automatically from `.claude/rules/`.
 ## Authority
 
 Architecture decisions belong to the Architect. Exceptions require an ADR and explicit approval. Claude follows standards — it does not invent them.
+
+Multi-agent ADR triggers: adding/removing/rerouting graph nodes, material system prompt changes, graph state schema changes.

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -73,12 +73,14 @@
             { "src": "rules/backend/guardrails.md", "dest": ".claude/rules/guardrails.md" },
             { "src": "rules/backend/llm-evaluation.md", "dest": ".claude/rules/llm-evaluation.md" },
             { "src": "rules/backend/llm-observability.md", "dest": ".claude/rules/llm-observability.md" },
+            { "src": "rules/backend/multi-agent.md", "dest": ".claude/rules/multi-agent.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".claude/skills/architecture-preflight/" },
             { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/implementation-plan/" },
             { "src": "skills/backend/adr-author/", "dest": ".claude/skills/adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".claude/skills/genai-preflight/" },
-            { "src": "skills/backend/eval-suite-planning/", "dest": ".claude/skills/eval-suite-planning/" }
+            { "src": "skills/backend/eval-suite-planning/", "dest": ".claude/skills/eval-suite-planning/" },
+            { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/multi-agent-design/" }
           ],
           "shared": [
             "docs/backend/",
@@ -136,12 +138,14 @@
             { "src": "rules/backend/guardrails.md", "dest": ".claude/rules/guardrails.md" },
             { "src": "rules/backend/llm-evaluation.md", "dest": ".claude/rules/llm-evaluation.md" },
             { "src": "rules/backend/llm-observability.md", "dest": ".claude/rules/llm-observability.md" },
+            { "src": "rules/backend/multi-agent.md", "dest": ".claude/rules/multi-agent.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".claude/skills/architecture-preflight/" },
             { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/implementation-plan/" },
             { "src": "skills/backend/adr-author/", "dest": ".claude/skills/adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".claude/skills/genai-preflight/" },
-            { "src": "skills/backend/eval-suite-planning/", "dest": ".claude/skills/eval-suite-planning/" }
+            { "src": "skills/backend/eval-suite-planning/", "dest": ".claude/skills/eval-suite-planning/" },
+            { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/multi-agent-design/" }
           ],
           "shared": [
             "docs/backend/",
@@ -244,7 +248,8 @@
             "ci/github/",
             "ci/github/deepeval-gate.yml",
             "ci/github/promptfoo-gate.yml",
-            "ci/github/guardrails-check.yml"
+            "ci/github/guardrails-check.yml",
+            "ci/github/multi-agent-gate.yml"
           ]
         }
       },
@@ -261,7 +266,8 @@
             "ci/azure/",
             "ci/azure/deepeval-gate.yml",
             "ci/azure/promptfoo-gate.yml",
-            "ci/azure/guardrails-check.yml"
+            "ci/azure/guardrails-check.yml",
+            "ci/azure/multi-agent-gate.yml"
           ]
         }
       }

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -39,9 +39,11 @@
           { "src": "skills/backend/adr-author/", "dest": ".claude/skills/adr-author/" }
         ],
         "shared": [
-          "docs/backend/",
           "features/starter_backend/",
-          "features/schema_contract_example/",
+          "features/schema_contract_example/"
+        ],
+        "governed": [
+          "docs/backend/",
           "governance/backend/"
         ],
         "level_3": {
@@ -53,11 +55,13 @@
             { "src": "skills/backend/l3-implementation-plan/", "dest": ".claude/skills/implementation-plan/" }
           ],
           "shared": [
+            "features/starter_backend_l3/"
+          ],
+          "governed": [
             "docs/backend/architecture/DESIGN_PRINCIPLES.md",
             "docs/backend/architecture/TESTING.md",
             "docs/backend/architecture/GHERKIN_CONVENTIONS.md",
             "docs/backend/architecture/GHERKIN_TAGS.md",
-            "features/starter_backend_l3/",
             "governance/backend/templates/l3-plan.md"
           ]
         },
@@ -83,9 +87,11 @@
             { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/multi-agent-design/" }
           ],
           "shared": [
-            "docs/backend/",
             "features/starter_backend_l5/",
-            "features/schema_contract_example/",
+            "features/schema_contract_example/"
+          ],
+          "governed": [
+            "docs/backend/",
             "governance/backend/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
@@ -105,8 +111,10 @@
           { "src": "skills/backend/adr-author/", "dest": ".claude/skills/adr-author/" }
         ],
         "shared": [
+          "features/starter_cli/"
+        ],
+        "governed": [
           "docs/backend/",
-          "features/starter_cli/",
           "governance/backend/"
         ],
         "level_3": {
@@ -118,11 +126,13 @@
             { "src": "skills/backend/l3-implementation-plan/", "dest": ".claude/skills/implementation-plan/" }
           ],
           "shared": [
+            "features/starter_cli_l3/"
+          ],
+          "governed": [
             "docs/backend/architecture/DESIGN_PRINCIPLES.md",
             "docs/backend/architecture/TESTING.md",
             "docs/backend/architecture/GHERKIN_CONVENTIONS.md",
             "docs/backend/architecture/GHERKIN_TAGS.md",
-            "features/starter_cli_l3/",
             "governance/backend/templates/l3-plan.md"
           ]
         },
@@ -148,8 +158,10 @@
             { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/multi-agent-design/" }
           ],
           "shared": [
+            "features/starter_cli_l5/"
+          ],
+          "governed": [
             "docs/backend/",
-            "features/starter_cli_l5/",
             "governance/backend/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
@@ -174,14 +186,16 @@
           { "src": "skills/ui/adr-author/", "dest": ".claude/skills/ui-adr-author/" }
         ],
         "shared": [
+          "features/starter_ui/",
+          "features/ui_task_dashboard/"
+        ],
+        "governed": [
           "docs/ui/architecture/MVVM_CONTRACT.md",
           "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
           "docs/ui/architecture/ADR/",
           "docs/ui/architecture/react/",
           "docs/ui/evaluation/",
-          "governance/ui/",
-          "features/starter_ui/",
-          "features/ui_task_dashboard/"
+          "governance/ui/"
         ],
         "level_3": {
           "files": [
@@ -192,7 +206,9 @@
             { "src": "skills/ui/l3-implementation-plan/", "dest": ".claude/skills/ui-implementation-plan/" }
           ],
           "shared": [
-            "features/starter_ui_l3/",
+            "features/starter_ui_l3/"
+          ],
+          "governed": [
             "governance/ui/templates/l3-plan.md"
           ]
         }
@@ -210,14 +226,16 @@
           { "src": "skills/ui/adr-author/", "dest": ".claude/skills/ui-adr-author/" }
         ],
         "shared": [
+          "features/starter_ui/",
+          "features/ui_task_dashboard/"
+        ],
+        "governed": [
           "docs/ui/architecture/MVVM_CONTRACT.md",
           "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
           "docs/ui/architecture/ADR/",
           "docs/ui/architecture/angular/",
           "docs/ui/evaluation/",
-          "governance/ui/",
-          "features/starter_ui/",
-          "features/ui_task_dashboard/"
+          "governance/ui/"
         ],
         "level_3": {
           "files": [
@@ -228,7 +246,9 @@
             { "src": "skills/ui/l3-implementation-plan/", "dest": ".claude/skills/ui-implementation-plan/" }
           ],
           "shared": [
-            "features/starter_ui_l3/",
+            "features/starter_ui_l3/"
+          ],
+          "governed": [
             "governance/ui/templates/l3-plan.md"
           ]
         }
@@ -237,14 +257,17 @@
     "ci": {
       "github": {
         "files": [],
-        "shared": ["ci/github/"],
+        "shared": [],
+        "governed": ["ci/github/"],
         "level_3": {
           "files": [],
-          "shared": ["ci/github/l3-quality-gate.yml"]
+          "shared": [],
+          "governed": ["ci/github/l3-quality-gate.yml"]
         },
         "level_5": {
           "files": [],
-          "shared": [
+          "shared": [],
+          "governed": [
             "ci/github/",
             "ci/github/deepeval-gate.yml",
             "ci/github/promptfoo-gate.yml",
@@ -255,14 +278,17 @@
       },
       "azure": {
         "files": [],
-        "shared": ["ci/azure/"],
+        "shared": [],
+        "governed": ["ci/azure/"],
         "level_3": {
           "files": [],
-          "shared": ["ci/azure/l3-quality-gate.yml"]
+          "shared": [],
+          "governed": ["ci/azure/l3-quality-gate.yml"]
         },
         "level_5": {
           "files": [],
-          "shared": [
+          "shared": [],
+          "governed": [
             "ci/azure/",
             "ci/azure/deepeval-gate.yml",
             "ci/azure/promptfoo-gate.yml",

--- a/agents/claude-code/rules/backend/multi-agent.md
+++ b/agents/claude-code/rules/backend/multi-agent.md
@@ -1,0 +1,26 @@
+# Multi-Agent Rules
+
+These rules apply when editing files in agent, graph, and orchestrator layers.
+
+Contract: `docs/backend/architecture/AGENT_ARCHITECTURE.md` (Section 17)
+
+---
+
+## Rules
+
+- Graph definitions live in `services/graphs/` — not in adapters, API routes, or CLI commands
+- Graph state must be a `TypedDict` defined in `services/graphs/<feature>_state.py` — no untyped dicts between nodes
+- Node functions must have signature `(state: T) -> dict` — pure transformation, no side effects inside the node
+- All LLM calls from graph node functions route through `LLMPort` — no direct provider SDK usage
+- System prompts are loaded from the file path declared in `agent_topology.md` — never hardcoded as strings in graph code
+- All routing between agents goes through LangGraph graph edges — no direct agent-to-agent calls
+- `agent_topology.md` must exist and be complete before implementation begins
+
+## Prohibited
+
+- Importing `openai`, `anthropic`, `cohere`, or other provider SDKs in graph or orchestrator files
+- Hardcoding system prompt strings inside graph node functions
+- Calling one agent's logic directly from another agent's node function
+- Defining graph state as untyped `dict`
+- Placing graph definitions in `adapters/` or `api/` layers
+- Implicit or unconditional loops in the graph definition

--- a/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
@@ -74,3 +74,24 @@ Choose one:
 Write this report to `features/$ARGUMENTS/architecture_preflight.md`.
 
 If any spec inputs are missing, ask before proceeding.
+
+---
+
+## 15. Agent Topology (multi-agent features only)
+
+Check if `features/$ARGUMENTS/eval_criteria.yaml` declares `multi_agent: true`.
+
+If **not declared**, write: "Section 15: Not applicable — multi_agent not declared." and skip the rest of this section.
+
+If **declared**:
+
+- [ ] `features/$ARGUMENTS/agent_topology.md` exists — if missing, **HALT**: request `/multi-agent-design $ARGUMENTS` first
+- [ ] Orchestrator section is complete: role, system prompt path, model alias, routing strategy
+- [ ] Each specialist agent has: role, typed input state fields, typed output state fields, system prompt path, model alias
+- [ ] All system prompt files declared in `agent_topology.md` exist in the repository
+- [ ] Routing Logic covers all edge conditions — every node has a path to END
+- [ ] Failure Modes define per-node timeout, graph timeout, and node failure behavior
+- [ ] State schema reference is present (TypedDict path declared)
+- [ ] ADR required? (Yes if this is a new multi-agent feature or any topology change from prior preflight)
+
+**Section 15 Status:** Approved / Blocked (strike one — Blocked if any item above is unchecked)

--- a/agents/claude-code/skills/backend/genai-preflight/SKILL.md
+++ b/agents/claude-code/skills/backend/genai-preflight/SKILL.md
@@ -56,6 +56,21 @@ For each item, validate and document the finding:
 - Confirm LLM Fallback is populated (not TBD)
 - Confirm LLM Safety is populated (not TBD)
 
+### 6. Multi-Agent Validation (Section 16 — only when `multi_agent: true`)
+
+Check if `features/$ARGUMENTS/eval_criteria.yaml` declares `multi_agent: true`.
+
+If **not declared**: write "Section 16: Not applicable" and skip.
+
+If **declared**:
+- Confirm `features/$ARGUMENTS/agent_topology.md` exists and all four sections are complete
+- Confirm each agent's system prompt file exists at the declared path in the repository
+- Confirm graph state schema `TypedDict` is declared (path in agent_topology.md)
+- Confirm `eval_criteria.yaml` includes `multi_agent_evaluation` block with `topology_validated` and `system_prompt_governed` fields
+- Confirm LangGraph is listed as approved in `docs/backend/architecture/TECH_STACK.md`
+
+Block if any item fails.
+
 ## Output
 
 Update `features/$ARGUMENTS/architecture_preflight.md` sections 10-14 with findings.

--- a/agents/claude-code/skills/backend/multi-agent-design/SKILL.md
+++ b/agents/claude-code/skills/backend/multi-agent-design/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: "Design the agent topology for a multi-agent feature and produce agent_topology.md"
+argument-hint: "<feature_name>"
+---
+
+# Multi-Agent Design
+
+You are designing the agent topology for the feature: **$ARGUMENTS**
+
+Run this skill before `/architecture-preflight` whenever `eval_criteria.yaml` declares `multi_agent: true`.
+
+## Inputs to read
+
+- `features/$ARGUMENTS/nfrs.md` — understand scope and constraints
+- `features/$ARGUMENTS/acceptance.feature` — understand required outcomes
+- `features/$ARGUMENTS/eval_criteria.yaml` — confirm `multi_agent: true`
+- `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17 — architecture rules
+- `docs/backend/architecture/TECH_STACK.md` — approved model aliases
+
+## Step 1: Justify multi-agent
+
+Answer these questions before proceeding. If the answers do not justify multiple agents, recommend a single-agent design and stop.
+
+- What workflow step genuinely benefits from specialization?
+- Would a single agent with tool calls achieve the same outcome? If yes, prefer that.
+- Is the expected output quality meaningfully better with specialized agents?
+
+## Step 2: Define the Orchestrator
+
+- What decision does the orchestrator make?
+- What is its routing strategy (e.g., classify first, then route)?
+- System prompt file path: `src/agents/orchestrator/system_prompt.md`
+- Which LLM model alias does it use?
+
+## Step 3: Define each Specialist Agent
+
+For each specialist, specify:
+- Role: one sentence
+- Input state fields: name and type for each field received from the graph state
+- Output state fields: name and type for each field written back to graph state
+- System prompt file path: `src/agents/<name>/system_prompt.md`
+- LLM model alias
+- Outbound ports invoked (e.g., `LLMPort`, `VectorSearchPort`, `DatabasePort`)
+
+Stop if any specialist's role overlaps significantly with another — collapse it.
+
+## Step 4: Define Routing Logic
+
+Map every graph edge with its condition. Every node must have a path to END. No unconditional loops.
+
+Format:
+```
+START → <node>
+<node> → <node>  (condition: <what triggers this edge>)
+<node> → END     (condition: <what triggers termination>)
+```
+
+## Step 5: Define Failure Modes
+
+- Per-node timeout (seconds)
+- Graph-level timeout (seconds)
+- What happens when a node fails: return partial state with `error` field, route to END
+- Fallback model: declare in LiteLLM config, not in graph code
+
+## Step 6: Define State Schema
+
+Name the `TypedDict` and list all fields with types:
+- Input fields (set by the caller)
+- Intermediate fields (written and read between nodes)
+- Output fields (consumed by the caller)
+- `error: str | None` (required — populated on node failure)
+
+## Output
+
+Write `features/$ARGUMENTS/agent_topology.md` following the template in `features/starter_backend_l5/agent_topology.md`.
+
+After writing, confirm:
+- [ ] All system prompt paths are declared
+- [ ] All state fields are typed
+- [ ] Every node has a path to END
+- [ ] No direct agent-to-agent calls are implied
+- [ ] `agent_topology.md` has all four required sections: Orchestrator, Specialist Agents, Routing Logic, Failure Modes
+
+Then proceed to `/architecture-preflight $ARGUMENTS`.

--- a/agents/codex/agents-md/l5-backend-api.md
+++ b/agents/codex/agents-md/l5-backend-api.md
@@ -24,6 +24,7 @@ Before planning or generating code:
   - `docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md`
   - `docs/backend/architecture/GUARDRAILS_CONTRACT.md`
   - `docs/backend/architecture/EVALUATION_LLM_CONTRACT.md`
+- If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17
 - Apply architecture, testing, technology, evaluation, and GenAI contracts as binding constraints
 - Confirm required feature artifacts exist
 
@@ -53,6 +54,7 @@ Before proceeding to Architecture Preflight or planning:
 
 ## Feature Lifecycle (Mandatory Order — no steps may be skipped)
 
+0. **Multi-agent features only:** invoke `$multi-agent-design` before architecture preflight to produce `agent_topology.md`
 1. Architecture Preflight → invoke `$architecture-preflight`
 2. GenAI Preflight → invoke `$genai-preflight` (validates L5-specific decisions)
 3. ADR creation (if required by preflight)
@@ -91,6 +93,9 @@ An ADR is required when:
 - A new LLM provider is added to the routing table
 - The guardrail mode is changed for a production feature
 - LiteLLM is bypassed for any LLM call
+- A multi-agent graph node is added, removed, or rerouted
+- An agent's system prompt is materially changed
+- The shared graph state schema is changed
 
 ---
 

--- a/agents/codex/agents-md/l5-backend-cli.md
+++ b/agents/codex/agents-md/l5-backend-cli.md
@@ -24,6 +24,7 @@ Before planning or generating code:
   - `docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md`
   - `docs/backend/architecture/GUARDRAILS_CONTRACT.md`
   - `docs/backend/architecture/EVALUATION_LLM_CONTRACT.md`
+- If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17
 - Apply all contracts as binding constraints
 - Confirm required feature artifacts exist
 
@@ -47,6 +48,7 @@ Implementation must not begin unless all five artifacts exist.
 
 ## Feature Lifecycle (Mandatory Order — no steps may be skipped)
 
+0. **Multi-agent features only:** invoke `$multi-agent-design` before architecture preflight to produce `agent_topology.md`
 1. Architecture Preflight → invoke `$architecture-preflight`
 2. GenAI Preflight → invoke `$genai-preflight` (if feature uses LLM)
 3. ADR creation (if required by preflight)
@@ -112,3 +114,5 @@ Layer-specific rules load automatically via nested `AGENTS.md` files at each sco
 ## Authority
 
 Architecture decisions belong to the Architect. Exceptions require an ADR and explicit approval. Codex follows standards — it does not invent them.
+
+Multi-agent ADR triggers: adding/removing/rerouting graph nodes, material system prompt changes, graph state schema changes.

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -39,9 +39,11 @@
           { "src": "skills/backend/adr-author/", "dest": ".agents/skills/adr-author/" }
         ],
         "shared": [
-          "docs/backend/",
           "features/starter_backend/",
-          "features/schema_contract_example/",
+          "features/schema_contract_example/"
+        ],
+        "governed": [
+          "docs/backend/",
           "governance/backend/"
         ],
         "level_3": {
@@ -51,11 +53,13 @@
             { "src": "skills/backend/l3-implementation-plan/", "dest": ".agents/skills/implementation-plan/" }
           ],
           "shared": [
+            "features/starter_backend_l3/"
+          ],
+          "governed": [
             "docs/backend/architecture/DESIGN_PRINCIPLES.md",
             "docs/backend/architecture/TESTING.md",
             "docs/backend/architecture/GHERKIN_CONVENTIONS.md",
             "docs/backend/architecture/GHERKIN_TAGS.md",
-            "features/starter_backend_l3/",
             "governance/backend/templates/l3-plan.md"
           ]
         },
@@ -81,9 +85,11 @@
             { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/multi-agent-design/" }
           ],
           "shared": [
-            "docs/backend/",
             "features/starter_backend_l5/",
-            "features/schema_contract_example/",
+            "features/schema_contract_example/"
+          ],
+          "governed": [
+            "docs/backend/",
             "governance/backend/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
@@ -103,8 +109,10 @@
           { "src": "skills/backend/adr-author/", "dest": ".agents/skills/adr-author/" }
         ],
         "shared": [
+          "features/starter_cli/"
+        ],
+        "governed": [
           "docs/backend/",
-          "features/starter_cli/",
           "governance/backend/"
         ],
         "level_3": {
@@ -114,11 +122,13 @@
             { "src": "skills/backend/l3-implementation-plan/", "dest": ".agents/skills/implementation-plan/" }
           ],
           "shared": [
+            "features/starter_cli_l3/"
+          ],
+          "governed": [
             "docs/backend/architecture/DESIGN_PRINCIPLES.md",
             "docs/backend/architecture/TESTING.md",
             "docs/backend/architecture/GHERKIN_CONVENTIONS.md",
             "docs/backend/architecture/GHERKIN_TAGS.md",
-            "features/starter_cli_l3/",
             "governance/backend/templates/l3-plan.md"
           ]
         },
@@ -144,8 +154,10 @@
             { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/multi-agent-design/" }
           ],
           "shared": [
+            "features/starter_cli_l5/"
+          ],
+          "governed": [
             "docs/backend/",
-            "features/starter_cli_l5/",
             "governance/backend/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
@@ -170,14 +182,16 @@
           { "src": "skills/ui/adr-author/", "dest": ".agents/skills/ui-adr-author/" }
         ],
         "shared": [
+          "features/starter_ui/",
+          "features/ui_task_dashboard/"
+        ],
+        "governed": [
           "docs/ui/architecture/MVVM_CONTRACT.md",
           "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
           "docs/ui/architecture/ADR/",
           "docs/ui/architecture/react/",
           "docs/ui/evaluation/",
-          "governance/ui/",
-          "features/starter_ui/",
-          "features/ui_task_dashboard/"
+          "governance/ui/"
         ],
         "level_3": {
           "files": [
@@ -186,7 +200,9 @@
             { "src": "skills/ui/l3-implementation-plan/", "dest": ".agents/skills/ui-implementation-plan/" }
           ],
           "shared": [
-            "features/starter_ui_l3/",
+            "features/starter_ui_l3/"
+          ],
+          "governed": [
             "governance/ui/templates/l3-plan.md"
           ]
         }
@@ -204,14 +220,16 @@
           { "src": "skills/ui/adr-author/", "dest": ".agents/skills/ui-adr-author/" }
         ],
         "shared": [
+          "features/starter_ui/",
+          "features/ui_task_dashboard/"
+        ],
+        "governed": [
           "docs/ui/architecture/MVVM_CONTRACT.md",
           "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
           "docs/ui/architecture/ADR/",
           "docs/ui/architecture/angular/",
           "docs/ui/evaluation/",
-          "governance/ui/",
-          "features/starter_ui/",
-          "features/ui_task_dashboard/"
+          "governance/ui/"
         ],
         "level_3": {
           "files": [
@@ -220,7 +238,9 @@
             { "src": "skills/ui/l3-implementation-plan/", "dest": ".agents/skills/ui-implementation-plan/" }
           ],
           "shared": [
-            "features/starter_ui_l3/",
+            "features/starter_ui_l3/"
+          ],
+          "governed": [
             "governance/ui/templates/l3-plan.md"
           ]
         }
@@ -229,14 +249,17 @@
     "ci": {
       "github": {
         "files": [],
-        "shared": ["ci/github/"],
+        "shared": [],
+        "governed": ["ci/github/"],
         "level_3": {
           "files": [],
-          "shared": ["ci/github/l3-quality-gate.yml"]
+          "shared": [],
+          "governed": ["ci/github/l3-quality-gate.yml"]
         },
         "level_5": {
           "files": [],
-          "shared": [
+          "shared": [],
+          "governed": [
             "ci/github/",
             "ci/github/deepeval-gate.yml",
             "ci/github/promptfoo-gate.yml",
@@ -247,14 +270,17 @@
       },
       "azure": {
         "files": [],
-        "shared": ["ci/azure/"],
+        "shared": [],
+        "governed": ["ci/azure/"],
         "level_3": {
           "files": [],
-          "shared": ["ci/azure/l3-quality-gate.yml"]
+          "shared": [],
+          "governed": ["ci/azure/l3-quality-gate.yml"]
         },
         "level_5": {
           "files": [],
-          "shared": [
+          "shared": [],
+          "governed": [
             "ci/azure/",
             "ci/azure/deepeval-gate.yml",
             "ci/azure/promptfoo-gate.yml",

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -71,12 +71,14 @@
             { "src": "rules/backend/guardrails.md", "dest": "adapters/guardrails/AGENTS.md" },
             { "src": "rules/backend/llm-evaluation.md", "dest": "tests/eval/AGENTS.md" },
             { "src": "rules/backend/llm-observability.md", "dest": "adapters/observability/AGENTS.md" },
+            { "src": "rules/backend/multi-agent.md", "dest": "services/graphs/AGENTS.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".agents/skills/architecture-preflight/" },
             { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/implementation-plan/" },
             { "src": "skills/backend/adr-author/", "dest": ".agents/skills/adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".agents/skills/genai-preflight/" },
-            { "src": "skills/backend/eval-suite-planning/", "dest": ".agents/skills/eval-suite-planning/" }
+            { "src": "skills/backend/eval-suite-planning/", "dest": ".agents/skills/eval-suite-planning/" },
+            { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/multi-agent-design/" }
           ],
           "shared": [
             "docs/backend/",
@@ -132,12 +134,14 @@
             { "src": "rules/backend/guardrails.md", "dest": "adapters/guardrails/AGENTS.md" },
             { "src": "rules/backend/llm-evaluation.md", "dest": "tests/eval/AGENTS.md" },
             { "src": "rules/backend/llm-observability.md", "dest": "adapters/observability/AGENTS.md" },
+            { "src": "rules/backend/multi-agent.md", "dest": "services/graphs/AGENTS.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".agents/skills/architecture-preflight/" },
             { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/implementation-plan/" },
             { "src": "skills/backend/adr-author/", "dest": ".agents/skills/adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".agents/skills/genai-preflight/" },
-            { "src": "skills/backend/eval-suite-planning/", "dest": ".agents/skills/eval-suite-planning/" }
+            { "src": "skills/backend/eval-suite-planning/", "dest": ".agents/skills/eval-suite-planning/" },
+            { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/multi-agent-design/" }
           ],
           "shared": [
             "docs/backend/",
@@ -236,7 +240,8 @@
             "ci/github/",
             "ci/github/deepeval-gate.yml",
             "ci/github/promptfoo-gate.yml",
-            "ci/github/guardrails-check.yml"
+            "ci/github/guardrails-check.yml",
+            "ci/github/multi-agent-gate.yml"
           ]
         }
       },
@@ -253,7 +258,8 @@
             "ci/azure/",
             "ci/azure/deepeval-gate.yml",
             "ci/azure/promptfoo-gate.yml",
-            "ci/azure/guardrails-check.yml"
+            "ci/azure/guardrails-check.yml",
+            "ci/azure/multi-agent-gate.yml"
           ]
         }
       }

--- a/agents/codex/rules/backend/multi-agent.md
+++ b/agents/codex/rules/backend/multi-agent.md
@@ -1,0 +1,26 @@
+# Multi-Agent Rules
+
+These rules apply when editing files in agent, graph, and orchestrator layers.
+
+Contract: `docs/backend/architecture/AGENT_ARCHITECTURE.md` (Section 17)
+
+---
+
+## Rules
+
+- Graph definitions live in `services/graphs/` — not in adapters, API routes, or CLI commands
+- Graph state must be a `TypedDict` defined in `services/graphs/<feature>_state.py` — no untyped dicts between nodes
+- Node functions must have signature `(state: T) -> dict` — pure transformation, no side effects inside the node
+- All LLM calls from graph node functions route through `LLMPort` — no direct provider SDK usage
+- System prompts are loaded from the file path declared in `agent_topology.md` — never hardcoded as strings in graph code
+- All routing between agents goes through LangGraph graph edges — no direct agent-to-agent calls
+- `agent_topology.md` must exist and be complete before implementation begins
+
+## Prohibited
+
+- Importing `openai`, `anthropic`, `cohere`, or other provider SDKs in graph or orchestrator files
+- Hardcoding system prompt strings inside graph node functions
+- Calling one agent's logic directly from another agent's node function
+- Defining graph state as untyped `dict`
+- Placing graph definitions in `adapters/` or `api/` layers
+- Implicit or unconditional loops in the graph definition

--- a/agents/codex/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/codex/skills/backend/architecture-preflight/SKILL.md
@@ -74,3 +74,24 @@ Choose one:
 Write this report to `features/<feature_name>/architecture_preflight.md`.
 
 If any spec inputs are missing, ask before proceeding.
+
+---
+
+## 15. Agent Topology (multi-agent features only)
+
+Check if `features/$ARGUMENTS/eval_criteria.yaml` declares `multi_agent: true`.
+
+If **not declared**, write: "Section 15: Not applicable — multi_agent not declared." and skip the rest of this section.
+
+If **declared**:
+
+- [ ] `features/$ARGUMENTS/agent_topology.md` exists — if missing, **HALT**: request `$multi-agent-design $ARGUMENTS` first
+- [ ] Orchestrator section is complete: role, system prompt path, model alias, routing strategy
+- [ ] Each specialist agent has: role, typed input state fields, typed output state fields, system prompt path, model alias
+- [ ] All system prompt files declared in `agent_topology.md` exist in the repository
+- [ ] Routing Logic covers all edge conditions — every node has a path to END
+- [ ] Failure Modes define per-node timeout, graph timeout, and node failure behavior
+- [ ] State schema reference is present (TypedDict path declared)
+- [ ] ADR required? (Yes if this is a new multi-agent feature or any topology change from prior preflight)
+
+**Section 15 Status:** Approved / Blocked (strike one — Blocked if any item above is unchecked)

--- a/agents/codex/skills/backend/genai-preflight/SKILL.md
+++ b/agents/codex/skills/backend/genai-preflight/SKILL.md
@@ -56,6 +56,21 @@ For each item, validate and document the finding:
 - Confirm LLM Fallback is populated (not TBD)
 - Confirm LLM Safety is populated (not TBD)
 
+### 6. Multi-Agent Validation (Section 16 — only when `multi_agent: true`)
+
+Check if `features/$ARGUMENTS/eval_criteria.yaml` declares `multi_agent: true`.
+
+If **not declared**: write "Section 16: Not applicable" and skip.
+
+If **declared**:
+- Confirm `features/$ARGUMENTS/agent_topology.md` exists and all four sections are complete
+- Confirm each agent's system prompt file exists at the declared path in the repository
+- Confirm graph state schema `TypedDict` is declared (path in agent_topology.md)
+- Confirm `eval_criteria.yaml` includes `multi_agent_evaluation` block with `topology_validated` and `system_prompt_governed` fields
+- Confirm LangGraph is listed as approved in `docs/backend/architecture/TECH_STACK.md`
+
+Block if any item fails.
+
 ## Output
 
 Update `features/<feature_name>/architecture_preflight.md` sections 10-14 with findings.

--- a/agents/codex/skills/backend/multi-agent-design/SKILL.md
+++ b/agents/codex/skills/backend/multi-agent-design/SKILL.md
@@ -1,0 +1,84 @@
+---
+description: "Design the agent topology for a multi-agent feature and produce agent_topology.md"
+argument-hint: "<feature_name>"
+---
+
+# Multi-Agent Design
+
+You are designing the agent topology for the feature: **$ARGUMENTS**
+
+Run this skill before `$architecture-preflight` whenever `eval_criteria.yaml` declares `multi_agent: true`.
+
+## Inputs to read
+
+- `features/$ARGUMENTS/nfrs.md` — understand scope and constraints
+- `features/$ARGUMENTS/acceptance.feature` — understand required outcomes
+- `features/$ARGUMENTS/eval_criteria.yaml` — confirm `multi_agent: true`
+- `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17 — architecture rules
+- `docs/backend/architecture/TECH_STACK.md` — approved model aliases
+
+## Step 1: Justify multi-agent
+
+Answer these questions before proceeding. If the answers do not justify multiple agents, recommend a single-agent design and stop.
+
+- What workflow step genuinely benefits from specialization?
+- Would a single agent with tool calls achieve the same outcome? If yes, prefer that.
+- Is the expected output quality meaningfully better with specialized agents?
+
+## Step 2: Define the Orchestrator
+
+- What decision does the orchestrator make?
+- What is its routing strategy (e.g., classify first, then route)?
+- System prompt file path: `src/agents/orchestrator/system_prompt.md`
+- Which LLM model alias does it use?
+
+## Step 3: Define each Specialist Agent
+
+For each specialist, specify:
+- Role: one sentence
+- Input state fields: name and type for each field received from the graph state
+- Output state fields: name and type for each field written back to graph state
+- System prompt file path: `src/agents/<name>/system_prompt.md`
+- LLM model alias
+- Outbound ports invoked (e.g., `LLMPort`, `VectorSearchPort`, `DatabasePort`)
+
+Stop if any specialist's role overlaps significantly with another — collapse it.
+
+## Step 4: Define Routing Logic
+
+Map every graph edge with its condition. Every node must have a path to END. No unconditional loops.
+
+Format:
+```
+START → <node>
+<node> → <node>  (condition: <what triggers this edge>)
+<node> → END     (condition: <what triggers termination>)
+```
+
+## Step 5: Define Failure Modes
+
+- Per-node timeout (seconds)
+- Graph-level timeout (seconds)
+- What happens when a node fails: return partial state with `error` field, route to END
+- Fallback model: declare in LiteLLM config, not in graph code
+
+## Step 6: Define State Schema
+
+Name the `TypedDict` and list all fields with types:
+- Input fields (set by the caller)
+- Intermediate fields (written and read between nodes)
+- Output fields (consumed by the caller)
+- `error: str | None` (required — populated on node failure)
+
+## Output
+
+Write `features/$ARGUMENTS/agent_topology.md` following the template in `features/starter_backend_l5/agent_topology.md`.
+
+After writing, confirm:
+- [ ] All system prompt paths are declared
+- [ ] All state fields are typed
+- [ ] Every node has a path to END
+- [ ] No direct agent-to-agent calls are implied
+- [ ] `agent_topology.md` has all four required sections: Orchestrator, Specialist Agents, Routing Logic, Failure Modes
+
+Then proceed to `$architecture-preflight $ARGUMENTS`.

--- a/agents/copilot/copilot-instructions/l5-backend-api.md
+++ b/agents/copilot/copilot-instructions/l5-backend-api.md
@@ -24,6 +24,7 @@ Before planning or generating code:
 * Read all files under `docs/backend/architecture/`
 * Read `docs/backend/evaluation/eval_criteria.md`
 * Read L5 contracts: `LLM_GATEWAY_CONTRACT.md`, `OBSERVABILITY_LLM_CONTRACT.md`, `GUARDRAILS_CONTRACT.md`, `EVALUATION_LLM_CONTRACT.md`
+* If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17
 * Confirm required feature artifacts exist
 
 If required inputs are missing, stop and ask.
@@ -46,6 +47,7 @@ Implementation must not begin unless all artifacts exist and are complete.
 
 ## 3. Feature Lifecycle (Mandatory Order)
 
+0. **Multi-agent features only:** run `/multi-agent-design` before architecture preflight to produce `agent_topology.md`
 1. Architecture Preflight
 2. GenAI Preflight (L5-specific validation)
 3. ADR creation (if required)
@@ -132,3 +134,5 @@ Each increment must include:
 ## 9. Authority
 
 Architecture decisions belong to the Architect. Exceptions require an ADR and explicit approval. Copilot follows standards — it does not invent them.
+
+Multi-agent ADR triggers: adding/removing/rerouting graph nodes, material system prompt changes, graph state schema changes.

--- a/agents/copilot/copilot-instructions/l5-backend-cli.md
+++ b/agents/copilot/copilot-instructions/l5-backend-cli.md
@@ -19,6 +19,7 @@ Copilot operates aligned to:
 * Evaluation standards under `docs/backend/evaluation/`
 * Governance rules under `governance/`
 * L5 contracts: `LLM_GATEWAY_CONTRACT.md`, `OBSERVABILITY_LLM_CONTRACT.md`, `GUARDRAILS_CONTRACT.md`, `EVALUATION_LLM_CONTRACT.md`
+* If `eval_criteria.yaml` declares `multi_agent: true`, read `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17
 
 ---
 
@@ -32,6 +33,7 @@ CLI features may be deterministic (no LLM). If mode is `llm`, all L5 contracts a
 
 ## 3. Feature Lifecycle
 
+0. **Multi-agent features only:** run `/multi-agent-design` before architecture preflight to produce `agent_topology.md`
 1. Architecture Preflight
 2. GenAI Preflight (if mode: llm)
 3. ADR creation (if required)
@@ -86,3 +88,5 @@ These documents define your stack's implementation. The architecture principles 
 ## 7. Authority
 
 Copilot follows standards. It does not invent them.
+
+Multi-agent ADR triggers: adding/removing/rerouting graph nodes, material system prompt changes, graph state schema changes.

--- a/agents/copilot/instructions/backend/multi-agent.instructions.md
+++ b/agents/copilot/instructions/backend/multi-agent.instructions.md
@@ -1,0 +1,17 @@
+# Multi-Agent Instructions
+
+These instructions apply when editing files in `**/agents/**, **/graphs/**, **/orchestrators/**`.
+
+Contract: `docs/backend/architecture/AGENT_ARCHITECTURE.md` (Section 17)
+
+---
+
+- Graph definitions live in `services/graphs/` — not in adapters, API routes, or CLI commands
+- Graph state must be a `TypedDict` defined in `services/graphs/<feature>_state.py` — no untyped dicts between nodes
+- Node functions must have signature `(state: T) -> dict` — pure transformation, no side effects inside the node
+- All LLM calls from graph node functions route through `LLMPort` — no direct provider SDK usage
+- System prompts are loaded from the file path declared in `agent_topology.md` — never hardcoded as strings in graph code
+- All routing between agents goes through LangGraph graph edges — no direct agent-to-agent calls
+- `agent_topology.md` must exist and be complete before implementation begins
+
+**Prohibited:** Importing provider SDKs (`openai`, `anthropic`, `cohere`) in graph or orchestrator files. Hardcoding system prompt strings inside node functions. Direct agent-to-agent calls bypassing the graph. Untyped `dict` as graph state. Graph definitions in `adapters/` or `api/` layers. Implicit or unconditional loops.

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -32,9 +32,11 @@
           { "src": "skills/backend/", "dest": ".github/skills/" }
         ],
         "shared": [
-          "docs/backend/",
           "features/starter_backend/",
-          "features/schema_contract_example/",
+          "features/schema_contract_example/"
+        ],
+        "governed": [
+          "docs/backend/",
           "governance/backend/"
         ],
         "level_3": {
@@ -44,11 +46,13 @@
             { "src": "skills/backend/l3-implementation-plan/", "dest": ".github/skills/implementation-plan/" }
           ],
           "shared": [
+            "features/starter_backend_l3/"
+          ],
+          "governed": [
             "docs/backend/architecture/DESIGN_PRINCIPLES.md",
             "docs/backend/architecture/TESTING.md",
             "docs/backend/architecture/GHERKIN_CONVENTIONS.md",
             "docs/backend/architecture/GHERKIN_TAGS.md",
-            "features/starter_backend_l3/",
             "governance/backend/templates/l3-plan.md"
           ]
         },
@@ -67,9 +71,11 @@
             { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/multi-agent-design/" }
           ],
           "shared": [
-            "docs/backend/",
             "features/starter_backend_l5/",
-            "features/schema_contract_example/",
+            "features/schema_contract_example/"
+          ],
+          "governed": [
+            "docs/backend/",
             "governance/backend/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
@@ -82,8 +88,10 @@
           { "src": "skills/backend/", "dest": ".github/skills/" }
         ],
         "shared": [
+          "features/starter_cli/"
+        ],
+        "governed": [
           "docs/backend/",
-          "features/starter_cli/",
           "governance/backend/"
         ],
         "level_3": {
@@ -93,11 +101,13 @@
             { "src": "skills/backend/l3-implementation-plan/", "dest": ".github/skills/implementation-plan/" }
           ],
           "shared": [
+            "features/starter_cli_l3/"
+          ],
+          "governed": [
             "docs/backend/architecture/DESIGN_PRINCIPLES.md",
             "docs/backend/architecture/TESTING.md",
             "docs/backend/architecture/GHERKIN_CONVENTIONS.md",
             "docs/backend/architecture/GHERKIN_TAGS.md",
-            "features/starter_cli_l3/",
             "governance/backend/templates/l3-plan.md"
           ]
         },
@@ -116,8 +126,10 @@
             { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/multi-agent-design/" }
           ],
           "shared": [
+            "features/starter_cli_l5/"
+          ],
+          "governed": [
             "docs/backend/",
-            "features/starter_cli_l5/",
             "governance/backend/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
@@ -139,14 +151,16 @@
           { "src": "skills/ui/adr-author/", "dest": ".github/skills/ui-adr-author/" }
         ],
         "shared": [
+          "features/starter_ui/",
+          "features/ui_task_dashboard/"
+        ],
+        "governed": [
           "docs/ui/architecture/MVVM_CONTRACT.md",
           "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
           "docs/ui/architecture/ADR/",
           "docs/ui/architecture/react/",
           "docs/ui/evaluation/",
-          "governance/ui/",
-          "features/starter_ui/",
-          "features/ui_task_dashboard/"
+          "governance/ui/"
         ],
         "level_3": {
           "files": [
@@ -155,7 +169,9 @@
             { "src": "skills/ui/l3-implementation-plan/", "dest": ".github/skills/ui-implementation-plan/" }
           ],
           "shared": [
-            "features/starter_ui_l3/",
+            "features/starter_ui_l3/"
+          ],
+          "governed": [
             "governance/ui/templates/l3-plan.md"
           ]
         }
@@ -170,14 +186,16 @@
           { "src": "skills/ui/adr-author/", "dest": ".github/skills/ui-adr-author/" }
         ],
         "shared": [
+          "features/starter_ui/",
+          "features/ui_task_dashboard/"
+        ],
+        "governed": [
           "docs/ui/architecture/MVVM_CONTRACT.md",
           "docs/ui/architecture/ACCESSIBILITY_STANDARDS.md",
           "docs/ui/architecture/ADR/",
           "docs/ui/architecture/angular/",
           "docs/ui/evaluation/",
-          "governance/ui/",
-          "features/starter_ui/",
-          "features/ui_task_dashboard/"
+          "governance/ui/"
         ],
         "level_3": {
           "files": [
@@ -186,7 +204,9 @@
             { "src": "skills/ui/l3-implementation-plan/", "dest": ".github/skills/ui-implementation-plan/" }
           ],
           "shared": [
-            "features/starter_ui_l3/",
+            "features/starter_ui_l3/"
+          ],
+          "governed": [
             "governance/ui/templates/l3-plan.md"
           ]
         }
@@ -195,14 +215,17 @@
     "ci": {
       "github": {
         "files": [],
-        "shared": ["ci/github/"],
+        "shared": [],
+        "governed": ["ci/github/"],
         "level_3": {
           "files": [],
-          "shared": ["ci/github/l3-quality-gate.yml"]
+          "shared": [],
+          "governed": ["ci/github/l3-quality-gate.yml"]
         },
         "level_5": {
           "files": [],
-          "shared": [
+          "shared": [],
+          "governed": [
             "ci/github/",
             "ci/github/deepeval-gate.yml",
             "ci/github/promptfoo-gate.yml",
@@ -213,14 +236,17 @@
       },
       "azure": {
         "files": [],
-        "shared": ["ci/azure/"],
+        "shared": [],
+        "governed": ["ci/azure/"],
         "level_3": {
           "files": [],
-          "shared": ["ci/azure/l3-quality-gate.yml"]
+          "shared": [],
+          "governed": ["ci/azure/l3-quality-gate.yml"]
         },
         "level_5": {
           "files": [],
-          "shared": [
+          "shared": [],
+          "governed": [
             "ci/azure/",
             "ci/azure/deepeval-gate.yml",
             "ci/azure/promptfoo-gate.yml",

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -60,9 +60,11 @@
             { "src": "instructions/backend/guardrails.instructions.md", "dest": ".github/instructions/guardrails.instructions.md" },
             { "src": "instructions/backend/llm-evaluation.instructions.md", "dest": ".github/instructions/llm-evaluation.instructions.md" },
             { "src": "instructions/backend/llm-observability.instructions.md", "dest": ".github/instructions/llm-observability.instructions.md" },
+            { "src": "instructions/backend/multi-agent.instructions.md", "dest": ".github/instructions/multi-agent.instructions.md" },
             { "src": "skills/backend/", "dest": ".github/skills/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".github/skills/genai-preflight/" },
-            { "src": "skills/backend/eval-suite-planning/", "dest": ".github/skills/eval-suite-planning/" }
+            { "src": "skills/backend/eval-suite-planning/", "dest": ".github/skills/eval-suite-planning/" },
+            { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/multi-agent-design/" }
           ],
           "shared": [
             "docs/backend/",
@@ -107,9 +109,11 @@
             { "src": "instructions/backend/guardrails.instructions.md", "dest": ".github/instructions/guardrails.instructions.md" },
             { "src": "instructions/backend/llm-evaluation.instructions.md", "dest": ".github/instructions/llm-evaluation.instructions.md" },
             { "src": "instructions/backend/llm-observability.instructions.md", "dest": ".github/instructions/llm-observability.instructions.md" },
+            { "src": "instructions/backend/multi-agent.instructions.md", "dest": ".github/instructions/multi-agent.instructions.md" },
             { "src": "skills/backend/", "dest": ".github/skills/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".github/skills/genai-preflight/" },
-            { "src": "skills/backend/eval-suite-planning/", "dest": ".github/skills/eval-suite-planning/" }
+            { "src": "skills/backend/eval-suite-planning/", "dest": ".github/skills/eval-suite-planning/" },
+            { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/multi-agent-design/" }
           ],
           "shared": [
             "docs/backend/",
@@ -202,7 +206,8 @@
             "ci/github/",
             "ci/github/deepeval-gate.yml",
             "ci/github/promptfoo-gate.yml",
-            "ci/github/guardrails-check.yml"
+            "ci/github/guardrails-check.yml",
+            "ci/github/multi-agent-gate.yml"
           ]
         }
       },
@@ -219,7 +224,8 @@
             "ci/azure/",
             "ci/azure/deepeval-gate.yml",
             "ci/azure/promptfoo-gate.yml",
-            "ci/azure/guardrails-check.yml"
+            "ci/azure/guardrails-check.yml",
+            "ci/azure/multi-agent-gate.yml"
           ]
         }
       }

--- a/agents/copilot/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/copilot/skills/backend/architecture-preflight/SKILL.md
@@ -76,3 +76,24 @@ Choose one:
 Write this report to `features/$ARGUMENTS/architecture_preflight.md`.
 
 If any spec inputs are missing, ask the user before proceeding.
+
+---
+
+## 15. Agent Topology (multi-agent features only)
+
+Check if `features/$ARGUMENTS/eval_criteria.yaml` declares `multi_agent: true`.
+
+If **not declared**, write: "Section 15: Not applicable — multi_agent not declared." and skip the rest of this section.
+
+If **declared**:
+
+- [ ] `features/$ARGUMENTS/agent_topology.md` exists — if missing, **HALT**: request `/multi-agent-design $ARGUMENTS` first
+- [ ] Orchestrator section is complete: role, system prompt path, model alias, routing strategy
+- [ ] Each specialist agent has: role, typed input state fields, typed output state fields, system prompt path, model alias
+- [ ] All system prompt files declared in `agent_topology.md` exist in the repository
+- [ ] Routing Logic covers all edge conditions — every node has a path to END
+- [ ] Failure Modes define per-node timeout, graph timeout, and node failure behavior
+- [ ] State schema reference is present (TypedDict path declared)
+- [ ] ADR required? (Yes if this is a new multi-agent feature or any topology change from prior preflight)
+
+**Section 15 Status:** Approved / Blocked (strike one — Blocked if any item above is unchecked)

--- a/agents/copilot/skills/backend/genai-preflight/SKILL.md
+++ b/agents/copilot/skills/backend/genai-preflight/SKILL.md
@@ -28,6 +28,8 @@ Run after architecture preflight to validate GenAI-specific decisions for: **$AR
 4. **Evaluation:** DeepEval metrics in eval_criteria.yaml, Promptfoo stated, RAGAS if retrieval
 5. **LLM NFRs:** Latency, Cost, Fallback, Safety all populated in nfrs.md
 
+6. **Multi-Agent** (only when `multi_agent: true`): `agent_topology.md` complete, all system prompt files exist, state schema declared, `multi_agent_evaluation` block in `eval_criteria.yaml`, LangGraph approved in TECH_STACK.md
+
 ## Output
 
 Update `features/$ARGUMENTS/architecture_preflight.md` sections 10-14 and set final status.

--- a/agents/copilot/skills/backend/multi-agent-design/SKILL.md
+++ b/agents/copilot/skills/backend/multi-agent-design/SKILL.md
@@ -1,0 +1,85 @@
+---
+description: "Design the agent topology for a multi-agent feature and produce agent_topology.md"
+argument-hint: "<feature_name>"
+user-invocable: true
+---
+
+# Multi-Agent Design
+
+You are designing the agent topology for the feature: **$ARGUMENTS**
+
+Run this skill before `/architecture-preflight` whenever `eval_criteria.yaml` declares `multi_agent: true`.
+
+## Inputs to read
+
+- `features/$ARGUMENTS/nfrs.md` — understand scope and constraints
+- `features/$ARGUMENTS/acceptance.feature` — understand required outcomes
+- `features/$ARGUMENTS/eval_criteria.yaml` — confirm `multi_agent: true`
+- `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17 — architecture rules
+- `docs/backend/architecture/TECH_STACK.md` — approved model aliases
+
+## Step 1: Justify multi-agent
+
+Answer these questions before proceeding. If the answers do not justify multiple agents, recommend a single-agent design and stop.
+
+- What workflow step genuinely benefits from specialization?
+- Would a single agent with tool calls achieve the same outcome? If yes, prefer that.
+- Is the expected output quality meaningfully better with specialized agents?
+
+## Step 2: Define the Orchestrator
+
+- What decision does the orchestrator make?
+- What is its routing strategy (e.g., classify first, then route)?
+- System prompt file path: `src/agents/orchestrator/system_prompt.md`
+- Which LLM model alias does it use?
+
+## Step 3: Define each Specialist Agent
+
+For each specialist, specify:
+- Role: one sentence
+- Input state fields: name and type for each field received from the graph state
+- Output state fields: name and type for each field written back to graph state
+- System prompt file path: `src/agents/<name>/system_prompt.md`
+- LLM model alias
+- Outbound ports invoked (e.g., `LLMPort`, `VectorSearchPort`, `DatabasePort`)
+
+Stop if any specialist's role overlaps significantly with another — collapse it.
+
+## Step 4: Define Routing Logic
+
+Map every graph edge with its condition. Every node must have a path to END. No unconditional loops.
+
+Format:
+```
+START → <node>
+<node> → <node>  (condition: <what triggers this edge>)
+<node> → END     (condition: <what triggers termination>)
+```
+
+## Step 5: Define Failure Modes
+
+- Per-node timeout (seconds)
+- Graph-level timeout (seconds)
+- What happens when a node fails: return partial state with `error` field, route to END
+- Fallback model: declare in LiteLLM config, not in graph code
+
+## Step 6: Define State Schema
+
+Name the `TypedDict` and list all fields with types:
+- Input fields (set by the caller)
+- Intermediate fields (written and read between nodes)
+- Output fields (consumed by the caller)
+- `error: str | None` (required — populated on node failure)
+
+## Output
+
+Write `features/$ARGUMENTS/agent_topology.md` following the template in `features/starter_backend_l5/agent_topology.md`.
+
+After writing, confirm:
+- [ ] All system prompt paths are declared
+- [ ] All state fields are typed
+- [ ] Every node has a path to END
+- [ ] No direct agent-to-agent calls are implied
+- [ ] `agent_topology.md` has all four required sections: Orchestrator, Specialist Agents, Routing Logic, Failure Modes
+
+Then proceed to `/architecture-preflight $ARGUMENTS`.

--- a/ci/azure/multi-agent-gate.yml
+++ b/ci/azure/multi-agent-gate.yml
@@ -30,7 +30,7 @@ stages:
 
           - script: |
               errors=0
-              FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+              FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^[[:space:]]*multi_agent:[[:space:]]*true" {} \; 2>/dev/null || true)
               if [ -z "$FEATURES" ]; then
                 echo "No multi-agent features detected. Skipping."
                 exit 0
@@ -63,7 +63,7 @@ stages:
 
           - script: |
               errors=0
-              FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+              FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^[[:space:]]*multi_agent:[[:space:]]*true" {} \; 2>/dev/null || true)
               if [ -z "$FEATURES" ]; then
                 echo "No multi-agent features detected. Skipping."
                 exit 0
@@ -72,17 +72,15 @@ stages:
                 topology="$feature_dir/agent_topology.md"
                 [ ! -f "$topology" ] && continue
                 echo "Checking system prompts declared in $topology..."
-                while IFS= read -r line; do
-                  path=$(echo "$line" | sed "s/.*\`\(.*\)\`.*/\1/")
-                  if [ "$path" != "$line" ] && [ -n "$path" ]; then
-                    if [ ! -f "$path" ]; then
-                      echo "  FAIL: $path not found"
-                      errors=$((errors + 1))
-                    else
-                      echo "  PASS: $path exists"
-                    fi
+                while IFS= read -r path; do
+                  [ -z "$path" ] && continue
+                  if [ ! -f "$path" ]; then
+                    echo "  FAIL: $path not found"
+                    errors=$((errors + 1))
+                  else
+                    echo "  PASS: $path exists"
                   fi
-                done < <(grep "System Prompt:" "$topology" || true)
+                done < <(TOPOLOGY="$topology" python3 -c 'import re,os;t=open(os.environ["TOPOLOGY"]).read();p=set(re.findall(r"^\s*system_prompt:\s*(\S+)",t,re.M))|set(re.findall(r"\*\*System Prompt:\*\*\s*`([^`]+)`",t));print("\n".join(sorted(x for x in p if x)))')
               done
               [ "$errors" -gt 0 ] && exit 1
               echo "All system prompt files present."

--- a/ci/azure/multi-agent-gate.yml
+++ b/ci/azure/multi-agent-gate.yml
@@ -1,0 +1,89 @@
+# Azure DevOps pipeline — Level 5 Multi-Agent Governance Gate.
+#
+# JOBS:
+#   TopologyCheck     — verifies agent_topology.md exists with all required sections
+#   SystemPromptCheck — verifies every system_prompt: path declared in agent_topology.md exists
+#
+# NO VARIABLES REQUIRED — structural validation only.
+#
+# SEE ALSO:
+#   docs/backend/architecture/AGENT_ARCHITECTURE.md  (Section 17)
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: MultiAgentGate
+    displayName: Multi-Agent Governance Gate (L5)
+    jobs:
+      - job: TopologyCheck
+        displayName: Agent topology validation
+        steps:
+          - checkout: self
+
+          - script: |
+              errors=0
+              FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+              if [ -z "$FEATURES" ]; then
+                echo "No multi-agent features detected. Skipping."
+                exit 0
+              fi
+              for feature_dir in $(echo "$FEATURES" | xargs -I{} dirname {}); do
+                topology="$feature_dir/agent_topology.md"
+                echo "Checking $topology..."
+                if [ ! -f "$topology" ]; then
+                  echo "  FAIL: agent_topology.md missing in $feature_dir"
+                  errors=$((errors + 1))
+                  continue
+                fi
+                for section in "## Orchestrator" "## Specialist Agents" "## Routing Logic" "## Failure Modes"; do
+                  if ! grep -q "^$section" "$topology"; then
+                    echo "  FAIL: Missing section '$section' in $topology"
+                    errors=$((errors + 1))
+                  fi
+                done
+                echo "  PASS: $topology valid"
+              done
+              [ "$errors" -gt 0 ] && exit 1
+              echo "All agent topology files valid."
+            displayName: Validate agent_topology.md presence and sections
+
+      - job: SystemPromptCheck
+        displayName: System prompt file validation
+        dependsOn: TopologyCheck
+        steps:
+          - checkout: self
+
+          - script: |
+              errors=0
+              FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+              if [ -z "$FEATURES" ]; then
+                echo "No multi-agent features detected. Skipping."
+                exit 0
+              fi
+              for feature_dir in $(echo "$FEATURES" | xargs -I{} dirname {}); do
+                topology="$feature_dir/agent_topology.md"
+                [ ! -f "$topology" ] && continue
+                echo "Checking system prompts declared in $topology..."
+                while IFS= read -r line; do
+                  path=$(echo "$line" | sed "s/.*\`\(.*\)\`.*/\1/")
+                  if [ "$path" != "$line" ] && [ -n "$path" ]; then
+                    if [ ! -f "$path" ]; then
+                      echo "  FAIL: $path not found"
+                      errors=$((errors + 1))
+                    else
+                      echo "  PASS: $path exists"
+                    fi
+                  fi
+                done < <(grep "System Prompt:" "$topology" || true)
+              done
+              [ "$errors" -gt 0 ] && exit 1
+              echo "All system prompt files present."
+            displayName: Validate system prompt files exist

--- a/ci/github/multi-agent-gate.yml
+++ b/ci/github/multi-agent-gate.yml
@@ -1,0 +1,111 @@
+# multi-agent-gate.yml
+#
+# PURPOSE: Level 5 — Validates multi-agent topology governance when multi_agent: true.
+# Copy this file to .github/workflows/multi-agent-gate.yml.
+#
+# JOBS:
+#   topology-check     — verifies agent_topology.md exists with all required sections
+#   system-prompt-check — verifies every system_prompt: path declared in agent_topology.md exists
+#
+# NO SECRETS REQUIRED — structural validation only.
+#
+# SEE ALSO:
+#   docs/backend/architecture/AGENT_ARCHITECTURE.md  (Section 17)
+#   features/<feature>/agent_topology.md
+
+name: Multi-Agent Governance Gate (L5)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  topology-check:
+    name: Agent topology validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect multi-agent features
+        id: detect
+        run: |
+          FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+          if [ -z "$FEATURES" ]; then
+            echo "No multi-agent features detected. Skipping."
+            echo "has_multi_agent=false" >> $GITHUB_OUTPUT
+          else
+            echo "Multi-agent features found:"
+            echo "$FEATURES"
+            echo "has_multi_agent=true" >> $GITHUB_OUTPUT
+            echo "feature_dirs=$(echo "$FEATURES" | xargs -I{} dirname {} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate agent_topology.md presence and sections
+        if: steps.detect.outputs.has_multi_agent == 'true'
+        run: |
+          errors=0
+          for feature_dir in ${{ steps.detect.outputs.feature_dirs }}; do
+            topology="$feature_dir/agent_topology.md"
+            echo "Checking $topology..."
+            if [ ! -f "$topology" ]; then
+              echo "  FAIL: agent_topology.md missing in $feature_dir"
+              errors=$((errors + 1))
+              continue
+            fi
+            for section in "## Orchestrator" "## Specialist Agents" "## Routing Logic" "## Failure Modes"; do
+              if ! grep -q "^$section" "$topology"; then
+                echo "  FAIL: Missing section '$section' in $topology"
+                errors=$((errors + 1))
+              fi
+            done
+            echo "  PASS: $topology has all required sections"
+          done
+          if [ "$errors" -gt 0 ]; then
+            echo "$errors topology error(s) found"
+            exit 1
+          fi
+
+  system-prompt-check:
+    name: System prompt file validation
+    runs-on: ubuntu-latest
+    needs: topology-check
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect multi-agent features
+        id: detect
+        run: |
+          FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+          if [ -z "$FEATURES" ]; then
+            echo "has_multi_agent=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_multi_agent=true" >> $GITHUB_OUTPUT
+            echo "feature_dirs=$(echo "$FEATURES" | xargs -I{} dirname {} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate system prompt files exist
+        if: steps.detect.outputs.has_multi_agent == 'true'
+        run: |
+          errors=0
+          for feature_dir in ${{ steps.detect.outputs.feature_dirs }}; do
+            topology="$feature_dir/agent_topology.md"
+            [ ! -f "$topology" ] && continue
+            echo "Checking system prompts declared in $topology..."
+            while IFS= read -r line; do
+              path=$(echo "$line" | sed "s/.*\`\(.*\)\`.*/\1/")
+              if [ "$path" != "$line" ] && [ -n "$path" ]; then
+                if [ ! -f "$path" ]; then
+                  echo "  FAIL: system prompt not found: $path"
+                  errors=$((errors + 1))
+                else
+                  echo "  PASS: $path exists"
+                fi
+              fi
+            done < <(grep "System Prompt:" "$topology" || true)
+          done
+          if [ "$errors" -gt 0 ]; then
+            echo "$errors system prompt file(s) missing"
+            exit 1
+          fi

--- a/ci/github/multi-agent-gate.yml
+++ b/ci/github/multi-agent-gate.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Detect multi-agent features
         id: detect
         run: |
-          FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+          FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^[[:space:]]*multi_agent:[[:space:]]*true" {} \; 2>/dev/null || true)
           if [ -z "$FEATURES" ]; then
             echo "No multi-agent features detected. Skipping."
             echo "has_multi_agent=false" >> $GITHUB_OUTPUT
@@ -39,7 +39,8 @@ jobs:
             echo "Multi-agent features found:"
             echo "$FEATURES"
             echo "has_multi_agent=true" >> $GITHUB_OUTPUT
-            echo "feature_dirs=$(echo "$FEATURES" | xargs -I{} dirname {} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+            feature_dirs="$(printf '%s\n' "$FEATURES" | xargs -I{} dirname {} | tr '\n' ' ')"
+            echo "feature_dirs=$feature_dirs" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate agent_topology.md presence and sections
@@ -77,12 +78,13 @@ jobs:
       - name: Detect multi-agent features
         id: detect
         run: |
-          FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^multi_agent: true" {} \; 2>/dev/null || true)
+          FEATURES=$(find features/ -name "eval_criteria.yaml" -exec grep -l "^[[:space:]]*multi_agent:[[:space:]]*true" {} \; 2>/dev/null || true)
           if [ -z "$FEATURES" ]; then
             echo "has_multi_agent=false" >> $GITHUB_OUTPUT
           else
             echo "has_multi_agent=true" >> $GITHUB_OUTPUT
-            echo "feature_dirs=$(echo "$FEATURES" | xargs -I{} dirname {} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+            feature_dirs="$(printf '%s\n' "$FEATURES" | xargs -I{} dirname {} | tr '\n' ' ')"
+            echo "feature_dirs=$feature_dirs" >> $GITHUB_OUTPUT
           fi
 
       - name: Validate system prompt files exist
@@ -93,17 +95,15 @@ jobs:
             topology="$feature_dir/agent_topology.md"
             [ ! -f "$topology" ] && continue
             echo "Checking system prompts declared in $topology..."
-            while IFS= read -r line; do
-              path=$(echo "$line" | sed "s/.*\`\(.*\)\`.*/\1/")
-              if [ "$path" != "$line" ] && [ -n "$path" ]; then
-                if [ ! -f "$path" ]; then
-                  echo "  FAIL: system prompt not found: $path"
-                  errors=$((errors + 1))
-                else
-                  echo "  PASS: $path exists"
-                fi
+            while IFS= read -r path; do
+              [ -z "$path" ] && continue
+              if [ ! -f "$path" ]; then
+                echo "  FAIL: system prompt not found: $path"
+                errors=$((errors + 1))
+              else
+                echo "  PASS: $path exists"
               fi
-            done < <(grep "System Prompt:" "$topology" || true)
+            done < <(TOPOLOGY="$topology" python3 -c 'import re,os;t=open(os.environ["TOPOLOGY"]).read();p=set(re.findall(r"^\s*system_prompt:\s*(\S+)",t,re.M))|set(re.findall(r"\*\*System Prompt:\*\*\s*`([^`]+)`",t));print("\n".join(sorted(x for x in p if x)))')
           done
           if [ "$errors" -gt 0 ]; then
             echo "$errors system prompt file(s) missing"

--- a/cli/govkit.py
+++ b/cli/govkit.py
@@ -31,6 +31,11 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+try:
+    from importlib.metadata import version as _pkg_version
+    _GOVKIT_VERSION = _pkg_version("govkit")
+except Exception:
+    _GOVKIT_VERSION = "dev"
 
 _HERE = Path(__file__).parent
 # When installed via pip, agents/ is bundled inside the cli package.
@@ -90,18 +95,29 @@ def read_govkit_level(target: Path) -> str | None:
         return None
 
 
+def read_govkit_marker(target: Path) -> dict | None:
+    """Read the full .govkit marker dict, or None if missing or unreadable."""
+    marker = target / ".govkit"
+    if not marker.exists():
+        return None
+    try:
+        return json.loads(marker.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 def write_govkit_marker(target: Path, agent: str, level: str, options: dict) -> None:
     """Write the .govkit marker file to track the applied configuration."""
     marker = target / ".govkit"
     data = {
-        "version": "0.4.0",
+        "version": _GOVKIT_VERSION,
         "level": level,
         "agent": agent,
         "options": {k: v for k, v in options.items() if k != "level"},
         "applied_at": datetime.now(timezone.utc).isoformat(),
     }
     marker.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
-    print(f"\n  .govkit marker written (level {level})")
+    print(f"\n  .govkit marker written (level {level}, govkit {_GOVKIT_VERSION})")
 
 
 # ---------------------------------------------------------------------------
@@ -145,8 +161,9 @@ def _collect_entries(
     selected: dict,
     all_files: list, seen_files: set,
     all_shared: list, seen_shared: set,
+    all_governed: list, seen_governed: set,
 ) -> None:
-    """Append deduplicated files and shared paths from a selected variant config."""
+    """Append deduplicated files, shared, and governed paths from a selected variant config."""
     for f in selected.get("files", []):
         key = (f["src"], f["dest"])
         if key not in seen_files:
@@ -156,14 +173,26 @@ def _collect_entries(
         if s not in seen_shared:
             all_shared.append(s)
             seen_shared.add(s)
+    for g in selected.get("governed", []):
+        if g not in seen_governed:
+            all_governed.append(g)
+            seen_governed.add(g)
 
 
-def resolve_variant_files(manifest: dict, options: dict) -> tuple[list, list]:
-    """Collect files and shared entries from all selected variant dimensions, deduplicated."""
+def resolve_variant_files(manifest: dict, options: dict) -> tuple[list, list, list]:
+    """Collect files, shared, and governed entries from all selected variant dimensions, deduplicated.
+
+    Returns (files, shared, governed):
+      files   — agent config files; always overwritten on apply and upgrade
+      shared  — project-owned paths; written once (skip_existing), never overwritten
+      governed — govkit-owned contracts; written once on apply, refreshed on upgrade
+    """
     all_files = list(manifest.get("base_files", []))
     all_shared: list[str] = []
+    all_governed: list[str] = []
     seen_files: set[tuple[str, str]] = {(f["src"], f["dest"]) for f in all_files}
     seen_shared: set[str] = set()
+    seen_governed: set[str] = set()
     variants = manifest.get("variants", {})
     level = options.get("level", "4")
     level_key = f"level_{level}" if level != "4" else None
@@ -171,8 +200,8 @@ def resolve_variant_files(manifest: dict, options: dict) -> tuple[list, list]:
         if dimension == "level":
             continue
         selected = _select_variant(variants, dimension, value, level_key)
-        _collect_entries(selected, all_files, seen_files, all_shared, seen_shared)
-    return all_files, all_shared
+        _collect_entries(selected, all_files, seen_files, all_shared, seen_shared, all_governed, seen_governed)
+    return all_files, all_shared, all_governed
 
 
 # ---------------------------------------------------------------------------
@@ -194,13 +223,21 @@ def cmd_apply(args: argparse.Namespace) -> None:
         options = resolve_options(manifest, args)
         level = options.get("level", "4")
         print(f"\n  Configuration: {options}\n")
-        files, shared = resolve_variant_files(manifest, options)
+        files, shared, governed = resolve_variant_files(manifest, options)
 
         print("Agent files:")
         for entry in files:
             src = agent_dir / entry["src"]
             dest = target / entry["dest"]
             copy_entry(src, dest)
+
+        print("\nGoverned contracts (skip if present):")
+        for governed_path in governed:
+            if governed_path.startswith("features/"):
+                continue
+            src = REPO_ROOT / governed_path
+            dest = target / governed_path
+            copy_entry(src, dest, skip_existing=True)
 
         print("\nShared governance:")
         for shared_path in shared:
@@ -337,6 +374,67 @@ def cmd_validate(args: argparse.Namespace) -> None:
     sys.exit(run_validation(target, level=level))
 
 
+def cmd_upgrade(args: argparse.Namespace) -> None:
+    """Refresh agent config and governed contracts to the current govkit version."""
+    target = Path(args.target).resolve()
+    if not target.exists():
+        print(f"Error: target directory '{target}' does not exist.")
+        sys.exit(1)
+
+    stored = read_govkit_marker(target)
+    if not stored:
+        print("Error: no .govkit marker found. Run 'govkit apply' first.")
+        sys.exit(1)
+
+    stored_version = stored.get("version", "unknown")
+    agent = stored.get("agent")
+    stored_level = stored.get("level", "4")
+    stored_options = stored.get("options", {})
+
+    if not agent:
+        print("Error: .govkit marker missing 'agent' field. Run 'govkit apply' to reinitialise.")
+        sys.exit(1)
+
+    if stored_version == _GOVKIT_VERSION and not args.force:
+        print(f"\nAlready at govkit {_GOVKIT_VERSION}. Nothing to upgrade.")
+        print("Use --force to re-apply even when the version is current.")
+        return
+
+    print(f"\nUpgrading govkit {stored_version} → {_GOVKIT_VERSION}")
+    print(f"  Agent: {agent}  Level: {stored_level}\n")
+
+    manifest = load_manifest(agent)
+    agent_dir = AGENTS_DIR / agent
+    options = {**stored_options, "level": stored_level}
+    files, shared, governed = resolve_variant_files(manifest, options)
+
+    print("Agent files (refreshed):")
+    for entry in files:
+        src = agent_dir / entry["src"]
+        dest = target / entry["dest"]
+        copy_entry(src, dest)
+
+    print("\nGoverned contracts (refreshed):")
+    for governed_path in governed:
+        if governed_path.startswith("features/"):
+            continue
+        src = REPO_ROOT / governed_path
+        dest = target / governed_path
+        copy_entry(src, dest)
+
+    print("\nShared governance (skip if present):")
+    for shared_path in shared:
+        if shared_path.startswith("features/"):
+            continue
+        src = REPO_ROOT / shared_path
+        dest = target / shared_path
+        copy_entry(src, dest, skip_existing=True)
+
+    write_govkit_marker(target, agent, stored_level, options)
+    print(f"\nDone. '{agent}' upgraded to govkit {_GOVKIT_VERSION} at {target}")
+    print("\nReview changes with: git diff")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="govkit",
@@ -375,6 +473,17 @@ def main() -> None:
     validate_parser.add_argument("--level", choices=["3", "4", "5"], default=None,
                                  help="Maturity level (default: read from .govkit or 4)")
 
+    # --- upgrade ---
+    upgrade_parser = subparsers.add_parser(
+        "upgrade",
+        help="Refresh agent config and governed contracts to the current govkit version",
+    )
+    upgrade_parser.add_argument("--target", required=True, help="Path to the target project root")
+    upgrade_parser.add_argument(
+        "--force", action="store_true",
+        help="Re-apply even when the project is already at the current govkit version",
+    )
+
     args = parser.parse_args()
 
     if args.command == "apply":
@@ -385,6 +494,8 @@ def main() -> None:
         cmd_init(args)
     elif args.command == "validate":
         cmd_validate(args)
+    elif args.command == "upgrade":
+        cmd_upgrade(args)
 
 
 if __name__ == "__main__":

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -41,8 +41,8 @@ _PLAN_MD = "plan.md"
 _EVAL_CRITERIA_YAML = "eval_criteria.yaml"
 _ARCH_PREFLIGHT_MD = "architecture_preflight.md"
 
-_RE_MODE_LLM = r"^mode:\s*llm"
-_RE_MULTI_AGENT = r"^multi_agent:\s*true"
+_RE_MODE_LLM = r"^\s*mode:\s*llm\b"
+_RE_MULTI_AGENT = r"^\s*multi_agent:\s*true\b"
 _AGENT_TOPOLOGY_MD = "agent_topology.md"
 
 L3_REQUIRED_ARTIFACTS = [

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -42,6 +42,8 @@ _EVAL_CRITERIA_YAML = "eval_criteria.yaml"
 _ARCH_PREFLIGHT_MD = "architecture_preflight.md"
 
 _RE_MODE_LLM = r"^mode:\s*llm"
+_RE_MULTI_AGENT = r"^multi_agent:\s*true"
+_AGENT_TOPOLOGY_MD = "agent_topology.md"
 
 L3_REQUIRED_ARTIFACTS = [
     _ACCEPTANCE_FEATURE,
@@ -248,6 +250,49 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
 LLM_NFR_CATEGORIES = {"llm latency", "llm cost", "llm fallback", "llm safety"}
 
 
+def _is_multi_agent(feature_dir: Path) -> bool | None:
+    """Returns True if eval_criteria.yaml declares multi_agent: true, None if file missing."""
+    eval_path = feature_dir / _EVAL_CRITERIA_YAML
+    if not eval_path.exists():
+        return None
+    return bool(re.search(_RE_MULTI_AGENT, eval_path.read_text(encoding="utf-8"), re.MULTILINE))
+
+
+def check_agent_topology_exists(feature_dir: Path) -> tuple[bool, str]:
+    """When multi_agent: true, agent_topology.md must exist and be non-empty."""
+    is_ma = _is_multi_agent(feature_dir)
+    if not is_ma:
+        return True, "multi_agent not declared — agent topology check not applicable"
+    path = feature_dir / _AGENT_TOPOLOGY_MD
+    if not path.exists():
+        return False, f"{_AGENT_TOPOLOGY_MD} missing — required when multi_agent: true"
+    if path.stat().st_size == 0:
+        return False, f"{_AGENT_TOPOLOGY_MD} is empty"
+    return True, f"{_AGENT_TOPOLOGY_MD} present"
+
+
+def check_agent_topology_sections(feature_dir: Path) -> tuple[bool, str]:
+    """When multi_agent: true, agent_topology.md must have all required sections."""
+    is_ma = _is_multi_agent(feature_dir)
+    if not is_ma:
+        return True, "multi_agent not declared — agent topology sections check not applicable"
+    path = feature_dir / _AGENT_TOPOLOGY_MD
+    if not path.exists():
+        return False, f"{_AGENT_TOPOLOGY_MD} not found"
+    text = path.read_text(encoding="utf-8")
+    required = [
+        (r"^##\s+Orchestrator", "Orchestrator"),
+        (r"^##\s+Specialist Agents", "Specialist Agents"),
+        (r"^##\s+Routing Logic", "Routing Logic"),
+        (r"^##\s+Failure Modes", "Failure Modes"),
+    ]
+    missing = [name for pattern, name in required
+               if not re.search(pattern, text, re.MULTILINE)]
+    if missing:
+        return False, f"{_AGENT_TOPOLOGY_MD} missing sections: {', '.join(missing)}"
+    return True, f"{_AGENT_TOPOLOGY_MD} has all required sections"
+
+
 def _is_mode_llm(feature_dir: Path) -> bool | None:
     """Check if eval_criteria.yaml exists and has mode: llm. Returns None if file missing."""
     eval_path = feature_dir / _EVAL_CRITERIA_YAML
@@ -375,6 +420,8 @@ def _build_checks(level: str) -> tuple[list[str], list]:
             check_llm_nfrs,
             check_l5_eval_criteria,
             check_l5_preflight_sections,
+            check_agent_topology_exists,
+            check_agent_topology_sections,
         ]
     else:
         artifacts = L4_REQUIRED_ARTIFACTS

--- a/docs/backend/architecture/AGENT_ARCHITECTURE.md
+++ b/docs/backend/architecture/AGENT_ARCHITECTURE.md
@@ -100,6 +100,16 @@ Rules:
 - Prompts must not be embedded directly in code
 - Prompt changes should be reviewed like code changes
 
+**Multi-agent system prompt convention:**
+
+When a feature declares `multi_agent: true`, each agent's system prompt must be declared in `features/<feature>/agent_topology.md` using an explicit file path:
+
+```
+system_prompt: src/agents/<agent_name>/system_prompt.md
+```
+
+System prompts are loaded by the adapter at runtime — they are never hardcoded as Python strings in graph node functions. A system prompt change that materially alters agent behavior requires an ADR review.
+
 ---
 
 # 6. Agent State
@@ -230,6 +240,18 @@ Evaluation may include:
 
 Evaluation must run in CI.
 
+**Cross-agent evaluation (multi-agent features):**
+
+Single-agent evaluation (DeepEval, Promptfoo) measures individual node output quality. Multi-agent features require a system-level evaluation tier that measures the composed output of the full graph — not just individual nodes.
+
+When `multi_agent: true` is declared in `eval_criteria.yaml`, include a `multi_agent_evaluation` block with:
+- `topology_validated` — confirms `agent_topology.md` was reviewed before implementation
+- `system_prompt_governed` — confirms all system prompts are file-based and declared
+- `cross_agent_coherence` — score entry for composed output coherence
+- `orchestrator_routing_accuracy` — score entry for routing correctness
+
+Cross-agent eval runs in CI via `multi-agent-gate.yml`.
+
 ### LLM Evaluation Tools (Level 5)
 
 | Tool | Responsibility |
@@ -301,6 +323,10 @@ An ADR is required when:
 - introducing a new LLM provider
 - introducing a new tool capability
 - modifying evaluation strategies
+- adding or removing nodes in a multi-agent graph
+- rerouting edges between agents
+- making material changes to an agent's system prompt
+- changing the state schema shared between agents
 
 ADR template:
 ```
@@ -323,6 +349,90 @@ An agent feature is complete when:
 # 16. Guardrails Integration (Level 5)
 
 Agent features that interact with users must implement runtime guardrails.
+
+---
+
+# 17. Multi-Agent Topology
+
+When a feature uses multiple coordinated agents, declare `multi_agent: true` in `features/<feature>/eval_criteria.yaml`. This activates multi-agent governance for that feature.
+
+## Required governance artifact: `agent_topology.md`
+
+Every multi-agent feature must have `features/<feature>/agent_topology.md` before architecture preflight begins. Run `/multi-agent-design <feature>` (claude-code/copilot) or `$multi-agent-design <feature>` (codex) to produce it.
+
+**Required sections:**
+
+### Orchestrator
+- Role description
+- System prompt path: `src/agents/<name>/system_prompt.md`
+- LLM model alias (from `TECH_STACK.md`)
+- Routing strategy (conditions for dispatching to each specialist)
+
+### Specialist Agents
+For each specialist:
+- Role description
+- Input state fields (typed)
+- Output state fields (typed)
+- System prompt path: `src/agents/<name>/system_prompt.md`
+- LLM model alias
+- Tools/ports invoked
+
+### Routing Logic
+Explicit edge conditions for the LangGraph graph — which node fires under which conditions. No implicit or unconditional loops.
+
+### Failure Modes
+- Per-node timeout (seconds)
+- Graph-level timeout (seconds)
+- Fallback behavior when a node fails or times out
+
+## Architecture rules for multi-agent systems
+
+- The LangGraph graph definition lives in `services/graphs/<feature>_graph.py` — it is a service, not an adapter
+- Graph state is a `TypedDict` defined in `services/graphs/<feature>_state.py`
+- Each node function signature: `(state: FeatureState) -> dict` — pure transformation, no side effects
+- All LLM calls from node functions route through `LLMPort` — no direct provider SDK imports in graph files
+- System prompts are loaded from declared file paths at startup — never hardcoded as Python strings
+- No direct agent-to-agent calls — all routing goes through LangGraph graph edges
+
+## Example `agent_topology.md` structure
+
+```markdown
+# Agent Topology: <feature_name>
+
+## Orchestrator
+- **Role:** Route user queries to the appropriate specialist
+- **System Prompt:** `src/agents/orchestrator/system_prompt.md`
+- **Model:** `gpt-4o` (alias from TECH_STACK.md)
+- **Routing:** classifier output → specialist selection
+
+## Specialist Agents
+
+### analysis-agent
+- **Role:** Classify and structure the input query
+- **Input State:** `{ query: str, context: list[str] }`
+- **Output State:** `{ classification: str, confidence: float }`
+- **System Prompt:** `src/agents/analysis/system_prompt.md`
+- **Model:** `gpt-4o-mini`
+
+### solution-agent
+- **Role:** Generate a response based on the classification
+- **Input State:** `{ classification: str, confidence: float, query: str }`
+- **Output State:** `{ response: str }`
+- **System Prompt:** `src/agents/solution/system_prompt.md`
+- **Model:** `gpt-4o`
+
+## Routing Logic
+- START → orchestrator
+- orchestrator → analysis-agent (always)
+- analysis-agent → solution-agent (if confidence >= 0.7)
+- analysis-agent → END with escalation flag (if confidence < 0.7)
+- solution-agent → END
+
+## Failure Modes
+- Per-node timeout: 30s
+- Graph timeout: 120s
+- Node failure: return partial state with `error` field set; graph routes to END
+```
 
 | Tool | When to Use |
 |------|------------|

--- a/docs/backend/architecture/AGENT_ARCHITECTURE.md
+++ b/docs/backend/architecture/AGENT_ARCHITECTURE.md
@@ -102,11 +102,17 @@ Rules:
 
 **Multi-agent system prompt convention:**
 
-When a feature declares `multi_agent: true`, each agent's system prompt must be declared in `features/<feature>/agent_topology.md` using an explicit file path:
+When a feature declares `multi_agent: true`, each agent's system prompt must be declared in `features/<feature>/agent_topology.md` using an explicit file path. Two equivalent formats are accepted — use whichever fits your topology document's style:
 
 ```
+# YAML-like (compact, machine-readable)
 system_prompt: src/agents/<agent_name>/system_prompt.md
+
+# Markdown label (readable in rendered docs)
+- **System Prompt:** `src/agents/<agent_name>/system_prompt.md`
 ```
+
+The CI gate (`multi-agent-gate.yml`) recognises both formats and verifies each declared path exists in the repository.
 
 System prompts are loaded by the adapter at runtime — they are never hardcoded as Python strings in graph node functions. A system prompt change that materially alters agent behavior requires an ADR review.
 

--- a/features/starter_backend_l5/agent_topology.md
+++ b/features/starter_backend_l5/agent_topology.md
@@ -1,0 +1,79 @@
+# Agent Topology: <feature_name>
+
+> This file is required when `multi_agent: true` is declared in `eval_criteria.yaml`.
+> Run `/multi-agent-design <feature_name>` to generate this from guided prompts.
+> See `docs/backend/architecture/AGENT_ARCHITECTURE.md` Section 17 for rules.
+
+---
+
+## Orchestrator
+
+- **Role:** TBD — describe what the orchestrator decides and how it routes
+- **System Prompt:** `src/agents/orchestrator/system_prompt.md`
+- **Model:** TBD — use alias from `docs/backend/architecture/TECH_STACK.md`
+- **Routing Strategy:** TBD — describe the conditions that determine which specialist receives the task
+
+---
+
+## Specialist Agents
+
+### <specialist-1-name>
+
+- **Role:** TBD — one sentence describing this agent's bounded responsibility
+- **Input State:**
+  - `field_name: type` — description
+- **Output State:**
+  - `field_name: type` — description
+- **System Prompt:** `src/agents/<specialist-1-name>/system_prompt.md`
+- **Model:** TBD — use alias from `docs/backend/architecture/TECH_STACK.md`
+- **Ports Invoked:** TBD — list outbound ports called (e.g., `LLMPort`, `VectorSearchPort`)
+
+### <specialist-2-name>
+
+- **Role:** TBD — one sentence describing this agent's bounded responsibility
+- **Input State:**
+  - `field_name: type` — description
+- **Output State:**
+  - `field_name: type` — description
+- **System Prompt:** `src/agents/<specialist-2-name>/system_prompt.md`
+- **Model:** TBD — use alias from `docs/backend/architecture/TECH_STACK.md`
+- **Ports Invoked:** TBD
+
+---
+
+## Routing Logic
+
+Describe the LangGraph edge conditions. Every path to END must be explicit.
+
+```
+START → orchestrator
+orchestrator → <specialist-1-name>  (condition: TBD)
+orchestrator → <specialist-2-name>  (condition: TBD)
+<specialist-1-name> → END           (condition: TBD)
+<specialist-2-name> → END           (condition: TBD)
+```
+
+No implicit recursion or unconditional loops permitted (see Section 13 of `AGENT_ARCHITECTURE.md`).
+
+---
+
+## Failure Modes
+
+- **Per-node timeout:** TBD seconds
+- **Graph timeout:** TBD seconds
+- **Node failure handling:** TBD — describe what happens when a node raises an exception or times out (e.g., return partial state with `error` field, route to END)
+- **Fallback model:** TBD — declare in LiteLLM config, not in graph code
+
+---
+
+## State Schema Reference
+
+State TypedDict defined in: `services/graphs/<feature_name>_state.py`
+
+```python
+class <FeatureName>State(TypedDict):
+    # inputs
+    # intermediate fields
+    # outputs
+    error: str | None  # populated on node failure
+```

--- a/features/starter_backend_l5/eval_criteria.yaml
+++ b/features/starter_backend_l5/eval_criteria.yaml
@@ -80,3 +80,18 @@ llm_evaluation:
 
   dataset: tests/eval/<feature_name>/eval_sets/dataset.json
   fail_on_regression: true
+
+# ---------------------------------------------------------------------------
+# Multi-agent governance (uncomment when multi_agent: true)
+# ---------------------------------------------------------------------------
+# multi_agent: true
+#
+# multi_agent_evaluation:
+#   topology_validated: false        # set true after agent_topology.md is reviewed
+#   system_prompt_governed: false    # set true after all system prompt paths are declared
+#   cross_agent_coherence:
+#     score: null
+#     evidence: ""
+#   orchestrator_routing_accuracy:
+#     score: null
+#     evidence: ""

--- a/governance/backend/templates/l5-architecture-preflight.md
+++ b/governance/backend/templates/l5-architecture-preflight.md
@@ -205,8 +205,30 @@ If any LLM NFR is TBD, stop and request completion.
 
 ---
 
-## 15. Final Status
+## 15. Agent Topology (multi-agent features only)
+
+Check `eval_criteria.yaml` for `multi_agent: true`.
+
+If **not declared**: "Section 15: Not applicable — multi_agent not declared."
+
+If **declared**, complete each item:
+
+- [ ] `agent_topology.md` exists — run `/multi-agent-design` if missing
+- [ ] Orchestrator: role, system prompt path, model alias, routing strategy declared
+- [ ] Each specialist: role, typed input/output state, system prompt path, model alias declared
+- [ ] All system prompt files exist at declared paths
+- [ ] Routing Logic: all edge conditions explicit, every node has path to END
+- [ ] Failure Modes: per-node timeout, graph timeout, node failure behavior declared
+- [ ] State schema TypedDict path declared
+- [ ] ADR required? (Yes for new multi-agent feature or topology change)
+
+**Section 15 Status:** Approved / Blocked
+
+---
+
+## 16. Final Status
 
 - L4 preflight status: approved | blocked
 - L5 GenAI status: approved | blocked
+- Multi-agent status (if applicable): approved | blocked | n/a
 - Combined status: **Approved for planning** | **Blocked pending resolution**

--- a/governance/backend/templates/l5-plan.md
+++ b/governance/backend/templates/l5-plan.md
@@ -93,6 +93,21 @@
 
 ---
 
+## Multi-Agent Configuration (skip if multi_agent not declared)
+
+- Agent topology: `features/<feature_name>/agent_topology.md`
+- Graph state schema: `services/graphs/<feature_name>_state.py`
+
+| Agent | Role | System Prompt | Model |
+|---|---|---|---|
+| orchestrator | TBD | `src/agents/orchestrator/system_prompt.md` | TBD |
+| <specialist-1> | TBD | `src/agents/<specialist-1>/system_prompt.md` | TBD |
+
+- `topology_validated`: false → set true after agent_topology.md reviewed
+- `system_prompt_governed`: false → set true after all prompt files confirmed
+
+---
+
 ## Evaluation Compliance Summary (MANDATORY)
 
 Predicted BEFORE implementation begins. All score and evidence fields must be populated — null values are not permitted at plan finalization.

--- a/governance/schemas/evaluation_prediction.schema.json
+++ b/governance/schemas/evaluation_prediction.schema.json
@@ -74,6 +74,24 @@
           },
           "additionalProperties": false
         },
+        "multi_agent_evaluation": {
+          "description": "Multi-agent governance predictions (optional — only for features with multi_agent: true)",
+          "type": "object",
+          "required": ["topology_validated", "system_prompt_governed"],
+          "properties": {
+            "topology_validated": {
+              "type": "boolean",
+              "description": "agent_topology.md was reviewed and approved before implementation"
+            },
+            "system_prompt_governed": {
+              "type": "boolean",
+              "description": "All agent system prompts are file-based and declared in agent_topology.md"
+            },
+            "cross_agent_coherence": { "$ref": "#/$defs/score_entry" },
+            "orchestrator_routing_accuracy": { "$ref": "#/$defs/score_entry" }
+          },
+          "additionalProperties": false
+        },
         "thresholds_met": {
           "type": "boolean"
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.5.0"
+version = "0.6.0"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from cli.govkit import copy_entry, load_manifest, resolve_options, resolve_variant_files, cmd_apply, cmd_init, write_govkit_marker
+from cli.govkit import copy_entry, load_manifest, resolve_options, resolve_variant_files, cmd_apply, cmd_init, cmd_upgrade, write_govkit_marker, read_govkit_marker, _GOVKIT_VERSION
 
 
 # ---------------------------------------------------------------------------
@@ -225,11 +225,12 @@ class TestResolveVariantFiles:
                 }
             },
         }
-        files, shared = resolve_variant_files(manifest, {"ci": "github"})
+        files, shared, governed = resolve_variant_files(manifest, {"ci": "github"})
         assert len(files) == 2
         assert files[0]["src"] == "base.md"
         assert files[1]["src"] == "gh.yml"
         assert shared == ["governance/schemas/"]
+        assert governed == []
 
     def test_deduplication(self):
         manifest = {
@@ -249,7 +250,7 @@ class TestResolveVariantFiles:
                 },
             },
         }
-        files, shared = resolve_variant_files(manifest, {"ci": "github", "type": "api"})
+        files, shared, _ = resolve_variant_files(manifest, {"ci": "github", "type": "api"})
         assert len(files) == 1  # deduplicated
         assert len(shared) == 1  # deduplicated
 
@@ -263,18 +264,20 @@ class TestResolveVariantFiles:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"ci": "azure"})
+        files, shared, governed = resolve_variant_files(manifest, {"ci": "azure"})
         assert len(files) == 1
         assert shared == []
+        assert governed == []
 
     def test_unknown_variant_value(self):
         manifest = {
             "base_files": [],
             "variants": {"ci": {"github": {"files": [{"src": "g.yml", "dest": "g.yml"}]}}},
         }
-        files, shared = resolve_variant_files(manifest, {"ci": "nonexistent"})
+        files, shared, governed = resolve_variant_files(manifest, {"ci": "nonexistent"})
         assert files == []
         assert shared == []
+        assert governed == []
 
     def test_level_3_override(self):
         """When level=3, level_3 sub-key files/shared replace the top-level ones."""
@@ -292,7 +295,7 @@ class TestResolveVariantFiles:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"type": "api", "level": "3"})
+        files, shared, _ = resolve_variant_files(manifest, {"type": "api", "level": "3"})
         assert len(files) == 1
         assert files[0]["src"] == "l3-api.md"
         assert shared == ["docs/backend/architecture/DESIGN_PRINCIPLES.md"]
@@ -313,7 +316,7 @@ class TestResolveVariantFiles:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"type": "api", "level": "4"})
+        files, shared, _ = resolve_variant_files(manifest, {"type": "api", "level": "4"})
         assert len(files) == 1
         assert files[0]["src"] == "l4-api.md"
         assert shared == ["docs/backend/"]
@@ -334,7 +337,7 @@ class TestResolveVariantFiles:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"type": "api"})
+        files, _, _ = resolve_variant_files(manifest, {"type": "api"})
         assert files[0]["src"] == "l4-api.md"
 
     def test_level_3_missing_override_falls_through(self):
@@ -349,10 +352,9 @@ class TestResolveVariantFiles:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"ci": "github", "level": "3"})
+        files, _, _ = resolve_variant_files(manifest, {"ci": "github", "level": "3"})
         assert len(files) == 1
         assert files[0]["src"] == "gh.yml"
-        assert shared == ["ci/github/"]
 
     def test_level_3_multiple_dimensions(self):
         """Level 3 override applies across multiple dimensions."""
@@ -380,7 +382,7 @@ class TestResolveVariantFiles:
                 },
             }
         }
-        files, shared = resolve_variant_files(
+        files, shared, _ = resolve_variant_files(
             manifest, {"type": "api", "ci": "github", "level": "3"}
         )
         assert len(files) == 1
@@ -426,12 +428,12 @@ class TestGovkitMarker:
 
     def test_write_level_5_marker(self, tmp_path):
         import json
-        from cli.govkit import write_govkit_marker, read_govkit_level
+        from cli.govkit import write_govkit_marker, read_govkit_level, _GOVKIT_VERSION
 
         write_govkit_marker(tmp_path, "claude-code", "5", {"type": "api", "level": "5"})
         data = json.loads((tmp_path / ".govkit").read_text(encoding="utf-8"))
         assert data["level"] == "5"
-        assert data["version"] == "0.4.0"
+        assert data["version"] == _GOVKIT_VERSION
         assert read_govkit_level(tmp_path) == "5"
 
 
@@ -460,7 +462,7 @@ class TestLevel5VariantResolution:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"type": "api", "level": "5"})
+        files, shared, _ = resolve_variant_files(manifest, {"type": "api", "level": "5"})
         assert len(files) == 2
         assert files[0]["src"] == "l5-api.md"
         assert files[1]["src"] == "llm-gateway.md"
@@ -482,7 +484,7 @@ class TestLevel5VariantResolution:
                 }
             }
         }
-        files, shared = resolve_variant_files(manifest, {"type": "api", "level": "4"})
+        files, shared, _ = resolve_variant_files(manifest, {"type": "api", "level": "4"})
         assert files[0]["src"] == "l4-api.md"
         assert "features/starter_backend_l5/" not in shared
 
@@ -512,7 +514,7 @@ class TestLevel5VariantResolution:
                 },
             }
         }
-        files, shared = resolve_variant_files(
+        files, shared, _ = resolve_variant_files(
             manifest, {"type": "api", "ci": "github", "level": "5"}
         )
         assert files[0]["src"] == "l5.md"
@@ -653,3 +655,222 @@ class TestSmokeInit:
 
         content = (target / "features" / "new-feature" / "acceptance.feature").read_text(encoding="utf-8")
         assert content == "Feature: bundled", "Should use bundled starter, not stale target starter"
+
+
+# ---------------------------------------------------------------------------
+# governed key in resolve_variant_files
+# ---------------------------------------------------------------------------
+
+
+class TestGoverned:
+    def test_governed_entries_collected(self):
+        """governed key in variant config is returned as the third tuple element."""
+        manifest = {
+            "variants": {
+                "type": {
+                    "api": {
+                        "files": [{"src": "CLAUDE.md", "dest": "CLAUDE.md"}],
+                        "shared": ["features/starter_backend/"],
+                        "governed": ["docs/backend/", "governance/backend/"],
+                    }
+                }
+            }
+        }
+        files, shared, governed = resolve_variant_files(manifest, {"type": "api"})
+        assert governed == ["docs/backend/", "governance/backend/"]
+        assert shared == ["features/starter_backend/"]
+
+    def test_governed_deduplicated_across_dimensions(self):
+        """Same governed path from two dimensions is deduplicated."""
+        manifest = {
+            "variants": {
+                "type": {
+                    "api": {"files": [], "governed": ["docs/backend/"]},
+                },
+                "ci": {
+                    "github": {"files": [], "governed": ["docs/backend/", "ci/github/"]},
+                },
+            }
+        }
+        _, _, governed = resolve_variant_files(manifest, {"type": "api", "ci": "github"})
+        assert governed.count("docs/backend/") == 1
+        assert "ci/github/" in governed
+
+    def test_level_5_governed_override(self):
+        """level_5 governed entries replace the top-level ones for that dimension."""
+        manifest = {
+            "variants": {
+                "type": {
+                    "api": {
+                        "files": [{"src": "l4.md", "dest": "CLAUDE.md"}],
+                        "shared": ["features/starter_backend/"],
+                        "governed": ["docs/backend/"],
+                        "level_5": {
+                            "files": [{"src": "l5.md", "dest": "CLAUDE.md"}],
+                            "shared": ["features/starter_backend_l5/"],
+                            "governed": ["docs/backend/", "governance/schemas/eval.json"],
+                        },
+                    }
+                }
+            }
+        }
+        _, shared, governed = resolve_variant_files(manifest, {"type": "api", "level": "5"})
+        assert "features/starter_backend_l5/" in shared
+        assert "features/starter_backend/" not in shared
+        assert "governance/schemas/eval.json" in governed
+
+    def test_no_governed_returns_empty(self):
+        """Variants without a governed key return an empty list."""
+        manifest = {
+            "variants": {
+                "ci": {"github": {"files": [], "shared": ["ci/github/"]}}
+            }
+        }
+        _, _, governed = resolve_variant_files(manifest, {"ci": "github"})
+        assert governed == []
+
+
+# ---------------------------------------------------------------------------
+# cmd_upgrade
+# ---------------------------------------------------------------------------
+
+
+def _make_upgrade_repo(tmp_path: Path, agent: str = "test-agent") -> Path:
+    """Create a minimal govkit repo with a governed entry."""
+    agents = tmp_path / "agents" / agent
+    agents.mkdir(parents=True)
+    contract = tmp_path / "docs" / "contract.md"
+    contract.parent.mkdir(parents=True)
+    contract.write_text("# Contract v1", encoding="utf-8")
+
+    manifest = {
+        "agent": agent,
+        "description": "upgrade test agent",
+        "options": {
+            "level": {"prompt": "Level?", "choices": ["3", "4", "5"], "default": "4"},
+            "type": {"prompt": "Type?", "choices": ["api"], "default": "api"},
+            "ci": {"prompt": "CI?", "choices": ["github"], "default": "github"},
+            "ui": {"prompt": "UI?", "choices": ["none"], "default": "none"},
+        },
+        "variants": {
+            "type": {
+                "api": {
+                    "files": [{"src": "CLAUDE.md", "dest": "CLAUDE.md"}],
+                    "shared": [],
+                    "governed": ["docs/"],
+                }
+            }
+        },
+        "base_files": [],
+    }
+    (agents / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    (agents / "CLAUDE.md").write_text("# Agent instructions v2", encoding="utf-8")
+    return tmp_path
+
+
+class TestCmdUpgrade:
+    def _target_with_marker(self, tmp_path: Path, repo: Path, version: str = "0.1.0") -> Path:
+        target = tmp_path / "project"
+        target.mkdir()
+        # Pre-existing CLAUDE.md from old install
+        (target / "CLAUDE.md").write_text("# Agent instructions v1", encoding="utf-8")
+        # Pre-existing governed file
+        contract = target / "docs" / "contract.md"
+        contract.parent.mkdir(parents=True)
+        contract.write_text("# Contract v1", encoding="utf-8")
+        # .govkit marker with old version
+        marker = {
+            "version": version,
+            "level": "4",
+            "agent": "test-agent",
+            "options": {"type": "api", "ci": "github", "ui": "none"},
+            "applied_at": "2025-01-01T00:00:00+00:00",
+        }
+        (target / ".govkit").write_text(json.dumps(marker), encoding="utf-8")
+        return target
+
+    def test_upgrade_refreshes_agent_files(self, tmp_path, monkeypatch):
+        """cmd_upgrade overwrites agent files (files category)."""
+        import cli.govkit as mod
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version="0.1.0")
+        monkeypatch.setattr(mod, "AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr(mod, "REPO_ROOT", repo)
+        monkeypatch.setattr(mod, "_GOVKIT_VERSION", "0.2.0")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        assert (target / "CLAUDE.md").read_text(encoding="utf-8") == "# Agent instructions v2"
+
+    def test_upgrade_refreshes_governed_files(self, tmp_path, monkeypatch):
+        """cmd_upgrade overwrites governed files when version advances."""
+        import cli.govkit as mod
+
+        repo = _make_upgrade_repo(tmp_path)
+        # Update the governed file in the repo to simulate a govkit update
+        (repo / "docs" / "contract.md").write_text("# Contract v2", encoding="utf-8")
+
+        target = self._target_with_marker(tmp_path, repo, version="0.1.0")
+        monkeypatch.setattr(mod, "AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr(mod, "REPO_ROOT", repo)
+        monkeypatch.setattr(mod, "_GOVKIT_VERSION", "0.2.0")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        assert (target / "docs" / "contract.md").read_text(encoding="utf-8") == "# Contract v2"
+
+    def test_upgrade_skips_when_version_current(self, tmp_path, monkeypatch, capsys):
+        """cmd_upgrade does nothing when already at current version."""
+        import cli.govkit as mod
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version=_GOVKIT_VERSION)
+        monkeypatch.setattr(mod, "AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr(mod, "REPO_ROOT", repo)
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        out = capsys.readouterr().out
+        assert "Nothing to upgrade" in out
+        # CLAUDE.md was NOT overwritten
+        assert (target / "CLAUDE.md").read_text(encoding="utf-8") == "# Agent instructions v1"
+
+    def test_upgrade_force_overwrites_even_if_current(self, tmp_path, monkeypatch):
+        """cmd_upgrade --force overwrites even when version is current."""
+        import cli.govkit as mod
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version=_GOVKIT_VERSION)
+        monkeypatch.setattr(mod, "AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr(mod, "REPO_ROOT", repo)
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=True))
+
+        assert (target / "CLAUDE.md").read_text(encoding="utf-8") == "# Agent instructions v2"
+
+    def test_upgrade_updates_marker_version(self, tmp_path, monkeypatch):
+        """cmd_upgrade writes the new govkit version to the .govkit marker."""
+        import cli.govkit as mod
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version="0.1.0")
+        monkeypatch.setattr(mod, "AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr(mod, "REPO_ROOT", repo)
+        monkeypatch.setattr(mod, "_GOVKIT_VERSION", "0.2.0")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        marker = read_govkit_marker(target)
+        assert marker["version"] == "0.2.0"
+
+    def test_upgrade_no_marker_exits(self, tmp_path, monkeypatch):
+        """cmd_upgrade exits 1 when no .govkit marker exists."""
+        import cli.govkit as mod
+
+        target = tmp_path / "bare"
+        target.mkdir()
+        monkeypatch.setattr(mod, "AGENTS_DIR", tmp_path / "agents")
+
+        with pytest.raises(SystemExit):
+            cmd_upgrade(argparse.Namespace(target=str(target), force=False))

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 
 from cli.validate import (
+    check_agent_topology_exists,
+    check_agent_topology_sections,
     check_completeness,
     check_eval_criteria,
     check_gherkin_nfr_coverage,
@@ -889,4 +891,176 @@ class TestL5Validation:
         marker = tmp_path / ".govkit"
         marker.write_text(json.dumps({"level": "5"}), encoding="utf-8")
         result = run_validation(tmp_path)
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Multi-agent validation
+# ---------------------------------------------------------------------------
+
+VALID_AGENT_TOPOLOGY = """\
+    # Agent Topology: my_feature
+
+    ## Orchestrator
+    - **Role:** Route queries to specialists
+    - **System Prompt:** `src/agents/orchestrator/system_prompt.md`
+    - **Model:** gpt-4o
+
+    ## Specialist Agents
+
+    ### analysis-agent
+    - **Role:** Classify the input
+    - **Input State:** query: str
+    - **Output State:** classification: str
+    - **System Prompt:** `src/agents/analysis/system_prompt.md`
+
+    ## Routing Logic
+    START → orchestrator
+    orchestrator → analysis-agent (always)
+    analysis-agent → END
+
+    ## Failure Modes
+    - Per-node timeout: 30s
+    - Graph timeout: 120s
+"""
+
+MULTI_AGENT_EVAL_CRITERIA = """\
+    version: 1
+    mode: llm
+    multi_agent: true
+    owner: team-ai
+
+    unit_tests:
+      enforce_FIRST: true
+      minimum_FIRST_average: 4
+
+    code_quality:
+      enforce_virtues: true
+      minimum_virtue_average: 4
+
+    llm_evaluation:
+      criteria:
+        - name: faithfulness
+          eval_class: deepeval_faithfulness
+          threshold: 0.8
+          fail_on: below_threshold
+          tool: deepeval
+      dataset: tests/eval/my_feature/eval_sets/dataset.json
+      fail_on_regression: true
+
+    multi_agent_evaluation:
+      topology_validated: true
+      system_prompt_governed: true
+"""
+
+
+class TestMultiAgentValidation:
+    def test_topology_exists_pass(self, tmp_path):
+        """check_agent_topology_exists passes when agent_topology.md is present."""
+        write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
+        write(tmp_path / "agent_topology.md", VALID_AGENT_TOPOLOGY)
+        ok, msg = check_agent_topology_exists(tmp_path)
+        assert ok is True
+        assert "agent_topology.md present" in msg
+
+    def test_topology_exists_missing_fails(self, tmp_path):
+        """check_agent_topology_exists fails when multi_agent: true but file missing."""
+        write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
+        ok, msg = check_agent_topology_exists(tmp_path)
+        assert ok is False
+        assert "missing" in msg
+
+    def test_topology_exists_empty_fails(self, tmp_path):
+        """check_agent_topology_exists fails when agent_topology.md is empty."""
+        write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
+        (tmp_path / "agent_topology.md").write_text("", encoding="utf-8")
+        ok, msg = check_agent_topology_exists(tmp_path)
+        assert ok is False
+        assert "empty" in msg
+
+    def test_topology_exists_not_declared_skips(self, tmp_path):
+        """check_agent_topology_exists skips when multi_agent not declared."""
+        write(tmp_path / "eval_criteria.yaml", "version: 1\nmode: llm\n")
+        ok, msg = check_agent_topology_exists(tmp_path)
+        assert ok is True
+        assert "not applicable" in msg
+
+    def test_topology_exists_no_eval_criteria_skips(self, tmp_path):
+        """check_agent_topology_exists skips when eval_criteria.yaml is missing."""
+        ok, msg = check_agent_topology_exists(tmp_path)
+        assert ok is True
+        assert "not applicable" in msg
+
+    def test_topology_sections_pass(self, tmp_path):
+        """check_agent_topology_sections passes when all four sections present."""
+        write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
+        write(tmp_path / "agent_topology.md", VALID_AGENT_TOPOLOGY)
+        ok, msg = check_agent_topology_sections(tmp_path)
+        assert ok is True
+        assert "all required sections" in msg
+
+    def test_topology_sections_missing_one_fails(self, tmp_path):
+        """check_agent_topology_sections fails when a required section is absent."""
+        write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
+        write(tmp_path / "agent_topology.md", """\
+            # Agent Topology
+
+            ## Orchestrator
+            - Role: route
+
+            ## Specialist Agents
+            ### agent-a
+            - Role: analyse
+
+            ## Routing Logic
+            START → END
+
+            # Missing Failure Modes section
+        """)
+        ok, msg = check_agent_topology_sections(tmp_path)
+        assert ok is False
+        assert "Failure Modes" in msg
+
+    def test_topology_sections_not_declared_skips(self, tmp_path):
+        """check_agent_topology_sections skips when multi_agent not declared."""
+        write(tmp_path / "eval_criteria.yaml", "version: 1\nmode: llm\n")
+        ok, msg = check_agent_topology_sections(tmp_path)
+        assert ok is True
+        assert "not applicable" in msg
+
+    def test_topology_sections_file_missing_fails(self, tmp_path):
+        """check_agent_topology_sections fails when file is missing (multi_agent declared)."""
+        write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
+        ok, msg = check_agent_topology_sections(tmp_path)
+        assert ok is False
+        assert "not found" in msg
+
+    def test_l5_multi_agent_full_pass(self, tmp_path):
+        """Full L5 validation passes for a multi-agent feature with topology present."""
+        features = tmp_path / "features"
+        make_l5_feature(
+            features / "ma_feature",
+            **{
+                "eval_criteria.yaml": MULTI_AGENT_EVAL_CRITERIA,
+                "agent_topology.md": VALID_AGENT_TOPOLOGY,
+            },
+        )
+        result = run_validation(tmp_path, level="5")
+        assert result == 0
+
+    def test_l5_multi_agent_missing_topology_fails(self, tmp_path):
+        """L5 validation fails when multi_agent: true but agent_topology.md is absent."""
+        features = tmp_path / "features"
+        make_l5_feature(
+            features / "ma_feature",
+            **{"eval_criteria.yaml": MULTI_AGENT_EVAL_CRITERIA},
+        )
+        result = run_validation(tmp_path, level="5")
+        assert result == 1
+
+    def test_l5_non_multi_agent_unaffected(self, tmp_path):
+        """Standard L5 features without multi_agent: true are not affected."""
+        features = tmp_path / "features"
+        make_l5_feature(features / "single_agent_feature")
+        result = run_validation(tmp_path, level="5")
         assert result == 0


### PR DESCRIPTION
## What
Adds a multi-agent governance layer across all three coding agents (claude-code, copilot, codex) and introduces a `govkit upgrade` command for keeping governance contracts current after a govkit version bump.

## Why
Modern AI-assisted systems increasingly use multiple specialized agents orchestrated by a system prompt. The existing framework governed single-LLM features well but had no contracts, rules, or lifecycle checkpoints for multi-agent topology — meaning teams building orchestrator/specialist patterns had no govkit-enforced guidance. The `upgrade` command solves a separate long-standing gap: re-running `govkit apply` on an existing project silently skipped architecture contracts, so contract updates (like the new multi-agent sections) never reached installed projects.

## Changes

**Multi-agent governance (all 3 agents — claude-code, copilot, codex)**
- `docs/backend/architecture/AGENT_ARCHITECTURE.md` — extended with Section 17 (multi-agent topology rules), plus updates to sections 5 (system prompt governance), 10 (cross-agent eval tier), and 14 (ADR triggers for topology changes)
- New rule files: `agents/*/rules/backend/multi-agent.md` (and copilot `.instructions.md`) — path-scoped rules enforcing typed state, LLMPort usage, no hardcoded system prompts, no direct agent-to-agent calls
- New skill: `agents/*/skills/backend/multi-agent-design/SKILL.md` — pre-planning skill that produces `features/<name>/agent_topology.md` before architecture preflight
- Updated `architecture-preflight/SKILL.md` (all 3 agents) — new Section 15 validates `agent_topology.md` before planning proceeds; halts if missing
- Updated `genai-preflight/SKILL.md` (all 3 agents) — new Section 6 validates system prompt file existence and cross-agent eval block
- Updated L5 root instructions (all 3 agents, api + cli) — lifecycle step 0 for multi-agent features, new ADR triggers, contract reference
- New CI gates: `ci/github/multi-agent-gate.yml`, `ci/azure/multi-agent-gate.yml` — validate `agent_topology.md` and system prompt file paths
- New starter template: `features/starter_backend_l5/agent_topology.md`
- Extended `features/starter_backend_l5/eval_criteria.yaml` with commented `multi_agent` block
- Extended `governance/schemas/evaluation_prediction.schema.json` with optional `multi_agent_evaluation` section
- Extended `governance/backend/templates/l5-plan.md` and `l5-architecture-preflight.md` with multi-agent sections
- `cli/validate.py` — two new L5 checks: `check_agent_topology_exists` and `check_agent_topology_sections`, both gated on `multi_agent: true` in `eval_criteria.yaml`
- All 3 `manifest.json` files updated to deploy new rule, skill, and CI gate at L5

**`govkit upgrade` command**
- `cli/govkit.py` — introduced three-category file model: `files` (always overwrite), `governed` (overwrite on upgrade), `shared` (never overwrite)
- New `cmd_upgrade` — reads `.govkit` marker to reconstruct agent/level/options, refreshes `files` + `governed`, skips `shared`, updates version in marker; `--force` flag re-applies even when version is current
- New `read_govkit_marker` function returning full marker dict
- `_GOVKIT_VERSION` constant sourced from `importlib.metadata` (installed package version)
- All 3 manifests updated: `docs/`, `governance/`, and `ci/` entries moved from `shared` → `governed`; `features/starter_*` remains in `shared`
- `README.md` — new step 6 "Keep governance contracts up to date" documenting the three file categories, upgrade workflow, `git diff` review step, and `--force` use case

**Tests**
- `tests/test_validate.py` — 12 new tests in `TestMultiAgentValidation`
- `tests/test_govkit.py` — updated all `resolve_variant_files` callers to 3-tuple; 4 new `TestGoverned` tests; 6 new `TestCmdUpgrade` tests

## Testing

```bash
# Run all tests
pytest tests/ -v

# Smoke test apply (verify new rule + skill deploy at L5)
govkit apply --agent claude-code --level 5 --type api --ui none --ci github --target /tmp/test-cc
ls /tmp/test-cc/.claude/rules/multi-agent.md
ls /tmp/test-cc/.claude/skills/multi-agent-design/

# Smoke test upgrade
govkit apply --agent claude-code --level 5 --type api --ui none --ci github --target /tmp/test-up
govkit upgrade --target /tmp/test-up --force
git -C /tmp/test-up diff
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)