### PR TITLE
feat: vision-inference extension (consume pretrained/hosted vision models)

### DIFF
--- a/extensions/vision-inference/README.md
+++ b/extensions/vision-inference/README.md
@@ -1,0 +1,70 @@
+# Vision Inference Extension
+
+## Purpose
+
+The `vision-inference` extension adds governed architecture contracts for
+applications that **consume** pretrained or hosted vision models — classification,
+detection, segmentation, OCR, and (in a later increment) generative / vision-language
+models — rather than train them.
+
+It layers on top of the core `--type api` / `--type cli` ports-and-adapters
+governance. The consumed model is an **outbound dependency behind a port**; this
+extension governs the concerns that consumption adds:
+
+- the model behind a swappable adapter/port (this increment)
+- external-model version pinning + drift detection
+- biometric data handling (sending images — faces — to a third party)
+- black-box acceptance evaluation on a held-out set
+- PII-safe prediction logging
+
+> **Scope boundary.** Training-time concerns (datasets, augmentation, the training
+> loop, leakage, reproducibility) belong to the `cv` *project type*, not this
+> extension. See `plans/CV_TYPE_PLAN.md` and `plans/VISION_INFERENCE_EXTENSION_PLAN.md`.
+
+## How extensions live in a project
+
+Extensions are **not installed by the govkit CLI**. They live in-place under the
+root-level `extensions/` folder of a consuming project, as a sibling of `docs/`,
+`governance/`, and `features/`. Govkit discovers them by scanning
+`extensions/*/manifest.yaml` during `apply` (for visibility) and `validate` (for
+compliance). All artifact paths in `manifest.yaml` are resolved relative to the
+extension folder.
+
+## Intended use
+
+Use this extension when a system consumes a vision model it does not train — e.g.
+a hosted vision API, a self-hosted inference server (Triton/TorchServe), or a
+loaded pretrained checkpoint used only for prediction.
+
+## Contract set
+
+Architecture contracts live under
+`extensions/vision-inference/docs/backend/architecture/`:
+
+- `VISION_MODEL_ADAPTER_CONTRACT.md` — the model behind an outbound port; SDK
+  confined to the adapter; providers swappable; deterministic preprocessing.
+- `MODEL_VERSIONING_CONTRACT.md` — pin `model_id` + `model_version`; record it per
+  prediction; drift detection; defined rollback.
+- `INFERENCE_ACCEPTANCE_CONTRACT.md` — black-box acceptance eval on a frozen
+  held-out set; per-class + per-slice metrics; re-gate on any behavior-moving
+  change; confidence-threshold + human-in-the-loop policy.
+- `BIOMETRIC_DATA_HANDLING_CONTRACT.md` — special-category handling for images of
+  people; consent/residency/retention declared as policy; never log the raw
+  payload.
+- `PREDICTION_LOGGING_CONTRACT.md` — structured, PII-safe prediction records with
+  model provenance, confidence, latency, and cost.
+
+### Generative / VLM contract set (`vision_generative`)
+
+For vision-language models (Claude vision, GPT-4V) and image generation:
+
+- `MULTIMODAL_INPUT_CONTRACT.md` — image-as-untrusted-instruction-channel
+  (prompt-injection-via-image), generated-output validation, and the biometric
+  obligations that still apply. **Reuses** the L5 GenAI-Ops contracts via
+  `relates_to.extends` (guardrails, eval-as-judge, LLM observability, gateway)
+  rather than reinventing them — so this set is intended for L5-governed projects.
+
+Schemas live under `extensions/vision-inference/schemas/`:
+
+- `prediction-record.schema.json` — the per-prediction provenance record consumed
+  by the acceptance gate and prediction logging.

--- a/extensions/vision-inference/docs/backend/architecture/BIOMETRIC_DATA_HANDLING_CONTRACT.md
+++ b/extensions/vision-inference/docs/backend/architecture/BIOMETRIC_DATA_HANDLING_CONTRACT.md
@@ -1,0 +1,67 @@
+# Biometric Data Handling Contract
+
+**Applies to:** any vision-consumption path where images may contain **biometric or
+personal data** (faces, gait, license plates, identifiable persons) — especially
+when those images leave the trust boundary to a third-party or hosted model.
+
+> This is the genuinely vision-specific risk of *consuming* models. Sending an
+> image to a hosted API is sending potentially special-category personal data to a
+> third party. This contract sets the principles; the specific values
+> (jurisdiction, retention window, residency region) are **team policy** declared in
+> configuration, not invented here.
+
+---
+
+## 1. Treat biometric data as special category
+
+- Images that may contain biometric/personal data are classified and handled as a
+  **special category** from ingestion onward — not discovered late at the API
+  boundary.
+- The classification (does this path handle biometric data?) is explicit in the
+  feature's `architecture_preflight.md`.
+
+## 2. Declare, don't assume, the policy
+
+The following are **declared in configuration** (and surfaced for review), not
+hard-coded or left implicit:
+
+- **Lawful basis / consent** — the basis for processing these images, and how
+  consent (where required) is captured and revocable.
+- **Residency region** — where images and predictions may be processed/stored.
+- **Retention window** — how long images and prediction records are kept before
+  deletion; defaults to the shortest viable.
+- **Third-party transmission** — which providers may receive images, and what their
+  data-use/retention terms are.
+
+A vision-consumption path that transmits biometric data to a provider not covered
+by a declared policy is blocked.
+
+## 3. Minimize and redact
+
+- Send the **minimum** necessary: prefer on-device/edge filtering, cropping to the
+  region of interest, or redaction before transmission where the use-case allows.
+- Never persist raw biometric images beyond the declared retention window; prefer a
+  reference or hash over the raw bytes wherever the workflow permits.
+
+## 4. Never log the raw payload
+
+- Raw biometric images **must not** appear in logs, traces, error reports, or
+  prediction records. The prediction record references the input by id/hash only
+  (see `PREDICTION_LOGGING_CONTRACT.md` and `prediction-record.schema.json`).
+
+## 5. Right to erasure
+
+- Deletion of a subject's images and associated prediction records is supported and
+  propagates to any retained derivatives, within the declared window.
+
+## 6. What requires an ADR
+
+- Transmitting biometric data to a provider/region not in the declared policy.
+- Retaining raw biometric images beyond the declared retention window.
+- Processing biometric data with no declared lawful basis/consent.
+
+## 7. Anti-patterns
+
+- Uploading full frames to a hosted API when only a cropped region is needed.
+- A face image landing in an exception log or an APM trace.
+- "We'll figure out retention later" — retention undeclared while data accumulates.

--- a/extensions/vision-inference/docs/backend/architecture/INFERENCE_ACCEPTANCE_CONTRACT.md
+++ b/extensions/vision-inference/docs/backend/architecture/INFERENCE_ACCEPTANCE_CONTRACT.md
@@ -1,0 +1,63 @@
+# Inference Acceptance Contract
+
+**Applies to:** consumption of a pretrained or hosted vision model. Governs how a
+**black-box** model — one you cannot retrain — is acceptance-tested on *your* data
+before and after every change that can move its behavior.
+
+> You cannot improve a consumed model, but you are still accountable for its
+> behavior in your system. The lever you do control is a held-out acceptance set
+> and a gate that re-runs when the model, provider, or preprocessing changes.
+
+---
+
+## 1. A frozen acceptance set
+
+- Maintain a **held-out acceptance set** representative of production inputs, with
+  ground-truth labels, kept stable so results are comparable over time.
+- It is evaluated as a **black box** — inputs in, predictions out — through the same
+  adapter and preprocessing production uses.
+- The set's contents and version are recorded; changing it is a reviewed change.
+
+## 2. Metrics are per-class and per-slice — never a single scalar
+
+- Report metrics **per class** and across **slices** (lighting, resolution,
+  occlusion, and — where biometric — demographic cohorts). Aggregate accuracy can
+  rise while a safety-critical class or cohort collapses.
+- Pin the **eval protocol** with the numbers: confidence threshold, IoU threshold,
+  NMS settings, max detections. Metrics are uncomparable without it.
+- Record results against the consumed `model_id` + `model_version`
+  (`MODEL_VERSIONING_CONTRACT.md`) and the acceptance-set version.
+
+## 3. Re-gate on every behavior-moving change
+
+The acceptance gate runs — and must pass — when any of these change:
+
+- the `model_id` / `model_version`,
+- the provider or adapter,
+- the boundary preprocessing,
+- a detected drift in a hosted model.
+
+A regression beyond the agreed tolerance band blocks the change.
+
+## 4. Confidence-threshold decision policy + human-in-the-loop
+
+- The system declares **what it does with low-confidence predictions**: a confidence
+  threshold per class/use-case, and a defined **human-in-the-loop** path for
+  predictions below it or in high-stakes cases.
+- The decision taken (accepted / rejected / routed-to-human) is recorded in the
+  prediction record so the policy is auditable.
+
+## 5. What requires an ADR
+
+- Shipping a model/provider/preprocessing change without passing the acceptance
+  gate.
+- Gating on aggregate metrics only, with no per-class/per-slice breakdown.
+- Auto-accepting low-confidence predictions in a high-stakes path with no
+  human-in-the-loop.
+
+## 6. Anti-patterns
+
+- "Accuracy is 94%" with no per-class or per-slice view.
+- Comparing this week's metric to last week's without pinning the model version or
+  eval protocol.
+- A demographic cohort silently regressing because only the aggregate was watched.

--- a/extensions/vision-inference/docs/backend/architecture/MODEL_VERSIONING_CONTRACT.md
+++ b/extensions/vision-inference/docs/backend/architecture/MODEL_VERSIONING_CONTRACT.md
@@ -1,0 +1,60 @@
+# Model Versioning Contract
+
+**Applies to:** consumption of a pretrained or hosted vision model behind the
+adapter defined in `VISION_MODEL_ADAPTER_CONTRACT.md`. Governs how the consumed
+model's identity and version are pinned, recorded, and watched for drift.
+
+> A hosted model can change *under you* with no code change on your side. An
+> unpinned, unrecorded model version makes every prediction unreproducible and
+> every regression invisible.
+
+---
+
+## 1. Pin the model + version
+
+- The consumed model is selected by an explicit **`model_id` + `model_version`**
+  from configuration (`configs/`), never an implicit "latest".
+- Where a provider does not expose a stable version, pin the **narrowest
+  identifier they offer** (endpoint/model revision, container image digest for a
+  self-hosted server, checkpoint hash for a local artifact) and record it.
+- A change to `model_id` or `model_version` is a reviewed change (PR + the
+  acceptance gate in `INFERENCE_ACCEPTANCE_CONTRACT.md`), not a silent config edit.
+
+## 2. Record the version with every prediction
+
+- Every prediction emits a record conforming to
+  `schemas/prediction-record.schema.json`, carrying `model_id` + `model_version`
+  (and `model_provider` where applicable).
+- This is what makes a result reproducible and lets you attribute a metric shift
+  to a specific model version.
+
+## 3. Detect drift
+
+- For hosted models that can change server-side, the system MUST be able to detect
+  that the model moved: monitor the provider's reported version where exposed, and
+  watch the acceptance metrics (`INFERENCE_ACCEPTANCE_CONTRACT.md`) on a canary
+  set for unexplained shifts.
+- A detected drift raises an alert and is treated as a version change — re-run the
+  acceptance gate before continuing to trust outputs.
+
+## 4. Rollback is defined, not improvised
+
+- The previous known-good `model_id` + `model_version` is recoverable, and the
+  adapter can be pointed back to it via configuration.
+- Rollback criteria (which acceptance regressions trigger it) are written down, not
+  decided in the moment.
+
+## 5. What requires an ADR
+
+- Consuming a model by a mutable "latest"/"stable" alias instead of a pinned
+  version.
+- Shipping a `model_version` change without running the acceptance gate.
+- Disabling drift monitoring for a hosted model that can change server-side.
+
+## 6. Anti-patterns
+
+- `model = "general-detector"` with no version recorded.
+- A metric regression that can't be tied to a model version because none was
+  logged.
+- Discovering a provider silently upgraded the model only after downstream
+  behavior broke.

--- a/extensions/vision-inference/docs/backend/architecture/MULTIMODAL_INPUT_CONTRACT.md
+++ b/extensions/vision-inference/docs/backend/architecture/MULTIMODAL_INPUT_CONTRACT.md
@@ -1,0 +1,69 @@
+# Multimodal Input Contract
+
+**Applies to:** consumption of a **generative / vision-language model** (a VLM such
+as Claude vision or GPT-4V, or image generation / diffusion). This is the net-new,
+vision-specific contract for generative consumption — everything else reuses the L5
+GenAI-Ops contracts (see "Relationship to L5" below).
+
+> A generative vision model takes **image + text** and produces **content**. That
+> doubles the attack and quality surface versus a discriminative model: the image is
+> now an *instruction channel*, and the output is generated content that must be
+> guarded and evaluated — not a bounded label set.
+
+---
+
+## 1. The image is an untrusted instruction channel
+
+- Treat image inputs to a VLM as **untrusted instructions**, not just data.
+  **Prompt-injection-via-image** (text embedded in the image, adversarial overlays,
+  steganographic instructions) can override the system prompt.
+- The system prompt and developer instructions are isolated from user-supplied
+  image/text content; user content can never be promoted to system authority.
+- Image provenance/size/format expectations are validated at the boundary before the
+  call (consistent with `VISION_MODEL_ADAPTER_CONTRACT.md` preprocessing).
+
+## 2. Validate generated output before use
+
+- Generated text/images are **validated before** they are surfaced or acted on —
+  never trusted verbatim. Structured outputs are schema-checked; free-form outputs
+  pass the guardrail checks in §4.
+- Generated **images** are themselves subject to the safety checks below (a VLM/
+  diffusion model can produce unsafe or infringing content).
+
+## 3. Multimodal inputs carry the biometric obligations
+
+- An image sent to a hosted VLM is still potentially biometric/personal data —
+  `BIOMETRIC_DATA_HANDLING_CONTRACT.md` applies in full (consent, residency,
+  retention, minimize, never log raw payload). Sending a face to a VLM is sending it
+  to a third party exactly as with a discriminative API.
+
+## 4. Relationship to L5 (reuse, don't reinvent)
+
+This contract **extends**, and does not duplicate, the core L5 GenAI-Ops contracts
+(declared in the manifest's `relates_to.extends`):
+
+- `GUARDRAILS_CONTRACT.md` — input/output safety (NSFW, unsafe, infringing content)
+  applies to image+text prompts and to generated images/text.
+- `EVALUATION_LLM_CONTRACT.md` — eval-as-judge for open-ended VLM output replaces the
+  bounded per-class acceptance metrics used for discriminative models.
+- `OBSERVABILITY_LLM_CONTRACT.md` — generation logging/tracing (PII-safe; never the
+  raw image).
+- `LLM_GATEWAY_CONTRACT.md` — hosted VLM calls route through the governed gateway.
+
+If a project does not have the L5 contracts installed, this contract set's
+`relates_to.extends` paths will be missing and `govkit doctor` / `validate` will flag
+them — the generative layer is meant for L5-governed projects.
+
+## 5. What requires an ADR
+
+- Passing user-supplied image/text into a position that can override system
+  instructions.
+- Surfacing or acting on generated output with no validation/guardrail pass.
+- Sending images to a VLM without satisfying `BIOMETRIC_DATA_HANDLING_CONTRACT.md`.
+
+## 6. Anti-patterns
+
+- Concatenating a user's caption request into the system prompt.
+- Rendering a model-generated image to end users without a safety check.
+- Treating "it's just an image" as exempt from biometric handling because the model
+  is generative.

--- a/extensions/vision-inference/docs/backend/architecture/PREDICTION_LOGGING_CONTRACT.md
+++ b/extensions/vision-inference/docs/backend/architecture/PREDICTION_LOGGING_CONTRACT.md
@@ -1,0 +1,56 @@
+# Prediction Logging Contract
+
+**Applies to:** observability of vision-consumption paths. Governs what is recorded
+for each prediction so the system is debuggable, auditable, and cost-aware —
+**without** logging raw biometric payloads.
+
+> Builds on the core `OBSERVABILITY_PORT_CONTRACT` of the `api`/`cli` type. This
+> contract adds the vision-consumption specifics: model provenance, confidence, and
+> PII-safe handling of image inputs.
+
+---
+
+## 1. Emit a structured prediction record
+
+- Each prediction emits a structured record conforming to
+  `schemas/prediction-record.schema.json`.
+- It captures, at minimum: `model_id` + `model_version` (provenance),
+  `outputs` with `confidence`, the `decision` taken, `latency_ms`, and `cost`
+  where metered.
+- Logging is **structured** (queryable fields), not free-text — so questions like
+  "p95 latency for model X last week" or "low-confidence rate per class" are
+  answerable.
+
+## 2. Reference the input — never the raw image
+
+- The record references the input by **id or content hash** (`input_ref`), never the
+  raw image bytes. Raw biometric/personal images must not enter logs, traces, or
+  error reports (`BIOMETRIC_DATA_HANDLING_CONTRACT.md`).
+- Where an image must be retained for debugging, it is stored in the governed data
+  store under the declared retention/residency policy — not in the log stream.
+
+## 3. Make provenance and decisions queryable
+
+- `model_id` + `model_version` on every record enables attributing a behavior shift
+  to a model version and supports drift detection
+  (`MODEL_VERSIONING_CONTRACT.md`).
+- The recorded `decision` + `confidence` makes the confidence-threshold policy
+  (`INFERENCE_ACCEPTANCE_CONTRACT.md`) auditable after the fact.
+
+## 4. Capture cost and latency
+
+- Per-prediction `latency_ms` and, for metered providers, `cost` are recorded so
+  the external-model dependency's operational footprint is visible and bounded.
+
+## 5. What requires an ADR
+
+- Logging raw image bytes (biometric or otherwise) into the log/trace stream.
+- Emitting predictions with no model-version provenance.
+- Free-text-only logging that can't answer per-class/per-model operational
+  questions.
+
+## 6. Anti-patterns
+
+- A debug log line containing a base64 image.
+- Prediction logs that record the output but not which model version produced it.
+- Cost/latency of the hosted model invisible until the invoice arrives.

--- a/extensions/vision-inference/docs/backend/architecture/VISION_MODEL_ADAPTER_CONTRACT.md
+++ b/extensions/vision-inference/docs/backend/architecture/VISION_MODEL_ADAPTER_CONTRACT.md
@@ -1,0 +1,70 @@
+# Vision Model Adapter Contract
+
+**Applies to:** projects that **consume** a pretrained or hosted vision model
+(classification, detection, segmentation, OCR) rather than train one. Layers on
+top of the core `--type api` / `--type cli` ports-and-adapters governance — the
+consumed model is just an **outbound dependency behind a port**.
+
+> This contract governs *consumption*. Training-time concerns (datasets,
+> augmentation, the training loop, leakage, reproducibility) are out of scope —
+> they belong to the `cv` project type, not this extension.
+
+---
+
+## 1. The model is an outbound port, not a leaked dependency
+
+- The consumed model — hosted (AWS Rekognition, GCP/Azure Vision) or self-hosted
+  (Triton, TorchServe, a local checkpoint) — sits behind a single **outbound
+  port** (interface) defined in the domain/services layer.
+- The vendor SDK / HTTP client / framework runtime is **confined to one adapter**
+  that implements the port. No `boto3`, `google.cloud.vision`, `tritonclient`,
+  `torch`, or `tensorflow` import may appear in services, domain, or API layers.
+- The port speaks the **domain's** vocabulary (e.g. `detect(image) -> [Detection]`),
+  never the provider's response shape. Mapping provider payloads → domain types is
+  the adapter's job.
+
+**Why:** providers change, get deprecated, or get swapped for cost/latency/accuracy.
+A leaked SDK type turns a provider swap into a refactor of the whole codebase.
+
+## 2. Providers are swappable by construction
+
+- Adding or replacing a provider means writing a new adapter against the existing
+  port — **no change to services, domain, or API**.
+- Provider selection is configuration, not code (`configs/`), and is injected at
+  the composition root. No hard-coded provider branch inside business logic.
+- A test double implementing the same port MUST be usable in unit tests without
+  any network or GPU.
+
+## 3. Deterministic preprocessing at the boundary
+
+- Image preprocessing the provider requires (resize, normalization, **color space
+  — RGB vs BGR**, channel order, encoding) is **deterministic** and lives in the
+  adapter (or a shared preprocessing module the adapter imports).
+- The exact preprocessing applied is recorded with the prediction (see the
+  prediction logging contract) so a result can be reproduced.
+
+## 4. Resilience is the adapter's responsibility
+
+- Every outbound call has an explicit **timeout**; failures surface as a domain
+  error type, never a raw provider exception.
+- Retries (with backoff) and any fallback/degraded path are defined in the adapter
+  and are **observable** — a fallback that silently returns lower-quality results
+  is forbidden.
+- Rate limits and cost ceilings are handled at the adapter boundary, not scattered
+  through callers.
+
+## 5. What requires an ADR
+
+- Importing a provider SDK anywhere outside its adapter.
+- Letting a provider response type cross the port into services/domain.
+- A provider-specific branch inside business logic.
+- A silent fallback between providers or models that changes prediction quality
+  without surfacing it.
+
+## 6. Anti-patterns
+
+- A service that calls `rekognition.detect_labels(...)` directly.
+- A domain object shaped like a provider's JSON response.
+- Preprocessing duplicated (and drifting) between the adapter and a notebook.
+- An adapter that swallows a timeout and returns an empty detection list as if the
+  image contained nothing.

--- a/extensions/vision-inference/manifest.yaml
+++ b/extensions/vision-inference/manifest.yaml
@@ -1,0 +1,71 @@
+id: vision-inference
+name: Vision Inference Extension
+version: 0.1.0
+description: Governed architecture contracts for applications that CONSUME pretrained or hosted vision models (discriminative and, later, generative/VLM) behind a port — versioning, biometric data handling, black-box acceptance eval, and prediction logging.
+govkit_min_version: 0.0.0
+extension_type: architecture
+supported_levels:
+  - 4
+  - 5
+supported_project_types:
+  - api
+  - cli
+
+contract_sets:
+  - id: vision_inference
+    description: Discriminative vision consumption — the model lives behind an adapter/port, with version pinning + drift detection, biometric data handling, black-box acceptance eval on a held-out set, and PII-safe prediction logging.
+    paths:
+      - docs/backend/architecture/VISION_MODEL_ADAPTER_CONTRACT.md
+      - docs/backend/architecture/MODEL_VERSIONING_CONTRACT.md
+      - docs/backend/architecture/INFERENCE_ACCEPTANCE_CONTRACT.md
+      - docs/backend/architecture/BIOMETRIC_DATA_HANDLING_CONTRACT.md
+      - docs/backend/architecture/PREDICTION_LOGGING_CONTRACT.md
+    applies_to:
+      - "**/*vision*"
+      - "**/*ocr*"
+      - "**/*detect*"
+      - "**/*classify*"
+      - "**/*predict*"
+      - "**/*inference*"
+    capabilities:
+      - vision-model-adapter
+      - external-model-versioning
+      - biometric-data-handling
+      - black-box-acceptance-eval
+      - prediction-observability
+
+  - id: vision_generative
+    description: Generative / vision-language consumption (VLMs such as Claude vision or GPT-4V, and image generation / diffusion). Adds multimodal input governance and REUSES the L5 GenAI-Ops contracts (guardrails, eval-as-judge, LLM observability, gateway) via relates_to.extends rather than reinventing them.
+    paths:
+      - docs/backend/architecture/MULTIMODAL_INPUT_CONTRACT.md
+    applies_to:
+      - "**/*vlm*"
+      - "**/*caption*"
+      - "**/*multimodal*"
+      - "**/*generate*"
+      - "**/*diffusion*"
+    capabilities:
+      - multimodal-input
+      - prompt-injection-via-image-defense
+      - generative-output-validation
+    relates_to:
+      extends:
+        - docs/backend/architecture/GUARDRAILS_CONTRACT.md
+        - docs/backend/architecture/EVALUATION_LLM_CONTRACT.md
+        - docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md
+        - docs/backend/architecture/LLM_GATEWAY_CONTRACT.md
+
+agent_guidance:
+  architecture_preflight:
+    - Read this extension manifest when present under extensions/*/manifest.yaml.
+    - Load the vision_inference contract set when a feature consumes a pretrained or hosted vision model (classification, detection, OCR, or a hosted vision API).
+    - List applicable extension contracts in architecture_preflight.md.
+    - Require an ADR for any override or violation of these contracts.
+  implementation_plan:
+    - Confine the vendor/model SDK to a single adapter behind a port; keep services and domain free of provider types.
+    - Pin the consumed model id + version and record it with every prediction.
+    - For any image leaving the trust boundary, satisfy the biometric data-handling contract before sending.
+  validation:
+    - Validate that declared contract files exist after apply.
+    - Validate that architecture_preflight.md cites applicable extension contracts.
+    - Validate that ADRs exist for approved contract exceptions.

--- a/extensions/vision-inference/schemas/prediction-record.schema.json
+++ b/extensions/vision-inference/schemas/prediction-record.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Vision Inference Prediction Record",
+  "description": "Per-prediction provenance record emitted by a vision-model adapter. The object the acceptance-eval gate and prediction logging both consume. Records model identity + version, the (referenced, never raw) input, the preprocessing applied, outputs with confidence, the decision taken, and slice tags for disaggregated evaluation.",
+  "type": "object",
+  "required": ["model_id", "model_version", "outputs"],
+  "additionalProperties": true,
+  "properties": {
+    "prediction_id": {
+      "type": "string",
+      "description": "Stable id for this prediction (for correlation in logs/traces)."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "model_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identity of the consumed model (provider model name or local artifact id)."
+    },
+    "model_version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Pinned version/revision of the consumed model. Required so a result is reproducible and drift is detectable."
+    },
+    "model_provider": {
+      "type": "string",
+      "description": "Provider/runtime behind the adapter (e.g. aws-rekognition, triton, local)."
+    },
+    "input_ref": {
+      "type": "string",
+      "description": "Reference or content hash of the input image — NEVER the raw image bytes (see BIOMETRIC_DATA_HANDLING_CONTRACT and PREDICTION_LOGGING_CONTRACT)."
+    },
+    "preprocessing": {
+      "type": "object",
+      "description": "Deterministic preprocessing applied at the adapter boundary (resize, normalization, color space). A hash or explicit descriptor so the result is reproducible.",
+      "additionalProperties": true
+    },
+    "outputs": {
+      "type": "array",
+      "description": "Model outputs. Each carries a label and a confidence so decision policy and per-class metrics are computable.",
+      "items": {
+        "type": "object",
+        "required": ["label", "confidence"],
+        "additionalProperties": true,
+        "properties": {
+          "label": {"type": "string"},
+          "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+          "bbox": {
+            "type": "array",
+            "items": {"type": "number"},
+            "description": "Optional [x, y, w, h] or [x1, y1, x2, y2] per the adapter's documented convention."
+          }
+        }
+      }
+    },
+    "decision": {
+      "type": "string",
+      "description": "What the system did with the prediction (accepted, rejected, routed-to-human) per the confidence-threshold policy."
+    },
+    "slice_tags": {
+      "type": "object",
+      "description": "Tags enabling disaggregated (per-slice) evaluation — e.g. lighting, resolution, demographic cohort. Keys are team-defined.",
+      "additionalProperties": {"type": "string"}
+    },
+    "latency_ms": {"type": "number", "minimum": 0},
+    "cost": {"type": "number", "minimum": 0}
+  }
+}

--- a/extensions/vision-inference/schemas/prediction-record.schema.json
+++ b/extensions/vision-inference/schemas/prediction-record.schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Vision Inference Prediction Record",
-  "description": "Per-prediction provenance record emitted by a vision-model adapter. The object the acceptance-eval gate and prediction logging both consume. Records model identity + version, the (referenced, never raw) input, the preprocessing applied, outputs with confidence, the decision taken, and slice tags for disaggregated evaluation.",
+  "description": "Per-prediction provenance record emitted by a vision-model adapter. The object the acceptance-eval gate and prediction logging both consume. Records model identity + version, the (referenced, never raw) input, the preprocessing applied, outputs with confidence, the decision taken, and slice tags for disaggregated evaluation. additionalProperties is false so a raw payload (e.g. raw_image / image_base64) cannot be smuggled into the record; team-specific metadata belongs in slice_tags.",
   "type": "object",
-  "required": ["model_id", "model_version", "outputs"],
-  "additionalProperties": true,
+  "required": ["model_id", "model_version", "input_ref", "outputs"],
+  "additionalProperties": false,
   "properties": {
     "prediction_id": {
       "type": "string",

--- a/plans/CV_TYPE_PLAN.md
+++ b/plans/CV_TYPE_PLAN.md
@@ -1,0 +1,194 @@
+# CV Type: Governed Computer-Vision Model Development
+
+**Status:** Plan only — no implementation yet.
+**Author:** govkit working group
+**Created:** 2026-06-05
+**Target version:** govkit v0.12.0 (current v0.11.1 per release history)
+**Precedent:** `--type data` + the `python-dbt` stack overlay (v0.10.x–v0.11.x) — this plan mirrors that pairing.
+
+---
+
+## 1. Summary
+
+Add a new project shape **`--type cv`** for computer-vision model development, paired with a **`python-tensorflow-vision`** stack overlay. The type imposes a separation-of-concerns contract on CV code — the discipline CV developers (and the agents writing for them) routinely collapse into a single leakage-prone notebook — and enforces the highest-value boundaries in CI.
+
+Scope is **discriminative vision** (classify / detect / segment) for two user profiles: **training from scratch** and **fine-tuning pretrained backbones**. Inference-only consumption is out of scope (that's closer to `--type api` with a model-adapter port). Generative / multimodal vision is explicitly deferred — see §7.
+
+**Ship L3 + L4 now. Defer L5.** L3 is the SoC spine; L4 adds the eval-regression + leakage gate, which is where CV maps onto govkit unusually well. L5 today is GenAI-Operations-shaped (LLM gateway, guardrails, prompt eval) and does **not** fit discriminative CV; a CV "Model Operations" L5 is a separate, later decision gated on the generative-vs-discriminative question.
+
+### Why this is a good fit for govkit
+
+govkit's value scales with the gap between what an agent produces *by default* and what a disciplined practitioner produces. For CV that gap is unusually wide: the agent's training data is saturated with single-file, leakage-prone tutorial/Kaggle code, so an unconstrained agent confidently reproduces exactly those anti-patterns. Path-scoped rules constrain the agent **at generation time**, and CI gates convert tacit CV discipline ("never augment the eval path", "split by group key") into mechanical feedback an agentic loop can iterate against.
+
+**Boundary of the claim (state it honestly):** govkit raises the floor on engineering discipline, reproducibility, and leakage prevention. It does **not** raise the floor on modeling judgment or production data quality. An agent can produce a clean, provenance-tracked pipeline that still picks the wrong augmentation policy or trains a model that doesn't converge. The pitch is "structurally sound, reproducible, leak-resistant CV code," not "a good ML researcher."
+
+---
+
+## 2. Canonical project layout (the contract's backbone)
+
+Each directory is a seam CV developers routinely collapse. Every boundary below is a path-scoped rule + a cheap CI check.
+
+```
+data/                # versioned datasets — DVC/pointer + recorded hash; never committed blobs
+configs/             # hyperparams + eval protocol as DATA (yaml), not literals in code
+src/
+  preprocessing/     # SINGLE source of truth for deterministic transforms (resize, normalize,
+                     #   color-space). Imported by BOTH datasets/ AND inference/ — never duplicated.
+  datasets/          # loading + split assembly; imports preprocessing/, may NOT import models/
+  augment/           # stochastic augmentation ONLY — train split only; co-transforms labels
+  models/            # architecture definitions ONLY — no optimizer, no data I/O, no fit/loop
+  training/          # the loop / compile+fit; owns optimizer+schedule; imports models/, never defines
+  evaluation/        # sole toucher of the TEST split; writes metrics+provenance artifact
+  inference/         # loads a trained artifact; imports preprocessing/, never training/
+labels/              # annotation source-of-truth + versioned class taxonomy (COCO/YOLO/VOC/masks)
+notebooks/           # orchestration + visualization ONLY — import from src/, never define pipeline
+```
+
+Two structural corrections that distinguish this from a naive layout (both are common production failures):
+
+- **`preprocessing/` is shared, not duplicated.** Train/serve preprocessing skew (resize/normalize/**RGB-vs-BGR**) is the #1 CV production bug. Normalization is *not* augmentation; it must live in shared `preprocessing/` imported by both `datasets/` and `inference/`. Augmentation is stochastic and train-only (TTA is the explicit carve-out).
+- **`labels/` is first-class.** In CV the labels *are* the product. Annotation format, class taxonomy (as versioned data), and consistency checks get their own seam and rule.
+
+---
+
+## 3. L3 — the SoC spine (path-scoped rules)
+
+Mirrors `rules/data/*` (one rule per seam, `paths_template` + `paths` frontmatter). Authored once, shipped identically to all three agents (§6).
+
+| Rule file | Enforced boundary (CI-checkable) |
+|---|---|
+| `rules/cv/preprocessing.md` | Deterministic transforms only; the single import target for both `datasets/` and `inference/` |
+| `rules/cv/datasets.md` | Loading + split assembly; no `import models`; **group/temporal/near-dup-aware splitting** |
+| `rules/cv/augment.md` | Stochastic aug; train-split only (TTA carve-out); **must co-transform boxes/masks** |
+| `rules/cv/models.md` | Architecture defs only — no optimizer, no `DataLoader`/`tf.data`, no `fit`/train loop |
+| `rules/cv/training.md` | Owns loop / `compile`+`fit`; imports `models/`, never defines; sets seeds; writes checkpoint + metrics |
+| `rules/cv/evaluation.md` | Sole toucher of the **test** split; pins eval protocol; emits metrics+provenance artifact |
+| `rules/cv/inference.md` | Loads artifact; imports `preprocessing/`, never `training/`; preprocessing identical to train |
+| `rules/cv/labels.md` | Annotation consistency (every image labeled, IDs in range, bboxes in-bounds, no degenerate boxes); taxonomy as versioned data |
+| `rules/cv/reproducibility.md` | Seeds + recorded env (CUDA/cuDNN/TF) + dataset hash; **bounded** nondeterminism (not bit-exact); config-as-data |
+| `rules/cv/notebooks.md` | `.ipynb` may not define an `nn`/Keras model or a train loop — visualization/exploration is fine |
+
+Reused generic rules at L3: `rules/generic/repo-scope-backend.md`. Reused at L4: `test-first.md`, `spec-compliance.md`.
+
+**Reuse from the `data` type:** vision datasets routinely contain faces = biometric PII, so `rules/data/pii.md` and `data-quality.md` concepts port directly. Decide at build time whether to reuse-by-reference or fork CV-specific copies.
+
+### Governed architecture contracts (`docs/cv/architecture/`)
+
+Mirrors `docs/data/architecture/`:
+
+- `ARCH_CONTRACT.md` — top-level shape
+- `BOUNDARIES.md` — the layer directionality rules (preprocessing shared; datasets→training→evaluation; inference isolated)
+- `DATA_SPLIT_CONTRACT.md` — **group / temporal / near-duplicate** leakage prevention; val vs test distinction; test-set immutability
+- `EVAL_CONTRACT.md` — per-class + sliced metrics, frozen eval protocol (IoU/NMS/score thresholds), noise band
+- `REPRODUCIBILITY_CONTRACT.md` — seeds, recorded env + dataset version, bounded determinism, artifact/checkpoint provenance
+- `LABEL_CONTRACT.md` — annotation schema, taxonomy versioning, consistency rules
+
+---
+
+## 4. L4 — the eval-regression + leakage gate (where CV shines)
+
+L4 adds `test-first` + `spec-compliance` rules, the spec-planning skills, a starter feature, and the CV-specific CI gate. CI **cannot retrain** (training is slow/GPU-bound), so the gate works like the `data` type's: it gates on a **committed artifact**, not a training run.
+
+### 4.1 The metrics+provenance artifact (the governed, agent-legible object)
+
+> Captured here per the earlier framing decision — this is a govkit-extending-into-ML gap, not a harness-vs-OpenAI gap, so it lives in this plan rather than `HARNESS_GAP_ROADMAP.md`. Promote to the roadmap only if the `data` type needs the same object.
+
+`evaluation/` emits a structured, versioned artifact (e.g. `evaluation/metrics.json` + schema in `governance/cv/schemas/`) recording:
+
+- **Per-class and per-slice metrics** — not just aggregate. Aggregate mAP can rise while a safety-critical rare class or demographic slice collapses; the gate must read the breakdown. This is also where the biometric/fairness story becomes real.
+- **Eval protocol** — IoU thresholds, NMS settings, score threshold, max detections. Metrics are uncomparable without it.
+- **Dataset version/hash** — the exact data the metric was computed on. In CV the data churns constantly; a metric without a data version can't be compared across PRs.
+- **Seed(s) + run variance** — mean±std across seeds so the gate can apply a **noise band** instead of failing on sub-noise deltas.
+
+### 4.2 The CI gate (`ci/{github,azure}/cv-eval-gate.yml`)
+
+1. Artifact exists and validates against the schema.
+2. Per-class / per-slice metrics meet thresholds declared in `eval_criteria.yaml` and **don't regress** beyond the noise band.
+3. **Leakage check** — train/test disjointness on **group keys + perceptual hashes**, not exact IDs (group/temporal/near-dup leakage; see §5).
+4. Eval protocol + dataset version recorded.
+
+Cheap pre-commit checks that *do* run in the agent's inner loop (high leverage because the heavy checks can't): folder-boundary import rules, "no model/loop defs in notebooks", config-as-data, label-bounds validation.
+
+### 4.3 Starter feature (`features/starter_cv/`)
+
+L3: `acceptance.feature`, `nfrs.md`, `plan.md`, `architecture_preflight.md`. L4 adds `eval_criteria.yaml` with **per-class** metric thresholds and a declared frozen test split — TF-targeted.
+
+---
+
+## 5. `python-tensorflow-vision` stack overlay
+
+TF-first per decision. Mirrors `cli/stacks/python-dbt/` (6 docs + `overlay.yaml`).
+
+- `TECH_STACK.md` — TF 2.x / Keras, `tf.data`, TF-Hub / KerasCV pretrained backbones, `torchmetrics`-equivalent (`keras.metrics` + COCO eval), TFRecord
+- `MODEL_LAYERING.md` — functional vs `Model`-subclass conventions; **the Keras friction (see below)**
+- `TRAINING_CONVENTIONS.md` — `compile`/`fit` vs custom `train_step`; callbacks; mixed precision
+- `AUGMENTATION.md` — KerasCV / `tf.image` / Albumentations; label-co-transforming for detection/segmentation
+- `EVALUATION.md` — per-class + sliced eval, COCO mAP/IoU, calibration (optional)
+- `REPRODUCIBILITY.md` — `tf.config.experimental.enable_op_determinism()`, `TF_DETERMINISTIC_OPS`, seed + env recording; SavedModel vs H5 artifact convention; TFRecord schema seam
+- `overlay.yaml` — `skill_context` (framework=tensorflow, eval libs, artifact format, source-folder hints), `default_assumptions`, `review_checklist`
+
+**Keras idiom friction — resolve explicitly.** The generic "`models/` defines architecture only, no training loop" rule fights Keras, where training conventionally lives inside the model via `compile()`/`fit()`. Resolution: `models/` builds the architecture (functional or subclass); `training/` owns `compile`/`fit`/`train_step` orchestration. State this in `MODEL_LAYERING.md` or TF developers will reject the contract.
+
+**Experiment tracking** (TensorBoard / W&B / MLflow) is the real system-of-record for runs, parallel to git. Reference a convention in the overlay; the metrics artifact (§4.1) is the *gated* projection of it.
+
+Follow-on overlay: `python-pytorch-vision` (same contract, different idioms).
+
+---
+
+## 6. Agent parity + wiring
+
+Per the parity invariant, every artifact ships identically across `claude-code`, `codex`, and `copilot`. A new type is ~3× the file count.
+
+Per agent: manifest `type.cv` variant (L3 `files`/`governed`, `level_4` merge block), `claude-md`/`agents-md`/`copilot-instructions` (`cv.md` + `l4-cv.md`), `rules/cv/*` (→ `.claude/rules/`, codex `rules/`, copilot `instructions/cv/*.instructions.md`), reused `skills/backend/*`. Manifest `options.type.choices` gains `"cv"`; `ci.{github,azure}.by_type` gains `cv` entries (L3 quality gate; L4 `cv-eval-gate.yml`).
+
+CLI/governance wiring: `overlay.yaml` discovered by `cli/overlay.py`; stack registered in `cli/stack_select.py` / `manifest.json options.stack`; `cli/detect.py` learns a TF-vision fingerprint; `cli/doctor.py` D006 picks up overlay versioning for free; `governance/cv/schemas/` for the metrics artifact schema. Test fixtures: `tests/fixtures/python-tf-vision/`.
+
+---
+
+## 7. Deferred: L5 and generative/multimodal
+
+L5 today installs LLM-gateway / guardrails / llm-evaluation / multi-agent — **generative-shaped**, a mismatch for a ResNet/YOLO. Two honest L5 paths, both later:
+
+- **Discriminative CV → new "Model Operations" L5**: drift monitoring, inference observability, human-in-the-loop review, rollback/versioning, robustness + fairness. Net-new authoring, not reuse.
+- **Generative/multimodal vision** (VLMs, diffusion, image-gen) → the *existing* GenAI-Ops L5 becomes genuinely relevant (safety/guardrail/eval-as-judge surfaces). Reuse is real there.
+
+Decision gate: confirm whether in-scope users are discriminative-only before any L5 work.
+
+---
+
+## 8. Staging (mirrors how data + python-dbt landed)
+
+- **PR 1 — `cv` type spine (L3):** manifest `type.cv`, `rules/cv/*`, `cv.md`, `docs/cv/architecture/*` contracts, `features/starter_cv/` (L3). Parity ×3. Tests.
+- **PR 2 — `python-tensorflow-vision` overlay:** 6 docs + `overlay.yaml`, `detect`/`doctor`/`stack_select` wiring, fixture.
+- **PR 3 — L4 eval-regression + leakage gate:** metrics-artifact schema, `cv-eval-gate.yml` (GitHub + Azure), `eval_criteria.yaml` starter, L4 manifest block + parity.
+
+Keep L4 lean initially (the `data` type shipped a deliberately thin L4) and grow it.
+
+---
+
+## 9. Open decisions
+
+1. ~~**Type name**~~ — **DECIDED: `cv`** (locked 2026-06-05; matches short existing types).
+2. **PII reuse** — reuse `data` type's `pii.md`/`data-quality.md` by reference, or fork CV-specific copies (faces = biometric is a stronger consent story than tabular PII).
+3. **Metrics-artifact format** — bespoke `metrics.json` schema vs adopting an existing model-card / eval format.
+4. **Discriminative-only confirmation** — gates the L5 question (§7).
+5. **DVC vs alternative** for the dataset-versioning convention in `data/`.
+
+---
+
+## 10. Tracking
+
+- [ ] PR 1: `cv` type spine (L3) — manifest, rules, contracts, starter, parity ×3, tests
+- [ ] PR 2: `python-tensorflow-vision` overlay + CLI/doctor/detect wiring + fixture
+- [ ] PR 3: L4 eval-regression + leakage gate + metrics-artifact schema + eval_criteria starter
+- [ ] Resolve §9 open decisions (name, PII reuse, artifact format, discriminative scope, DVC)
+- [ ] README: add `cv` to the type table + a short "governing CV" section
+- [ ] Follow-on: `python-pytorch-vision` overlay
+
+---
+
+## Related
+
+- Precedent pairing: `--type data` + `cli/stacks/python-dbt/`.
+- Runtime legibility for ML (model/eval-artifact legibility): [HARNESS_GAP_ROADMAP.md](HARNESS_GAP_ROADMAP.md) Initiative 2.
+- Heavyweight out-of-loop ML audits (perceptual-hash leakage, sliced-eval): [HARNESS_GAP_ROADMAP.md](HARNESS_GAP_ROADMAP.md) Initiative 1.

--- a/plans/HARNESS_GAP_ROADMAP.md
+++ b/plans/HARNESS_GAP_ROADMAP.md
@@ -1,0 +1,119 @@
+# Harness Gap Roadmap — Closing the Distance to OpenAI's Agent-First Harness
+
+> **Source of truth for this initiative.** Each issue and PR opened against the three gaps below must trace back to a section in this document. Generated 2026-06-04 from a comparison of govkit against OpenAI's ["Harness engineering: leveraging Codex in an agent-first world"](https://openai.com/index/harness-engineering/) (Feb 2026).
+
+## Context
+
+OpenAI's Harness Engineering post describes building and shipping an internal product with zero manually-written code over five months — agents write everything, humans steer. Read against govkit, the post is largely **independent validation**: their hard-won principles (repo as system of record, invariants over implementations, plans as first-class artifacts, agent legibility) are things govkit already ships as installable defaults.
+
+Three capabilities they describe have **no govkit equivalent yet**. None is a weakness in what govkit does today — govkit governs the *code*; these extend governance to *drift*, the *running system*, and *velocity evidence*. This roadmap captures them as three initiatives, prioritized, so they can be promoted into issues and PRs without losing the rationale.
+
+The framing matters for positioning: OpenAI explicitly warns their bespoke harness "should not be assumed to generalize without similar investment." govkit's job is to package the generalizable layer. Closing these three gaps moves govkit closer to being the portable version of what they built internally.
+
+---
+
+## Initiative 1 — Autonomous garbage collection ("govkit gardener")  ·  Priority: P1
+
+### Problem
+govkit defines the quality bar — FIRST principles and the 7 Code Virtues, scored 1–5 with a ≥ 4.0 floor — but **remediation of drift is entirely manual**. Agents replicate whatever patterns already exist in a repo, including uneven ones, so a governed repo still accumulates "AI slop" over time. Today nothing scans for it or pays it down.
+
+### What OpenAI does
+They encode opinionated "golden principles" into the repo and run a recurring set of background Codex tasks that scan for deviations, update quality grades, and open **targeted refactoring PRs** — most reviewable in under a minute and auto-merged. They frame technical debt as a high-interest loan: cheaper to pay down continuously than in painful bursts. Their team used to spend ~20% of every week (Fridays) cleaning up slop manually before this; it didn't scale.
+
+### Proposed approach
+A scheduled/agent-driven "gardener" that govkit installs and a team can run on a cadence (CI cron or local agent task):
+
+- A `docs/<area>/GOLDEN_PRINCIPLES.md` contract — opinionated, mechanical rules (e.g. prefer shared utility packages over hand-rolled helpers; validate boundaries, don't probe data shapes "YOLO-style").
+- A `/gardener` skill that scans the repo against FIRST / 7 Virtues + golden principles, updates a `docs/<area>/evaluation/QUALITY_SCORE.md` grade per domain/layer, and opens scoped refactoring PRs.
+- A CI workflow (`ci/github/gardener.yml` / Azure equivalent) to run it on a schedule and label/auto-merge low-risk fixes.
+- Golden-principles are authored **per type** (backend, ui, data, cv...). The gardener is also the right home for **heavyweight, out-of-inner-loop audits** — e.g. perceptual-hash train/test leakage scans and per-slice eval regressions for ML types — that are too slow to gate on every commit but compound if unwatched.
+
+### Rough sizing
+Medium. Reuses the existing FIRST / 7 Virtues rubrics and quality-grade concept; the new surface is the scanning skill, the golden-principles contract, and the scheduled CI job. Land in two PRs (contract + skill, then CI wiring).
+
+### Tracking
+- [ ] Draft `GOLDEN_PRINCIPLES.md` contract (backend + ui variants)
+- [ ] Add `QUALITY_SCORE.md` quality-grade artifact + schema
+- [ ] Build `/gardener` skill (scan → grade → scoped refactor PRs)
+- [ ] Add scheduled CI workflow with auto-merge for low-risk fixes
+- [ ] Document the cadence + review expectations in README
+
+### Done when
+A govkit-governed repo can run the gardener on a schedule, see per-domain quality grades update over time, and receive small auto-mergeable refactoring PRs without manual slop cleanup.
+
+---
+
+## Initiative 2 — Runtime legibility for the agent  ·  Priority: P1
+
+### Problem
+govkit makes the **code** legible to the agent (architecture contracts, path-scoped rules, specs). It does **not** make the **running system** legible. The agent governs what it can read statically, but cannot reproduce a bug, drive the app, or reason over live logs/metrics/traces. This is arguably the single biggest capability gap versus the OpenAI harness.
+
+### What OpenAI does
+They invested heavily in making the running app legible to Codex: the app is **bootable per git worktree** (one isolated instance per change); Chrome DevTools Protocol is wired into the agent runtime with skills for DOM snapshots, screenshots, and navigation; and a per-worktree ephemeral observability stack exposes logs (LogQL), metrics (PromQL), and traces (TraceQL). This lets prompts like "no span in these four critical journeys exceeds two seconds" become tractable, and lets the agent reproduce a bug, fix it, and validate the fix by driving the app — recording before/after videos.
+
+### Proposed approach
+This is the heaviest item and is best staged. govkit can't ship a universal runtime harness, but it can ship the **governed contract + skills** that standardize one:
+
+- A `docs/<area>/RUNTIME_LEGIBILITY_CONTRACT.md` defining what a govkit-governed project must expose to the agent (per-worktree boot, structured logs the agent can query, a metrics/trace endpoint).
+- A `/drive-app` skill family: boot the app for the current worktree, drive a UI path (DevTools/Playwright), capture before/after evidence, tear down.
+- An observability convention (structured logging is already a govkit taste invariant) extended to a queryable local stack the agent can read.
+- **Model/eval-artifact legibility (ML + data types):** for non-UI systems, "runtime" is the evaluation run. The agent should be able to read a structured metrics+provenance artifact (per-class/per-slice metrics, eval protocol, dataset version) and visual failure evidence (confusion matrix, failure-case montage) and iterate on the model. This is the ML analogue of driving the UI — CV is the forcing function; the `data` type benefits identically.
+- Stage 1 = contract + UI driving evidence; Stage 2 = log/metric/trace querying.
+
+### Rough sizing
+Large; stage it. Stage 1 (contract + UI driving + evidence capture) is a self-contained deliverable. Stage 2 (observability querying) depends on a reference stack and is a follow-on.
+
+### Tracking
+- [ ] Draft `RUNTIME_LEGIBILITY_CONTRACT.md` (what a project must expose)
+- [ ] Build `/drive-app` skill: per-worktree boot + UI drive + before/after evidence
+- [ ] Define structured-logging + local observability convention for agent querying
+- [ ] Stage 2: log/metric/trace query skills (LogQL/PromQL/TraceQL-equivalent)
+- [ ] Reference example wiring in `extensions/` or a sample repo
+
+### Done when
+A govkit-governed project can hand the agent a reported bug and have it reproduce, fix, and validate against the running app — at minimum for the UI path — with evidence attached to the PR.
+
+---
+
+## Initiative 3 — Throughput as a first-class metric  ·  Priority: P2
+
+### Problem
+govkit's framing is compliance-first. There is no instrumentation that shows governance **doesn't** tank velocity — which is the first objection a throughput-focused engineering leader will raise. We assert quality; we don't yet measure delivered pace inside the governed system.
+
+### What OpenAI does
+They treat human time and attention as the one scarce resource and measure throughput directly — PRs per engineer per day (3.5, and *increasing* as the team grew) — using it as the calculus for nearly every tradeoff (relaxed merge gates, agent-to-agent review, continuous GC).
+
+### Proposed approach
+Lighter than the other two, and high marketing/positioning value:
+
+- A `govkit metrics` command (or CI summary) that reports governed-delivery throughput: features/week through the L4 contract, CI gate pass rates, time-in-gate, gardener PRs merged.
+- A definition of "governed throughput" as the headline metric — pace *with* enforced gates, not raw PR count.
+- An optional dashboard artifact for teams to track it over time.
+
+### Rough sizing
+Small–medium. Mostly aggregation over existing `.govkit` markers, feature artifacts, and CI history.
+
+### Tracking
+- [ ] Define the "governed throughput" metric set
+- [ ] Add `govkit metrics` aggregation over `.govkit` + features + CI history
+- [ ] Optional: live dashboard artifact
+- [ ] Use the numbers in external positioning (governance ≠ slower)
+
+### Done when
+A govkit team can produce a credible governed-throughput number and trend, suitable for both internal review and external positioning.
+
+---
+
+## Prioritization summary
+
+| Initiative | Priority | Sizing | Why this order |
+|---|---|---|---|
+| 1 — Gardener | P1 | Medium | Highest leverage; reuses existing FIRST / 7 Virtues + quality-grade machinery. Closes a gap that actively compounds. |
+| 2 — Runtime legibility | P1 | Large (stage it) | Biggest capability gap, but heavy. Stage 1 (UI driving) ships independently; stage 2 follows. |
+| 3 — Throughput metrics | P2 | Small–medium | Lightest; strongest positioning payoff. Good fast-follow once 1 is moving. |
+
+## Related
+
+- Email to CTO summarizing the comparison: `govkit_vs_harness_email.docx` (repo root).
+- Source: OpenAI, ["Harness engineering: leveraging Codex in an agent-first world"](https://openai.com/index/harness-engineering/), Feb 2026.
+- Existing quality framework: FIRST principles + 7 Code Virtues (see README, `docs/<area>/evaluation/`).

--- a/plans/VISION_INFERENCE_EXTENSION_PLAN.md
+++ b/plans/VISION_INFERENCE_EXTENSION_PLAN.md
@@ -1,0 +1,144 @@
+# Vision-Inference Extension: Governed Consumption of Pretrained / Hosted Vision Models
+
+**Status:** Plan only — no implementation yet.
+**Author:** govkit working group
+**Created:** 2026-06-05
+**Target version:** govkit v0.12.0 (current v0.11.1) — lands independently of the `cv` type.
+**Precedent:** `extensions/agentic-skills/` — same extension mechanism (in-place contract pack layered on a core type).
+**Sibling plan:** [CV_TYPE_PLAN.md](CV_TYPE_PLAN.md) — the *training* shape. This is its orthogonal counterpart for *consumption*.
+
+---
+
+## 1. Summary
+
+Add a govkit **extension** — `extensions/vision-inference/` — that governs applications which **consume** pretrained or hosted vision models rather than train them. Covers the two flavors confirmed in scope:
+
+- **Discriminative vision APIs** — classify / detect / OCR via hosted (Rekognition, GCP/Azure Vision) or self-hosted (Triton/TorchServe) models.
+- **Generative / VLM** — vision-language models (Claude vision, GPT-4V) and image generation (diffusion), which add a safety/guardrail/eval-as-judge surface.
+
+### Why an extension, not a `--type`
+
+A govkit `--type` earns its existence from a **distinct layered architecture**. Consumption has none — it **is the existing `api`/`cli` hexagon with one special outbound port** (the vision model). The entire spine of the `cv` training type (preprocessing → datasets → training → evaluation → leakage → reproducibility) does not apply. What consumption needs is a thin, cross-cutting contract pack bolted onto an existing shape — precisely the slot the [agentic-skills extension](../extensions/agentic-skills/) occupies.
+
+This is a deliberate, candid scoping call: **inference-only is barely a model-training governance problem at all.** It's an external-dependency-integration problem with one genuinely vision-specific twist (biometric data leaving the building). Modeling it as a second training type would be wrong and would duplicate the `api` hexagon for no gain.
+
+### What the extension mechanism buys us (vs the `cv` type)
+
+Per the [extensions README](../extensions/agentic-skills/README.md): extensions are **agent-agnostic** and **not CLI-installed** — they live in-place under `extensions/<id>/` and are discovered by `apply`/`validate` scanning `extensions/*/manifest.yaml`. Consequences for this plan:
+
+- **No parity ×3 tax** — one source of contracts, not triplicated across claude-code / codex / copilot.
+- **No manifest / CLI / detect / doctor wiring** — nothing in `agents/*/manifest.json`, `cli/`, or CI `by_type`.
+- It **layers on** `--type api` (or `cli`), reusing that type's ports/services/adapters governance for free.
+
+That makes this materially lighter than the `cv` type — mostly contract authoring + a manifest + a schema.
+
+---
+
+## 2. Governance concerns (what consumption actually needs)
+
+The training spine doesn't apply; these do:
+
+| Concern | Why it matters for consumption |
+|---|---|
+| **Model behind a port/adapter** | The vendor model is an outbound dependency. No SDK leak into domain/services; provider swappable. Pure hexagonal — reuses `api` type governance. |
+| **Model versioning + drift** | A hosted model changes under you. Pin model + version; record it with every prediction; detect when the provider's model moves. |
+| **Black-box acceptance eval** | You can't retrain, but you must acceptance-test the consumed model on **your** held-out set, and re-gate on provider switch / version bump. A thin echo of the `cv` eval gate. |
+| **Confidence-threshold decision policy + HITL** | What the system does with low-confidence predictions; when a human must review. |
+| **Biometric data handling** | Sending images (faces) to a third party = consent, data-residency, retention, redaction. The genuinely vision-specific, and biggest, concern. |
+| **Prediction observability** | Log input ref / output / confidence / model version / latency / cost — **PII-safe** (never log raw biometric images). |
+
+---
+
+## 3. Contract set
+
+`extensions/vision-inference/docs/backend/architecture/` (mirrors how agentic-skills ships contracts):
+
+### 3.1 Discriminative spine (always)
+
+- `VISION_MODEL_PORT_CONTRACT.md` — the model is an outbound port behind an adapter; vendor SDK confined to the adapter; provider swappable; deterministic preprocessing at the boundary.
+- `MODEL_VERSIONING_CONTRACT.md` — pin model + version; record version per prediction; drift detection when the hosted model changes; rollback policy.
+- `INFERENCE_EVAL_CONTRACT.md` — black-box acceptance eval on a frozen held-out set; provider-switch / version-bump regression gate; per-class + per-slice breakdown; confidence-threshold decision policy + human-in-the-loop.
+- `BIOMETRIC_DATA_HANDLING_CONTRACT.md` — consent, data residency, third-party transmission limits, retention, redaction; biometric/face as special category. **Shares language with the `cv` type's PII contract and the `data` type's `pii.md`** — DRY decision in §6.
+- `PREDICTION_OBSERVABILITY_CONTRACT.md` — structured, PII-safe logging of prediction metadata (no raw biometric payloads); cost/latency/version captured.
+
+### 3.2 Generative / VLM layer (`relates_to.extends` the L5 GenAI-Ops contracts)
+
+Do **not** reinvent guardrails/eval-as-judge — extend the existing L5 contracts the agentic-skills extension already builds on:
+
+- Extends: `GUARDRAILS_CONTRACT` (NSFW/safety on generated images + text), `EVALUATION_LLM_CONTRACT` (eval-as-judge for VLM outputs), `OBSERVABILITY_LLM_CONTRACT`, `llm-gateway`.
+- New, vision-specific: `MULTIMODAL_INPUT_CONTRACT.md` — image+text prompt handling, **prompt-injection-via-image**, expected image size/format/normalization, output validation of generated content.
+
+### 3.3 Schemas
+
+`extensions/vision-inference/schemas/`:
+- `extension-manifest.schema.json` (or reuse the agentic-skills one).
+- `prediction-record.schema.json` — the per-prediction provenance record (model id + version, confidence, decision, slice tags) consumed by the acceptance-eval gate and observability.
+
+---
+
+## 4. `manifest.yaml`
+
+Mirrors `extensions/agentic-skills/manifest.yaml`:
+
+- `id: vision-inference`, `extension_type: architecture`
+- `supported_levels: [4, 5]` — discriminative acceptance eval is L4-shaped; generative guardrails pull in L5.
+- `supported_project_types: [api, cli]`
+- `contract_sets`: `vision_inference` (discriminative spine) + `vision_generative` (VLM layer), each with `paths`, `applies_to` globs (`**/*vision*`, `**/*ocr*`, `**/*detect*`, `**/*classify*`, `**/*caption*`, `**/*vlm*`, `**/*predict*`, `**/*inference*`), `capabilities`, and `relates_to.extends` pointing at the L5 contracts for the generative set.
+- `agent_guidance`: `architecture_preflight` / `implementation_plan` / `validation` blocks (load contracts when a feature touches vision consumption; require ADR for overrides; validate contract files exist + are cited).
+
+---
+
+## 5. Staging
+
+- **PR 1 — discriminative spine:** ✅ **DONE (2026-06-05).** `extensions/vision-inference/` scaffold (`manifest.yaml`, `README.md`), the 5 spine contracts + `prediction-record.schema.json`, regression-guarded by `tests/test_vision_inference.py` (TDD red→green; full suite 141 passed). Self-contained; ships independently of the `cv` type. **Note:** contract filenames were chosen collision-free against the validate-extension overlap heuristic — `VISION_MODEL_ADAPTER`, `MODEL_VERSIONING`, `INFERENCE_ACCEPTANCE`, `BIOMETRIC_DATA_HANDLING`, `PREDICTION_LOGGING` (the §3.1 `_PORT_`/`_EVAL_`/`_OBSERVABILITY_` names would trip false overlaps with core `OBSERVABILITY_PORT`/`EVALUATION_LLM` contracts).
+- **PR 2 — generative / VLM layer:** ✅ **DONE (2026-06-05).** `MULTIMODAL_INPUT_CONTRACT.md` + `vision_generative` contract set with `relates_to.extends` wired to the real L5 GenAI-Ops contracts (`GUARDRAILS`, `EVALUATION_LLM`, `OBSERVABILITY_LLM`, `LLM_GATEWAY`). Validates cleanly against repo root (those contracts exist there); in a non-L5 project the `extends` paths are missing and `doctor`/`validate` flag them — the closest thing to L5-gating, since `supported_levels` is inert. Regression-guarded by `tests/test_vision_inference.py::TestGenerativeLayer`.
+
+No CLI/agent-parity work in either PR (extension mechanism).
+
+---
+
+## 6. Open decisions
+
+1. **Extension id** — `vision-inference` (recommended) vs `vision-consumption` / `vision-model-adapter`.
+2. **`supported_levels`** — `[4, 5]` (recommended; discriminative=4, generative=5) vs `[5]` only.
+3. **Biometric DRY** — author `BIOMETRIC_DATA_HANDLING_CONTRACT.md` once and reference it from the `cv` type + `data` `pii.md`, or keep an extension-local copy. Leans toward a single shared contract.
+4. **Self-hosted vs hosted parity** — confirm the `VISION_MODEL_PORT_CONTRACT` abstracts Triton/TorchServe and hosted APIs behind one port (expected yes; the port is the point).
+5. **Black-box eval reuse** — does `INFERENCE_EVAL_CONTRACT` reuse the `cv` type's metrics-artifact schema, or a lighter consumption-specific one?
+
+### Follow-ups surfaced during implementation (govkit-core gaps, not blockers)
+
+These were discovered while building PR 1/PR 2. Both affect the existing
+`agentic-skills` extension identically, so they are govkit-core changes, not
+vision-inference-local — log here, decide separately.
+
+6. **`supported_levels` / `supported_project_types` are inert.** Nothing in the CLI
+   reads them — they're declared metadata only, so an extension is discovered and
+   surfaced at *any* level/type. The only de-facto level gate today is
+   `relates_to.extends` (the generative set's L5 paths are absent in a non-L5 project,
+   so `doctor`/`validate` flag them). **Decision:** leave advisory, or have
+   `validate_extension`/doctor compare `supported_levels` against the `.govkit` marker
+   level (and `supported_project_types` against the marker type) and warn/fail on
+   mismatch. If enforced, re-evaluate open decision #2.
+7. **`capabilities` don't reach `skill_context`.** `cli/skill_context.py:_extension_facts`
+   reads `manifest.get("capabilities")` at the top level, but both this extension and
+   `agentic-skills` declare `capabilities` nested under `contract_sets[]`. Result:
+   `contract_paths` project correctly into `.govkit/skill_context.yaml`, but
+   `capabilities` come through as `[]`. **Decision:** lift capabilities to top-level in
+   manifests, or teach `_extension_facts` to flatten nested `contract_sets[].capabilities`.
+
+---
+
+## 7. Relationship to the `cv` type plan
+
+Orthogonal and complementary — different teams, different repos, different mechanism:
+
+| | `cv` **type** ([CV_TYPE_PLAN](CV_TYPE_PLAN.md)) | `vision-inference` **extension** (this) |
+|---|---|---|
+| Shape | New `--type` with its own layered architecture | Contract pack layered on `--type api`/`cli` |
+| User | Trains / fine-tunes models | Consumes pretrained / hosted models |
+| Spine | preprocessing→datasets→training→evaluation | the `api` hexagon + a vision model port |
+| Parity tax | ×3 agents + CLI/manifest/CI wiring | none (extension is agent-agnostic, in-place) |
+| Eval | full eval-regression + leakage gate | black-box acceptance eval on held-out set |
+| Shared | biometric/PII handling; black-box-eval language (candidates for one shared contract — §6.3) |
+
+**Sequencing:** per your call, this plan is authored before `cv` PR 1. The two can then be implemented in either order; PR 1 of either is independently shippable. The only cross-link is the optional shared biometric contract (§6.3).

--- a/tests/test_vision_inference.py
+++ b/tests/test_vision_inference.py
@@ -140,6 +140,7 @@ class TestGenerativeLayer:
         "docs/backend/architecture/GUARDRAILS_CONTRACT.md",
         "docs/backend/architecture/EVALUATION_LLM_CONTRACT.md",
         "docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md",
+        "docs/backend/architecture/LLM_GATEWAY_CONTRACT.md",
     }
 
     @staticmethod

--- a/tests/test_vision_inference.py
+++ b/tests/test_vision_inference.py
@@ -91,6 +91,46 @@ def test_prediction_record_schema_pins_provenance_fields():
     )
 
 
+class TestPredictionRecordSchemaEnforcesNoRawPayload:
+    """The schema must back the contracts' invariant: a prediction record
+    references the input by id/hash (`input_ref`) and CANNOT carry raw image
+    bytes (no unexpected top-level fields like raw_image/image_base64)."""
+
+    @staticmethod
+    def _schema() -> dict:
+        return json.loads(PREDICTION_RECORD_SCHEMA.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _valid_record() -> dict:
+        return {
+            "model_id": "vision-detector",
+            "model_version": "2024-01",
+            "input_ref": "sha256:deadbeef",
+            "outputs": [{"label": "cat", "confidence": 0.91}],
+        }
+
+    def test_input_ref_is_required(self):
+        assert "input_ref" in self._schema().get("required", []), (
+            "input_ref must be required so a record always references the input"
+        )
+
+    def test_valid_record_passes(self):
+        errors = list(Draft202012Validator(self._schema()).iter_errors(self._valid_record()))
+        assert errors == [], f"a well-formed record must validate; got {errors}"
+
+    def test_missing_input_ref_rejected(self):
+        rec = self._valid_record()
+        del rec["input_ref"]
+        errors = list(Draft202012Validator(self._schema()).iter_errors(rec))
+        assert errors, "a record without input_ref must be rejected"
+
+    def test_raw_image_field_rejected(self):
+        rec = self._valid_record()
+        rec["image_base64"] = "iVBORw0KGgoAAAANSUhEUg=="  # smuggled raw payload
+        errors = list(Draft202012Validator(self._schema()).iter_errors(rec))
+        assert errors, "a record with a raw-image field must be rejected (additionalProperties)"
+
+
 class TestGenerativeLayer:
     """PR 2 — generative / VLM contract set. Adds MULTIMODAL_INPUT and REUSES the
     L5 GenAI-Ops contracts via relates_to.extends rather than reinventing them."""

--- a/tests/test_vision_inference.py
+++ b/tests/test_vision_inference.py
@@ -1,0 +1,132 @@
+"""Tests for the shipped vision-inference extension (discriminative spine).
+
+PR1 / Increment A — scaffold: the extension is discovered, validates cleanly
+against the repo, its manifest matches the extension schema, and the first
+spine contract (VISION_MODEL_ADAPTER) is present. Later increments add the
+remaining spine contracts and the generative/VLM layer.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from cli.extensions import discover_extensions, validate_extension
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXT_DIR = REPO_ROOT / "extensions" / "vision-inference"
+MANIFEST_PATH = EXT_DIR / "manifest.yaml"
+SCHEMA_PATH = (
+    REPO_ROOT / "extensions" / "agentic-skills" / "schemas" / "extension-manifest.schema.json"
+)
+ADAPTER_CONTRACT = "docs/backend/architecture/VISION_MODEL_ADAPTER_CONTRACT.md"
+SPINE_CONTRACTS = [
+    "docs/backend/architecture/VISION_MODEL_ADAPTER_CONTRACT.md",
+    "docs/backend/architecture/MODEL_VERSIONING_CONTRACT.md",
+    "docs/backend/architecture/INFERENCE_ACCEPTANCE_CONTRACT.md",
+    "docs/backend/architecture/BIOMETRIC_DATA_HANDLING_CONTRACT.md",
+    "docs/backend/architecture/PREDICTION_LOGGING_CONTRACT.md",
+]
+PREDICTION_RECORD_SCHEMA = EXT_DIR / "schemas" / "prediction-record.schema.json"
+
+
+def _manifest() -> dict:
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_extension_discovered():
+    exts = discover_extensions(REPO_ROOT)
+    assert any(e.id == "vision-inference" for e in exts), "vision-inference not discovered"
+
+
+def test_extension_validates_cleanly_against_repo():
+    """Must be WARN-free against the canonical repo — including the
+    undeclared-overlap heuristic against core *_CONTRACT.md topics."""
+    ext = next((e for e in discover_extensions(REPO_ROOT) if e.id == "vision-inference"), None)
+    assert ext is not None, "vision-inference extension not discovered in repo"
+    issues = validate_extension(ext, REPO_ROOT)
+    assert issues == [], f"extension must validate cleanly; got: {issues}"
+
+
+def test_manifest_matches_schema():
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = list(Draft202012Validator(schema).iter_errors(_manifest()))
+    assert not errors, f"manifest must validate; got: {errors}"
+
+
+def test_manifest_core_fields():
+    m = _manifest()
+    assert m["id"] == "vision-inference"
+    assert m["extension_type"] == "architecture"
+    assert "api" in m.get("supported_project_types", [])
+
+
+def test_adapter_contract_declared_and_present():
+    paths = [p for cs in _manifest()["contract_sets"] for p in cs.get("paths", [])]
+    assert ADAPTER_CONTRACT in paths, "adapter contract must be declared in a contract set"
+    assert (EXT_DIR / ADAPTER_CONTRACT).exists(), "adapter contract file must exist"
+
+
+def test_all_spine_contracts_declared_and_present():
+    paths = [p for cs in _manifest()["contract_sets"] for p in cs.get("paths", [])]
+    for contract in SPINE_CONTRACTS:
+        assert contract in paths, f"{contract} must be declared in a contract set"
+        assert (EXT_DIR / contract).exists(), f"{contract} file must exist"
+
+
+def test_prediction_record_schema_is_valid_json_schema():
+    schema = json.loads(PREDICTION_RECORD_SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+
+
+def test_prediction_record_schema_pins_provenance_fields():
+    """The per-prediction record is the object the acceptance gate and prediction
+    logging both consume — it must pin model identity + version + confidence."""
+    schema = json.loads(PREDICTION_RECORD_SCHEMA.read_text(encoding="utf-8"))
+    required = set(schema.get("required", []))
+    assert {"model_id", "model_version"} <= required, (
+        f"prediction record must require model identity + version; got {required}"
+    )
+
+
+class TestGenerativeLayer:
+    """PR 2 — generative / VLM contract set. Adds MULTIMODAL_INPUT and REUSES the
+    L5 GenAI-Ops contracts via relates_to.extends rather than reinventing them."""
+
+    GENERATIVE_CONTRACT = "docs/backend/architecture/MULTIMODAL_INPUT_CONTRACT.md"
+    EXPECTED_EXTENDS = {
+        "docs/backend/architecture/GUARDRAILS_CONTRACT.md",
+        "docs/backend/architecture/EVALUATION_LLM_CONTRACT.md",
+        "docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md",
+    }
+
+    @staticmethod
+    def _generative_set() -> dict | None:
+        return next(
+            (cs for cs in _manifest()["contract_sets"] if cs.get("id") == "vision_generative"),
+            None,
+        )
+
+    def test_generative_contract_set_present(self):
+        assert self._generative_set() is not None, "vision_generative contract set must exist"
+
+    def test_multimodal_contract_declared_and_present(self):
+        cs = self._generative_set()
+        assert cs is not None
+        assert self.GENERATIVE_CONTRACT in cs.get("paths", []), "multimodal contract must be declared"
+        assert (EXT_DIR / self.GENERATIVE_CONTRACT).exists(), "multimodal contract file must exist"
+
+    def test_generative_extends_l5_contracts(self):
+        cs = self._generative_set()
+        assert cs is not None
+        extends = set(cs.get("relates_to", {}).get("extends", []))
+        missing = self.EXPECTED_EXTENDS - extends
+        assert not missing, f"generative set must extend L5 GenAI-Ops contracts: {missing}"
+
+    def test_generative_extends_paths_exist_in_repo(self):
+        cs = self._generative_set()
+        assert cs is not None
+        for path in cs.get("relates_to", {}).get("extends", []):
+            assert (REPO_ROOT / path).exists(), f"declared extends path {path!r} not found in repo"


### PR DESCRIPTION
## Summary

Adds a govkit **extension** — `extensions/vision-inference/` — that governs applications which **consume** pretrained or hosted vision models (rather than train them), layered on the existing `--type api` / `--type cli` hexagon. The consumed model is just an outbound dependency behind a port.

This is the lighter half of the computer-vision initiative. Because it's an *extension* (agent-agnostic, discovered in-place, not CLI-installed), there's **no parity ×3 tax and no manifest/CLI wiring** — it's contract authoring plus a schema and tests. The heavier `--type cv` *training* shape is planned separately (`plans/CV_TYPE_PLAN.md`) and not in this PR.

## What's in it

**Two contract sets** in `manifest.yaml`:

- `vision_inference` (discriminative — classify/detect/OCR):
  - `VISION_MODEL_ADAPTER_CONTRACT` — model behind a port; vendor SDK confined to the adapter; providers swappable; deterministic boundary preprocessing.
  - `MODEL_VERSIONING_CONTRACT` — pin `model_id`+`model_version`, record per prediction, drift detection, defined rollback.
  - `INFERENCE_ACCEPTANCE_CONTRACT` — black-box acceptance eval on a frozen held-out set; **per-class + per-slice** metrics; re-gate on any behavior-moving change; confidence-threshold + human-in-the-loop policy.
  - `BIOMETRIC_DATA_HANDLING_CONTRACT` — special-category handling for images of people; consent/residency/retention declared as **team policy** (no invented numbers); never log raw payloads.
  - `PREDICTION_LOGGING_CONTRACT` — structured, PII-safe records with model provenance, confidence, latency, cost.
- `vision_generative` (VLM/diffusion):
  - `MULTIMODAL_INPUT_CONTRACT` — image-as-untrusted-instruction-channel (prompt-injection-via-image), generated-output validation, biometric obligations.
  - **Reuses** the L5 GenAI-Ops contracts via `relates_to.extends` (`GUARDRAILS`, `EVALUATION_LLM`, `OBSERVABILITY_LLM`, `LLM_GATEWAY`) rather than reinventing them.

**Schema:** `schemas/prediction-record.schema.json` — the per-prediction provenance object the acceptance gate and prediction logging both consume.

## Design notes

- Contract filenames were chosen **collision-free** against `validate_extension`'s overlap heuristic (the natural `_PORT_`/`_EVAL_`/`_OBSERVABILITY_` names would trip false overlaps with core `OBSERVABILITY_PORT` / `EVALUATION_LLM`).
- The generative set's `relates_to.extends` is the **de-facto L5 gate**: in a non-L5 project those contracts are absent and `doctor`/`validate` flag the dangling references. (`supported_levels` is currently inert — logged as a follow-up in the plan.)

## Testing

- `tests/test_vision_inference.py` — 12 tests, written **test-first** (red→green per increment): discovery, clean validation against the repo, schema validity, provenance fields, full spine presence, and the generative layer's L5 `extends` wiring.
- Full suite: **837 passed, 1 skipped** (pre-existing); ruff clean.

## Out of scope / follow-ups

- `--type cv` training shape — separate plan/PR.
- Two govkit-core gaps logged in the plan (affect `agentic-skills` too): inert `supported_levels` enforcement, and `capabilities` not projecting into `skill_context`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)