### PR TITLE
chore(data): clarify conservative CI contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Data CI behavior is now explicit in all production agent manifests: `--type
   data` installs the common repo-scope governance gate for GitHub or Azure at
   L3/L4 instead of inheriting it accidentally from the base CI block.
+- `govkit upgrade` now validates marker options against the current manifest
+  before resolving variants, so malformed markers fail fast instead of silently
+  omitting governed CI gates.
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed — explicit conservative data CI contract
+
+- Data CI behavior is now explicit in all production agent manifests: `--type
+  data` installs the common repo-scope governance gate for GitHub or Azure at
+  L3/L4 instead of inheriting it accidentally from the base CI block.
+- README data-stack guidance now describes the conservative CI model: common
+  governance is installed by default, while stack-specific execution gates
+  remain opt-in until configured.
+
 ### Fixed — data stack boundary and discoverability
 
 - `govkit apply --type data --level 5` now fails fast with a clear message. Data

--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ The 8-step lifecycle above applies to all project types. Key differences by type
 
 **Worked starter:** `govkit init <feature> --starter data` scaffolds a `customer_dim_freshness` feature with `@nfr-freshness / @nfr-quality / @nfr-pii / @nfr-lineage / @nfr-reliability / @nfr-cost` Gherkin scenarios.
 
-**CI gates:** intentionally empty in this release — gate selection (source freshness, dbt test, SQLfluff) is the kind of thing data teams want to shape themselves. Wire your own in `ci/github/` or `ci/azure/` for now; opinionated defaults arrive in a future release.
+**CI gates:** data installs include the common repo-scope governance gate. Stack-specific execution gates (source freshness, dbt test, SQLfluff, Databricks workspace validation) remain conservative and opt-in until configured by the team.
 
 **Maturity levels:** data projects support Level 3 and Level 4. Level 5 is GenAI Operations for LLM application delivery and does not apply to dbt/data project installs.
 

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -319,13 +319,13 @@
       "github": {
         "files": [],
         "shared": [],
-        "governed": ["ci/github/repo-scope-check.yml"],
+        "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/github/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/github/l3-quality-gate.yml"] },
-          "ui-react":   { "governed": ["ci/github/l3-ui-quality-gate.yml"] },
-          "ui-angular": { "governed": ["ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": [] }
+          "api":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
+          "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
+          "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -337,7 +337,7 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": [] }
+            "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
           }
         },
         "level_5": {
@@ -388,13 +388,13 @@
       "azure": {
         "files": [],
         "shared": [],
-        "governed": ["ci/azure/repo-scope-check.yml"],
+        "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/azure/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/azure/l3-quality-gate.yml"] },
-          "ui-react":   { "governed": ["ci/azure/l3-ui-quality-gate.yml"] },
-          "ui-angular": { "governed": ["ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": [] }
+          "api":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
+          "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
+          "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -406,7 +406,7 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": [] }
+            "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
           }
         },
         "level_5": {

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -335,12 +335,13 @@
       "github": {
         "files": [],
         "shared": [],
-        "governed": ["ci/github/repo-scope-check.yml"],
+        "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/github/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/github/l3-quality-gate.yml"] },
-          "ui-react":   { "governed": ["ci/github/l3-ui-quality-gate.yml"] },
-          "ui-angular": { "governed": ["ci/github/l3-ui-quality-gate.yml"] }
+          "api":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
+          "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
+          "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -351,7 +352,8 @@
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] }
+            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
+            "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
           }
         },
         "level_5": {
@@ -402,12 +404,13 @@
       "azure": {
         "files": [],
         "shared": [],
-        "governed": ["ci/azure/repo-scope-check.yml"],
+        "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/azure/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/azure/l3-quality-gate.yml"] },
-          "ui-react":   { "governed": ["ci/azure/l3-ui-quality-gate.yml"] },
-          "ui-angular": { "governed": ["ci/azure/l3-ui-quality-gate.yml"] }
+          "api":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
+          "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
+          "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -418,7 +421,8 @@
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] }
+            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
+            "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
           }
         },
         "level_5": {

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -317,12 +317,13 @@
       "github": {
         "files": [],
         "shared": [],
-        "governed": ["ci/github/repo-scope-check.yml"],
+        "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/github/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/github/l3-quality-gate.yml"] },
-          "ui-react":   { "governed": ["ci/github/l3-ui-quality-gate.yml"] },
-          "ui-angular": { "governed": ["ci/github/l3-ui-quality-gate.yml"] }
+          "api":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
+          "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
+          "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -333,7 +334,8 @@
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] }
+            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
+            "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
           }
         },
         "level_5": {
@@ -384,12 +386,13 @@
       "azure": {
         "files": [],
         "shared": [],
-        "governed": ["ci/azure/repo-scope-check.yml"],
+        "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/azure/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/azure/l3-quality-gate.yml"] },
-          "ui-react":   { "governed": ["ci/azure/l3-ui-quality-gate.yml"] },
-          "ui-angular": { "governed": ["ci/azure/l3-ui-quality-gate.yml"] }
+          "api":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
+          "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
+          "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -400,7 +403,8 @@
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] }
+            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
+            "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
           }
         },
         "level_5": {

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -23,6 +23,45 @@ from .manifest import load_manifest, resolve_variant_files
 from .marker import _compare_version, read_govkit_marker, write_govkit_marker
 
 
+def _validate_stored_options(manifest: dict, stored_options: dict) -> None:
+    """Fail fast when marker options cannot safely resolve manifest variants."""
+    if not isinstance(stored_options, dict):
+        print(
+            "Error: .govkit marker 'options' must be an object. "
+            "Re-run `govkit apply` to refresh the marker before upgrading.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    options_spec = manifest.get("options", {})
+    variants = manifest.get("variants", {})
+    required_dimensions = [
+        key for key in options_spec
+        if key != "level" and key in variants
+    ]
+
+    for key in required_dimensions:
+        spec = options_spec.get(key, {})
+        choices = spec.get("choices") or []
+        if key not in stored_options or stored_options.get(key) in (None, ""):
+            print(
+                f"Error: .govkit marker missing required option '{key}'. "
+                "Re-run `govkit apply` to refresh the marker before upgrading.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        value = stored_options[key]
+        if choices and value not in choices:
+            print(
+                f"Error: .govkit marker has invalid value {value!r} for option "
+                f"'{key}'. Expected one of: {', '.join(choices)}. "
+                "Re-run `govkit apply` to refresh the marker before upgrading.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
 def cmd_upgrade(args: argparse.Namespace) -> None:
     """Refresh agent config and governed contracts to the current govkit version.
 
@@ -60,6 +99,7 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
     print(f"  Agent: {agent}  Level: {stored_level}\n")
 
     manifest = load_manifest(agent)
+    _validate_stored_options(manifest, stored_options)
     agent_dir = paths.AGENTS_DIR / agent
     options = {**stored_options, "level": stored_level}
     files, shared, governed = resolve_variant_files(manifest, options)

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -1982,12 +1982,27 @@ def _make_upgrade_repo(tmp_path: Path, agent: str = "test-agent") -> Path:
                     "shared": [],
                     "governed": ["docs/"],
                 }
+            },
+            "ci": {
+                "github": {
+                    "files": [],
+                    "shared": [],
+                    "governed": [],
+                    "by_type": {
+                        "api": {
+                            "governed": ["ci/github/repo-scope-check.yml"],
+                        }
+                    },
+                }
             }
         },
         "base_files": [],
     }
     (agents / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     (agents / "CLAUDE.md").write_text("# Agent instructions v2", encoding="utf-8")
+    ci_gate = tmp_path / "ci" / "github" / "repo-scope-check.yml"
+    ci_gate.parent.mkdir(parents=True)
+    ci_gate.write_text("name: repo scope\n", encoding="utf-8")
     return tmp_path
 
 
@@ -2099,6 +2114,39 @@ class TestCmdUpgrade:
 
         with pytest.raises(SystemExit):
             cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+    @pytest.mark.parametrize(
+        "stored_options, expected",
+        [
+            ({"ci": "github"}, "missing required option 'type'"),
+            ({"type": "bogus", "ci": "github"}, "invalid value 'bogus' for option 'type'"),
+            ({"type": "api", "ci": "azure"}, "invalid value 'azure' for option 'ci'"),
+        ],
+    )
+    def test_upgrade_validates_marker_options_before_variant_resolution(
+        self, tmp_path, monkeypatch, capsys, stored_options, expected,
+    ):
+        """Malformed marker options fail fast instead of resolving empty governed CI."""
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version="0.11.0")
+        marker_path = target / ".govkit"
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["options"] = stored_options
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.12.0")
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert expected in err
+        assert "govkit apply" in err
+        assert not (target / "ci" / "github" / "repo-scope-check.yml").exists()
 
 
 class TestCmdUpgradeEditProtection:

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3123,6 +3123,52 @@ class TestNoUiDimensionInManifests:
         assert "python-dbt" in out
 
 
+class TestDataCiContract:
+    """Production data manifests make the conservative common CI gate explicit."""
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    @pytest.mark.parametrize(
+        "platform, repo_scope",
+        [
+            ("github", "ci/github/repo-scope-check.yml"),
+            ("azure", "ci/azure/repo-scope-check.yml"),
+        ],
+    )
+    @pytest.mark.parametrize("level", ["3", "4"])
+    def test_data_ci_resolves_common_repo_scope_gate(
+        self, agent, platform, repo_scope, level,
+    ):
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+
+        _, _, governed = resolve_variant_files(
+            manifest, {"type": "data", "ci": platform, "level": level}
+        )
+
+        ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
+        assert ci_governed == [repo_scope]
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    @pytest.mark.parametrize(
+        "platform, repo_scope",
+        [
+            ("github", "ci/github/repo-scope-check.yml"),
+            ("azure", "ci/azure/repo-scope-check.yml"),
+        ],
+    )
+    def test_data_ci_contract_is_explicit_in_manifest(self, agent, platform, repo_scope):
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+        ci_block = manifest["variants"]["ci"][platform]
+
+        assert ci_block.get("governed", []) == []
+        assert ci_block["by_type"]["data"]["governed"] == [repo_scope]
+        assert ci_block["level_4"].get("governed", []) == []
+        assert ci_block["level_4"]["by_type"]["data"]["governed"] == [repo_scope]
+
+
 class TestShapeMigrationWarning:
     """read_govkit_marker emits a one-time warning when marker carries legacy `ui` option."""
 


### PR DESCRIPTION
## Summary
- Make data CI behavior explicit in all production agent manifests instead of inheriting repo-scope from the base CI block
- Document repo-scope as the conservative common data governance gate
- Add regression tests for resolved data CI files across agents, levels, and CI platforms

## Tests
- `pytest tests/test_govkit.py::TestDataCiContract tests/test_schemas.py tests/test_main_dispatch.py`
- `pytest`