### PR TITLE
fix: remove internal PR references from calibrate step 9

### DIFF
--- a/cli/calibrate.py
+++ b/cli/calibrate.py
@@ -319,12 +319,12 @@ def build_checklist(target: Path, marker: dict) -> list[CalibrationStep]:
         title="Skill context",
         description="Facts skills will read (architecture style, stack, layer mappings).",
         file_path=".govkit/skill_context.yaml",
-        installed_summary="generated at end of calibrate (PR 5+)",
+        installed_summary="regenerated when calibration completes",
         detected_value=None,
         suggestion=(
             "Final review — these are the facts skills (architecture-preflight, "
-            "spec-planning, implementation-plan) will consult when generating "
-            "guidance. PR 6a wires the consumers."
+            "spec-planning, implementation-plan) consult when generating "
+            "guidance. Confirm they reflect the decisions you made above."
         ),
         assumption_id=None,
     ))

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -108,6 +108,22 @@ class TestBuildChecklist:
         assert any("docs/ui/architecture" in p for p in paths)
         assert not any("docs/backend/architecture" in p for p in paths)
 
+    def test_no_internal_pr_references_in_user_facing_text(self, tmp_path):
+        """Calibration steps are user-facing; they must not leak internal
+        roadmap/PR references (e.g. "PR 5+", "PR 6a wires the consumers")."""
+        import re
+
+        from cli.calibrate import build_checklist
+
+        marker = _write_marker(tmp_path)
+        steps = build_checklist(tmp_path, marker)
+        pr_ref = re.compile(r"\bPR\s*\d", re.IGNORECASE)
+        for step in steps:
+            for field_name in ("title", "description", "installed_summary", "suggestion"):
+                value = getattr(step, field_name) or ""
+                assert not pr_ref.search(value), \
+                    f"{step.id}.{field_name} leaks an internal PR reference: {value!r}"
+
     def test_agent_step_path_matches_agent(self, tmp_path):
         """The agent-instruction step uses the correct path per agent."""
         from cli.calibrate import build_checklist


### PR DESCRIPTION
## Why

`govkit calibrate`'s skill-context step (step 9) printed internal roadmap language into user-facing output — both the interactive prompt and the generated `GOVKIT_CALIBRATION_CHECKLIST.md`:

- `installed_summary`: "generated at end of calibrate (PR 5+)"
- `suggestion`: "...will consult when generating guidance. PR 6a wires the consumers."

Users shouldn't see internal PR numbers. Surfaced while smoke-testing calibrate for the README rewrite (#26).

## What changed

- Reworded step 9's `installed_summary` and `suggestion` to user-facing language
- Added a regression test (`test_no_internal_pr_references_in_user_facing_text`) asserting no calibration step's user-facing fields contain a `PR <n>` reference

## Verification

`pytest tests/test_calibrate.py` — 21 passed (new test fails on the pre-fix code, passes after). `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)