### PR TITLE
fix: --type data stack selection + data ADR template (v0.10.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ---
 
+## [0.10.1] — 2026-05-27
+
+### Fixed — `--type data` stack selection
+
+Patch release fixing two stack-selection bugs and one missing data artifact, all found while preparing a dbt demo against v0.10.0.
+
+- **`--type data` no longer adopts an incompatible inferred stack.** When a repo had an ambient framework signal from a *different* shape — e.g. `fastapi` mentioned in `pyproject.toml` of a dbt project — `govkit apply --type data` would select the `python-fastapi` stack (high-confidence framework inference) and install its `docs/backend/architecture/` overlay docs, contradicting the requested data shape. `_resolve_stack_choice` now checks a new `_STACK_SUPPORTED_TYPES` map and rejects an inferred stack that doesn't support the requested `--type`. Precedence is now: explicit `--stack` flag → type-compatible high-confidence inference → per-type default. The user's explicit `--type` intent outranks an incidental framework signal. The same guard protects the inverse case (an ambient `dbt_project.yml` no longer hijacks a `--type api` install).
+- **`govkit apply --detect` now reports the stack real apply would pick.** The dry-run path had its own inlined copy of the stack-resolution logic with the same bug. It now delegates to `_resolve_stack_choice`, so the proposed config can't drift from actual apply behavior.
+- **Data installs now ship `docs/data/architecture/ADR/TEMPLATE.md`.** `l4-data.md` advertises `/adr-author` and the shared `adr-author` skill references `ADR/TEMPLATE.md`, but no ADR template was installed for data projects — the skill pointed at a missing file. Added a data-adapted ADR template (layer-boundary, data-contract, and PII/compliance impact sections instead of the backend HTTP-route framing). It ships via the existing `docs/data/architecture/` folder copy — no manifest change.
+
+### Verification
+
+- 805 pytest tests pass + 1 expected skip (was 798). New tests: `TestResolveStackChoiceTypeCompatibility` (5), `TestCmdApplyDetectFlag::test_detect_flag_with_type_data_ignores_ambient_fastapi`, `TestDbtProjectFixture::test_data_adr_template_installed`.
+- Built wheel confirms `cli/docs/data/architecture/ADR/TEMPLATE.md` ships.
+
+---
+
 ## [0.10.0] — 2026-05-27
 
 ### Added — Governance Accelerator

--- a/cli/govkit.py
+++ b/cli/govkit.py
@@ -289,7 +289,7 @@ def copy_entry(
 ) -> None:
     """Copy a file or directory tree.
 
-    Edit-protection (A2): when `applied_at` is supplied, files at `dest` that
+    Edit-protection: when `applied_at` is supplied, files at `dest` that
     carry a govkit:editable header and were modified after `applied_at` are
     skipped with a warning unless `force=True`. Pass `applied_at=None` (the
     default) to preserve pre-PR-1 behavior for callers that don't manage
@@ -743,17 +743,13 @@ def _cmd_apply_detect_dry_run(target: Path, args: argparse.Namespace) -> None:
     profile = build_profile(target)
     inferred_stack, inferred_confidence = infer_stack(profile)
 
-    cli_stack = getattr(args, "stack", None)
-    if cli_stack:
-        chosen_stack = cli_stack
-        stack_source = "flag"
-    elif inferred_stack and inferred_confidence == "high":
-        chosen_stack = inferred_stack
-        stack_source = "detected"
-    else:
-        type_value = getattr(args, "type", None) or "api"
-        chosen_stack = _DEFAULT_STACK_BY_TYPE.get(type_value, "python-fastapi")
-        stack_source = "default"
+    # Delegate to _resolve_stack_choice so the dry-run reports the same stack
+    # real apply would pick — including the type-compatibility check that
+    # rejects e.g. python-fastapi inference when --type data is requested.
+    options = {"type": getattr(args, "type", None) or "api"}
+    chosen_stack, stack_source, _, _ = _resolve_stack_choice(
+        args, options, profile, inferred_stack, inferred_confidence, target,
+    )
 
     print(f"\n[dry-run --detect] govkit apply would target: {target}\n")
     _print_detection_summary(
@@ -867,6 +863,32 @@ _DEFAULT_STACK_BY_TYPE = {
     "data": "python-dbt",
 }
 
+# Which `--type` shapes each stack supports. An inferred stack that doesn't
+# support the user's chosen --type is treated as an ambient signal from a
+# different shape (e.g. fastapi in pyproject.toml of a dbt workshop dir) and
+# does NOT override the type-default. The user's explicit --type intent wins.
+_STACK_SUPPORTED_TYPES = {
+    "python-fastapi":    frozenset({"api", "cli"}),
+    "dotnet-aspnet":     frozenset({"api", "cli"}),
+    "java-spring-boot":  frozenset({"api", "cli"}),
+    "nodejs-fastify":    frozenset({"api", "cli"}),
+    "go-gin":            frozenset({"api", "cli"}),
+    "python-dbt":        frozenset({"data"}),
+}
+
+
+def _stack_supports_type(stack_id: str | None, type_value: str) -> bool:
+    """True when `stack_id` is a sensible overlay for `type_value`.
+
+    Unknown stack_ids return True so future-added stacks aren't accidentally
+    rejected by an out-of-date map — the type-default is a safety net, not a
+    gatekeeper.
+    """
+    if not stack_id:
+        return False
+    supported = _STACK_SUPPORTED_TYPES.get(stack_id)
+    return True if supported is None else type_value in supported
+
 
 def _resolve_stack_choice(
     args: argparse.Namespace, options: dict, profile, inferred_stack: str | None,
@@ -874,18 +896,23 @@ def _resolve_stack_choice(
 ) -> tuple[str, str, str, list[str]]:
     """Return (requested_stack, source, confidence, evidence).
 
-    Precedence: explicit --stack > high-confidence inference > per-type default.
+    Precedence: explicit --stack > type-compatible high-confidence inference >
+    per-type default. An inferred stack that does not match the requested
+    --type is ignored — the user's explicit shape intent (--type data) outranks
+    an incidental framework signal from a different shape (fastapi pyproject).
     """
     cli_stack = getattr(args, "stack", None)
     if cli_stack:
         return cli_stack, "flag", "high", []
-    if inferred_stack and inferred_confidence == "high":
+    type_value = options.get("type", "api")
+    if (inferred_stack
+            and inferred_confidence == "high"
+            and _stack_supports_type(inferred_stack, type_value)):
         evidence = list(
             profile.detected_frameworks
             + [str(p.relative_to(target)) for p in profile.detected_project_paths[:3]]
         )
         return inferred_stack, "detected", "high", evidence
-    type_value = options.get("type", "api")
     default_stack = _DEFAULT_STACK_BY_TYPE.get(type_value, "python-fastapi")
     return options.get("stack") or default_stack, "default", "low", []
 

--- a/docs/data/architecture/ADR/TEMPLATE.md
+++ b/docs/data/architecture/ADR/TEMPLATE.md
@@ -1,0 +1,157 @@
+# ADR-XXX: <Short Decision Title>
+
+## Status
+Proposed | Accepted | Rejected | Superseded
+
+## Date
+YYYY-MM-DD
+
+## Authors
+- <Name / Role>
+
+---
+
+## 1. Context
+
+Describe:
+
+- The model, pipeline, or data product impacted
+- Relevant architectural constraints (layering, freshness, materialization)
+- Existing standards or contracts that apply
+- The problem this decision addresses
+
+Reference:
+- `features/<feature_name>/plan.md`
+- Relevant sections of `ARCH_CONTRACT.md`
+- Relevant boundary rules in `BOUNDARIES.md`
+- Source freshness / SLA expectations in `PIPELINE_CONTRACT.md`
+
+---
+
+## 2. Decision
+
+State the decision clearly and concisely.
+
+Avoid narrative here. This section must stand alone.
+
+Example:
+
+> We will materialize `dim_customers` as `incremental` (merge strategy) rather
+> than `table`, because the daily full rebuild exceeds the warehouse cost
+> budget defined in `PIPELINE_CONTRACT.md`.
+
+---
+
+## 3. Architectural Impact
+
+### 3.1 Layer Boundaries
+- Layers affected (staging / intermediate / marts):
+- New models introduced and their layer:
+- Cross-source joins introduced (must live in intermediate):
+
+Confirm:
+- No staging model joins across sources
+- No mart reads another mart in a way that violates `BOUNDARIES.md`
+- Dependency direction (staging → intermediate → marts) is preserved
+
+### 3.2 Data Contract Impact
+If applicable:
+- Mart column additions / removals / renames:
+- Grain changes (does the primary key change?):
+- Downstream consumers affected (BI, reverse-ETL, other teams):
+- Breaking-change coordination required per `BOUNDARIES.md`:
+- Materialization change (view / table / incremental / ephemeral):
+
+### 3.3 PII / Compliance Impact
+- New PII columns introduced:
+- Masking strategy (`mask_pii()` macro per `PII_HANDLING_CONTRACT.md`):
+- New PII category beyond the default set:
+- Column-lineage capture required per `LINEAGE_CONTRACT.md`:
+- Environment exposure (is raw PII reachable in dev/ci?) per `ENVIRONMENTS.md`:
+
+---
+
+## 4. Alternatives Considered
+
+For each alternative:
+
+### Option A
+- Description
+- Pros
+- Cons
+- Why rejected
+
+Keep this section concise but explicit.
+
+---
+
+## 5. Evaluation Impact
+
+Does this decision affect:
+
+- LLM evaluation criteria?
+- Deterministic evaluation checks (schema tests, freshness checks)?
+- CI enforcement rules?
+
+If yes:
+- List affected criteria from `features/<feature_name>/eval_criteria.yaml`
+- Describe changes required
+
+If no:
+- State: "No evaluation impact."
+
+---
+
+## 6. Risks and Tradeoffs
+
+- Data quality risks (late-arriving data, nulls, duplicates):
+- Freshness / SLA risks:
+- Cost implications (warehouse compute, storage):
+- Backfill / reprocessing implications:
+
+Mitigations:
+
+---
+
+## 7. Plan Alignment
+
+Reference:
+
+- Feature plan increments impacted:
+- New increment required?
+- Scope adjustments required?
+
+If the decision changes scope:
+- `plan.md` must be updated.
+
+---
+
+## 8. Consequences
+
+### Positive
+- 
+
+### Negative
+- 
+
+### Neutral
+- 
+
+---
+
+## 9. Follow-Up Actions
+
+- Model changes required:
+- Test changes required (schema / singular / freshness):
+- Documentation updates required (exposures, model descriptions):
+- CI updates required:
+- Data governance / privacy review required:
+
+---
+
+## 10. Approval
+
+Approved by:
+- Data architect / lead:
+- Privacy / compliance (if PII impact):
+- Product / downstream owner (if contract impact):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.10.0"
+version = "0.10.1"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -274,6 +274,20 @@ class TestDbtProjectFixture:
         assert (arch_dir / "DATA_QUALITY_CONTRACT.md").is_file()
         assert (arch_dir / "PII_HANDLING_CONTRACT.md").is_file()
 
+    def test_data_adr_template_installed(self, tmp_path):
+        """The adr-author skill + l4-data.md both advertise ADRs, so the data
+        install must ship docs/data/architecture/ADR/TEMPLATE.md — otherwise
+        /adr-author points at a missing file in a dbt project."""
+        target = _copy_fixture("dbt-project", tmp_path)
+        self._apply(target)
+
+        adr = target / "docs" / "data" / "architecture" / "ADR" / "TEMPLATE.md"
+        assert adr.is_file(), "data install must ship an ADR template"
+        body = adr.read_text(encoding="utf-8")
+        # Data-adapted: it should speak to data contracts, not HTTP routes.
+        assert "Data Contract Impact" in body
+        assert "PII" in body
+
     def test_doctor_d001_quiet_on_dbt_layered_rules(self, tmp_path):
         """The dbt-layered rules (staging.md, intermediate.md, marts.md)
         should expand to globs that resolve in this fixture."""

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2555,6 +2555,38 @@ class TestCmdApplyDetectFlag:
         ))
         assert not (target / ".govkit").exists()
 
+    def test_detect_flag_with_type_data_ignores_ambient_fastapi(self, tmp_path, monkeypatch, capsys):
+        """Mirror of TestResolveStackChoiceTypeCompatibility, applied to the
+        --detect dry-run path. The reported stack must match what real apply
+        would pick — type-incompatible inferences are rejected in both places."""
+        import cli.govkit as mod
+
+        repo = self._agent(tmp_path)
+        target = tmp_path / "project"
+        target.mkdir()
+        # Ambient fastapi signal — the workshop-demo scenario.
+        (target / "pyproject.toml").write_text(
+            '[project]\nname = "demo"\ndependencies = ["fastapi>=0.100"]\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mod, "AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr(mod, "REPO_ROOT", repo)
+
+        cmd_apply(argparse.Namespace(
+            agent="test-agent", target=str(target),
+            level="4", type="data", ci="github", stack=None, force=False,
+            detect=True,
+        ))
+
+        out = capsys.readouterr().out
+        assert "python-dbt" in out, (
+            f"--detect with --type data + ambient fastapi must report python-dbt; "
+            f"got output:\n{out}"
+        )
+        assert "python-fastapi  (source: detected)" not in out, (
+            "--detect must not report python-fastapi as detected when --type data was requested"
+        )
+
 
 class TestCmdStackList:
     """PR 2 / Chunk F: govkit stack list enumerates bundled stack overlays."""
@@ -3189,3 +3221,97 @@ class TestUpgradeMigrateLevels:
         assert "maturity model" not in err, (
             "After --migrate-levels rewrites marker to 0.7.0, the warning must not fire"
         )
+
+
+class TestResolveStackChoiceTypeCompatibility:
+    """The user's explicit --type flag must outrank an ambient framework
+    signal from a different shape. Example: a workshop demo dir with
+    `fastapi` in pyproject.toml + `--type data` must select python-dbt,
+    not python-fastapi.
+    """
+
+    def _profile(self, tmp_path, frameworks=None, languages=None, signals=None):
+        from cli.detect import RepoProfile
+        return RepoProfile(
+            target=tmp_path,
+            detected_languages=list(languages or []),
+            detected_frameworks=list(frameworks or []),
+            detected_ci=[],
+            detected_test_packages=[],
+            detected_project_paths=[],
+            detected_api_style=None,
+            detected_llm_signals=[],
+            detected_architecture_signals=list(signals or []),
+        )
+
+    def _args(self, stack=None):
+        return argparse.Namespace(stack=stack)
+
+    def test_explicit_stack_flag_always_wins(self, tmp_path):
+        from cli.govkit import _resolve_stack_choice
+        chosen, source, _, _ = _resolve_stack_choice(
+            self._args(stack="java-spring-boot"),
+            {"type": "data"},
+            self._profile(tmp_path, frameworks=["fastapi"], languages=["python"]),
+            inferred_stack="python-fastapi", inferred_confidence="high",
+            target=tmp_path,
+        )
+        assert (chosen, source) == ("java-spring-boot", "flag")
+
+    def test_type_data_overrides_fastapi_inference(self, tmp_path):
+        """The reported bug: workshop dir has fastapi in pyproject, user passes
+        --type data, govkit picks python-fastapi instead of python-dbt."""
+        from cli.govkit import _resolve_stack_choice
+        chosen, source, _, _ = _resolve_stack_choice(
+            self._args(),
+            {"type": "data"},
+            self._profile(tmp_path, frameworks=["fastapi"], languages=["python"]),
+            inferred_stack="python-fastapi", inferred_confidence="high",
+            target=tmp_path,
+        )
+        assert chosen == "python-dbt", (
+            f"--type data with ambient fastapi signal must default to python-dbt, "
+            f"not honor the incompatible inferred stack; got {chosen}"
+        )
+        assert source == "default"
+
+    def test_type_data_honors_dbt_inference(self, tmp_path):
+        """When the inferred stack IS compatible with --type data (dbt),
+        we should still honor the high-confidence inference."""
+        from cli.govkit import _resolve_stack_choice
+        chosen, source, _, _ = _resolve_stack_choice(
+            self._args(),
+            {"type": "data"},
+            self._profile(tmp_path, frameworks=["dbt"], languages=["python"], signals=["dbt-shape"]),
+            inferred_stack="python-dbt", inferred_confidence="high",
+            target=tmp_path,
+        )
+        assert chosen == "python-dbt"
+        assert source == "detected"
+
+    def test_type_api_overrides_dbt_inference(self, tmp_path):
+        """Inverse: --type api with an ambient dbt_project.yml laying around
+        must default to python-fastapi, not honor the incompatible dbt match."""
+        from cli.govkit import _resolve_stack_choice
+        chosen, source, _, _ = _resolve_stack_choice(
+            self._args(),
+            {"type": "api"},
+            self._profile(tmp_path, frameworks=["dbt"], languages=["python"], signals=["dbt-shape"]),
+            inferred_stack="python-dbt", inferred_confidence="high",
+            target=tmp_path,
+        )
+        assert chosen == "python-fastapi"
+        assert source == "default"
+
+    def test_type_api_honors_compatible_backend_inference(self, tmp_path):
+        """Sanity: --type api with detected csharp/aspnet still works."""
+        from cli.govkit import _resolve_stack_choice
+        chosen, source, _, _ = _resolve_stack_choice(
+            self._args(),
+            {"type": "api"},
+            self._profile(tmp_path, frameworks=["aspnet-core"], languages=["csharp"]),
+            inferred_stack="dotnet-aspnet", inferred_confidence="high",
+            target=tmp_path,
+        )
+        assert chosen == "dotnet-aspnet"
+        assert source == "detected"


### PR DESCRIPTION
## Summary

Patch release (v0.10.1) fixing two stack-selection bugs and one missing data artifact, all found while preparing a dbt demo against v0.10.0.

## Type of Change

- [x] Fix
- [x] Documentation

## What Changed

- **`--type data` no longer adopts an incompatible inferred stack.** A `fastapi` mention in a dbt project's `pyproject.toml` fired the high-confidence framework detector and caused `govkit apply --type data` to select the `python-fastapi` stack — which then installed `docs/backend/architecture/` overlay docs, contradicting the requested data shape. `_resolve_stack_choice` now checks a new `_STACK_SUPPORTED_TYPES` map and rejects an inferred stack that doesn't support the requested `--type`. Precedence: explicit `--stack` → type-compatible high-confidence inference → per-type default. The inverse case (an ambient `dbt_project.yml` hijacking `--type api`) is also protected.
- **`govkit apply --detect` now reports the stack real apply would pick.** The dry-run path had its own inlined copy of the resolution logic with the same bug; it now delegates to `_resolve_stack_choice`.
- **Data installs now ship `docs/data/architecture/ADR/TEMPLATE.md`.** `l4-data.md` advertises `/adr-author` and the shared `adr-author` skill references `ADR/TEMPLATE.md`, but no ADR template was installed for data projects. Added a data-adapted template (layer-boundary / data-contract / PII-compliance impact sections). Ships via the existing `docs/data/architecture/` folder copy — no manifest change.

## Validation

- [x] Relevant tests passed — **805 pytest tests pass, 1 expected skip** (was 798). New: `TestResolveStackChoiceTypeCompatibility` (5), `test_detect_flag_with_type_data_ignores_ambient_fastapi`, `test_data_adr_template_installed`.
- [x] Built wheel confirms `cli/docs/data/architecture/ADR/TEMPLATE.md` ships.
- [x] Version bumped `0.10.0` → `0.10.1`. Overlay `version` fields deliberately left at `0.10.0` (no overlay content changed → avoids false D006 staleness warnings).

## Breaking Changes

- [x] No breaking changes

## Additional Notes

Found during dbt-demo prep: a workshop folder with an ambient `fastapi` reference produced a `--type data` install containing `docs/backend/architecture/` — the symptom that surfaced both stack-selection bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)