### PR TITLE
ci: add pytest workflow for PRs and main pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install
+        run: pip install -e ".[test]"
+
+      - name: Run pytest
+        run: pytest


### PR DESCRIPTION
## What
Adds [.github/workflows/test.yml](.github/workflows/test.yml) — runs pytest on every PR into `main` and on every push to `main`.

## Why
Before this, no checks ran on PRs (the v0.8.0 PR and the two Dependabot PRs all merged with empty status check rollups). Branch protection requires PRs but doesn't yet require any check to pass — this workflow gives future PRs something to gate against once you enable a required check.

## Changes
- New workflow `Tests` on `pull_request` (branches: `[main]`) and `push` (branches: `[main]`).
- Matrix runs on Python 3.11 and 3.12 — the versions advertised in [pyproject.toml](pyproject.toml) classifiers.
- Installs the package editable with the `test` extra (`pytest>=8.0`, `jsonschema>=4.0`).
- Reuses the same pinned action hashes as `publish.yml` (`actions/checkout@v6.0.2`, `actions/setup-python@v6.2.0`) so Dependabot bumps both workflows together.
- Enables pip caching to speed up re-runs.

## Testing
This PR is its own first test — once merged, every subsequent PR will see the `pytest (3.11)` and `pytest (3.12)` checks. The author verified `pytest` passes locally (366 tests) before the v0.8.0 merge.

## Follow-up
Optional: under repo Settings → Branches → main, add `pytest (3.11)` / `pytest (3.12)` to required status checks so future PRs can't merge red.