### PR TITLE
[codex] Add stack-aware data CI resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - `govkit upgrade` now validates marker options against the current manifest
   before resolving variants, so malformed markers fail fast instead of silently
   omitting governed CI gates.
+- Manifest resolution now supports optional `by_stack` entries nested under
+  `by_type`, enabling stack-aware data CI gates while preserving common CI for
+  unmapped future stacks.
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.

--- a/cli/manifest.py
+++ b/cli/manifest.py
@@ -7,9 +7,10 @@
 
 Loads agents/<agent>/manifest.json and resolves the effective install set
 (files / shared / governed) for a chosen set of options (level, type, ci, ...).
-The merge/replace and by_type dispatch rules that turn the manifest's variant
-declarations into a concrete file list live here. Depends only on the path
-kernel (cli/paths.py), so commands import it inward without a cycle.
+The merge/replace, by_type, and by_stack dispatch rules that turn the
+manifest's variant declarations into a concrete file list live here. Depends
+only on the path kernel (cli/paths.py), so commands import it inward without a
+cycle.
 """
 
 from __future__ import annotations
@@ -104,16 +105,37 @@ def _select_variant(
     return base, None, "merge"
 
 
-def _apply_by_type(block: dict, type_value: str | None) -> dict:
-    """Merge block + block.by_type[type_value] into a single effective block.
+_ENTRY_KEYS = ("files", "shared", "governed")
+
+
+def _merge_dispatch_blocks(block: dict, *dispatch_blocks: dict) -> dict:
+    """Merge a base block with one or more dispatch blocks."""
+    merged: dict = {
+        k: v for k, v in block.items()
+        if k not in (*_ENTRY_KEYS, "by_type", "by_stack")
+    }
+    for key in _ENTRY_KEYS:
+        entries = list(block.get(key, []))
+        for dispatch_block in dispatch_blocks:
+            entries.extend(dispatch_block.get(key, []))
+        merged[key] = entries
+    return merged
+
+
+def _apply_by_type(block: dict, type_value: str | None, stack_value: str | None) -> dict:
+    """Merge block + type/stack dispatch entries into one effective block.
 
     The `by_type` sub-block was added in v0.8 to let one dimension (currently `ci`)
     dispatch its entries based on another dimension's value (currently `type`).
     Example: ci.github.by_type["ui-react"] yields UI-specific CI gates; the
     backend types fall through to ci.github's own files/shared/governed.
 
+    The optional `by_stack` sub-block, nested inside a `by_type` entry, lets data
+    CI dispatch stack-specific static gates after `type=data` is selected.
+
     If the block has no `by_type` key, or no entry for type_value, the block
-    is returned unchanged. Non-list keys (like `mode`) are preserved.
+    is returned unchanged. If `by_stack` has no entry for stack_value, only the
+    parent type entry is folded in. Non-list keys (like `mode`) are preserved.
     """
     if not block:
         return {}
@@ -121,15 +143,15 @@ def _apply_by_type(block: dict, type_value: str | None) -> dict:
     type_block = by_type.get(type_value, {}) if type_value else {}
     if not type_block:
         return block
-    merged: dict = {k: v for k, v in block.items() if k not in ("files", "shared", "governed", "by_type")}
-    merged["files"]    = list(block.get("files", []))    + list(type_block.get("files", []))
-    merged["shared"]   = list(block.get("shared", []))   + list(type_block.get("shared", []))
-    merged["governed"] = list(block.get("governed", [])) + list(type_block.get("governed", []))
-    return merged
+    by_stack = type_block.get("by_stack") or {}
+    stack_block = by_stack.get(stack_value, {}) if stack_value else {}
+    dispatch_blocks = (type_block, stack_block) if stack_block else (type_block,)
+    return _merge_dispatch_blocks(block, *dispatch_blocks)
 
 
 def _dimension_entries(
-    base: dict, override: dict | None, mode: str, type_value: str | None = None,
+    base: dict, override: dict | None, mode: str,
+    type_value: str | None = None, stack_value: str | None = None,
 ) -> tuple[list, list, list]:
     """Compute one dimension's effective (files, shared, governed) after applying override.
 
@@ -144,12 +166,14 @@ def _dimension_entries(
     The optional `type_value` enables `by_type` dispatch (v0.8): each block's
     `by_type[type_value]` entries are folded into the block before the merge/
     replace logic runs. Used by the `ci` dimension to ship type-specific gates.
+    The optional `stack_value` enables nested `by_stack` dispatch (v0.12+) under
+    those type entries for data-stack-specific CI gates.
 
     Cross-dimension accumulation (e.g. type.api + ci.github both contributing to
     .github/instructions/) is handled by `_collect_entries`, not here.
     """
-    eff_base = _apply_by_type(base, type_value)
-    eff_override = _apply_by_type(override, type_value) if override else None
+    eff_base = _apply_by_type(base, type_value, stack_value)
+    eff_override = _apply_by_type(override, type_value, stack_value) if override else None
 
     if eff_override is None:
         return (
@@ -232,11 +256,15 @@ def resolve_variant_files(manifest: dict, options: dict) -> tuple[list, list, li
     variants = manifest.get("variants", {})
     level = options.get("level", "3")
     type_value = options.get("type")
+    stack_value = options.get("stack")
     for dimension, value in options.items():
         if dimension == "level":
             continue
         base, override, mode = _select_variant(variants, dimension, value, level)
-        files, shared, governed = _dimension_entries(base, override, mode, type_value=type_value)
+        files, shared, governed = _dimension_entries(
+            base, override, mode,
+            type_value=type_value, stack_value=stack_value,
+        )
         _collect_entries(
             files, shared, governed,
             all_files, seen_files,

--- a/governance/schemas/agent-manifest.schema.json
+++ b/governance/schemas/agent-manifest.schema.json
@@ -98,7 +98,7 @@
         "by_type": {
           "type": "object",
           "additionalProperties": { "$ref": "#/$defs/by_type_entry" },
-          "description": "v0.8 type-dispatched entries. Keys are values of the `type` option (e.g. 'api', 'ui-react'); each maps to a partial block whose files/shared/governed are folded into the parent block at resolve time. Currently used by the ci dimension to ship type-specific gates."
+          "description": "v0.8 type-dispatched entries. Keys are values of the `type` option (e.g. 'api', 'ui-react'); each maps to a partial block whose files/shared/governed are folded into the parent block at resolve time. Currently used by the ci dimension to ship type-specific gates. Entries may carry `by_stack` for a second dispatch by selected stack."
         },
         "level_4": {
           "$ref": "#/$defs/level_override",
@@ -142,6 +142,29 @@
       }
     },
     "by_type_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "files": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/file_entry" }
+        },
+        "shared": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "governed": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "by_stack": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/by_stack_entry" },
+          "description": "Optional stack-dispatched entries nested under a by_type entry. Keys are values of the `stack` option, used for data-stack-specific CI gates."
+        }
+      }
+    },
+    "by_stack_entry": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -639,6 +639,138 @@ class TestMergeMode:
             f"Missing by_type[api] entry must fall through to base only; got {governed}"
         )
 
+    def test_by_stack_dispatch_adds_stack_specific_data_ci(self):
+        """by_type[data].by_stack routes to stack-specific governed entries."""
+        manifest = {
+            "variants": {
+                "type": {"data": {"files": []}},
+                "ci": {
+                    "github": {
+                        "governed": [],
+                        "by_type": {
+                            "data": {
+                                "governed": ["ci/github/data-common-gate.yml"],
+                                "by_stack": {
+                                    "python-dbt": {
+                                        "governed": ["ci/github/dbt-gate.yml"],
+                                    },
+                                    "databricks-lakehouse": {
+                                        "governed": ["ci/github/databricks-gate.yml"],
+                                    },
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "python-dbt", "ci": "github", "level": "4"},
+        )
+
+        assert governed == ["ci/github/data-common-gate.yml", "ci/github/dbt-gate.yml"]
+
+    def test_by_stack_unknown_stack_falls_through_to_type_entries(self):
+        """Future/unmapped stacks keep common data CI without stack-specific gates."""
+        manifest = {
+            "variants": {
+                "type": {"data": {"files": []}},
+                "ci": {
+                    "github": {
+                        "governed": [],
+                        "by_type": {
+                            "data": {
+                                "governed": ["ci/github/data-common-gate.yml"],
+                                "by_stack": {
+                                    "python-dbt": {
+                                        "governed": ["ci/github/dbt-gate.yml"],
+                                    },
+                                },
+                            }
+                        },
+                    }
+                },
+            }
+        }
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "future-data-stack", "ci": "github"},
+        )
+
+        assert governed == ["ci/github/data-common-gate.yml"]
+
+    def test_by_stack_dispatch_at_level_4_merge(self):
+        """by_stack works in both base and level_4 override blocks."""
+        manifest = {
+            "variants": {
+                "type": {"data": {"files": []}},
+                "ci": {
+                    "github": {
+                        "governed": [],
+                        "by_type": {
+                            "data": {
+                                "governed": ["base-common.yml"],
+                                "by_stack": {
+                                    "python-dbt": {"governed": ["base-dbt.yml"]},
+                                },
+                            }
+                        },
+                        "level_4": {
+                            "mode": "merge",
+                            "governed": [],
+                            "by_type": {
+                                "data": {
+                                    "governed": ["l4-common.yml"],
+                                    "by_stack": {
+                                        "python-dbt": {"governed": ["l4-dbt.yml"]},
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+            }
+        }
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "python-dbt", "ci": "github", "level": "4"},
+        )
+
+        assert governed == ["base-common.yml", "base-dbt.yml", "l4-common.yml", "l4-dbt.yml"]
+
+    def test_by_stack_does_not_affect_non_data_types_without_mapping(self):
+        """Non-data types keep their by_type behavior when no by_stack is declared."""
+        manifest = {
+            "variants": {
+                "type": {"api": {"files": []}},
+                "ci": {
+                    "github": {
+                        "governed": ["ci/github/repo-scope-check.yml"],
+                        "by_type": {
+                            "api": {"governed": ["ci/github/l3-quality-gate.yml"]},
+                            "data": {
+                                "governed": ["ci/github/data-common-gate.yml"],
+                                "by_stack": {
+                                    "python-dbt": {"governed": ["ci/github/dbt-gate.yml"]},
+                                },
+                            },
+                        },
+                    }
+                },
+            }
+        }
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "api", "stack": "python-dbt", "ci": "github"},
+        )
+
+        assert governed == ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"]
+
     def test_cross_dimension_dest_collision_preserved(self):
         # Synthetic guard for the cross-dimension `(src, dest)` dedup mechanism
         # in `_collect_entries`. Two distinct dimensions contributing different

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -354,6 +354,54 @@ class TestSchemaAcceptsNewShapes:
         errors = list(validator.iter_errors(manifest))
         assert not errors, f"Schema must accept by_type sub-block; got: {errors}"
 
+    def test_accepts_by_stack_inside_by_type_entries(self):
+        # Data CI can dispatch first by type, then by stack, so stack-specific
+        # gates stay scoped to data stacks.
+        schema = _load_schema()
+        manifest = {
+            "agent": "x",
+            "description": "y",
+            "options": {
+                "type": {"prompt": "Type?", "choices": ["data"]},
+                "ci": {"prompt": "CI?", "choices": ["github"]},
+                "stack": {
+                    "choices": ["python-dbt", "databricks-lakehouse"],
+                    "default": "python-dbt",
+                },
+            },
+            "variants": {
+                "ci": {
+                    "github": {
+                        "governed": [],
+                        "by_type": {
+                            "data": {
+                                "governed": ["ci/github/data-common-gate.yml"],
+                                "by_stack": {
+                                    "python-dbt": {"governed": ["ci/github/dbt-gate.yml"]},
+                                    "databricks-lakehouse": {
+                                        "governed": ["ci/github/databricks-gate.yml"],
+                                    },
+                                },
+                            }
+                        },
+                        "level_4": {
+                            "mode": "merge",
+                            "by_type": {
+                                "data": {
+                                    "by_stack": {
+                                        "python-dbt": {"governed": ["ci/github/dbt-gate.yml"]},
+                                    }
+                                }
+                            },
+                        },
+                    }
+                }
+            },
+        }
+        validator = Draft202012Validator(schema)
+        errors = list(validator.iter_errors(manifest))
+        assert not errors, f"Schema must accept by_stack under by_type; got: {errors}"
+
     def test_rejects_unknown_key_in_by_type_entry(self):
         # by_type_entry has additionalProperties: false; rogue keys must error.
         schema = _load_schema()
@@ -373,6 +421,32 @@ class TestSchemaAcceptsNewShapes:
         validator = Draft202012Validator(schema)
         errors = list(validator.iter_errors(manifest))
         assert errors, "Unknown keys inside by_type_entry must be rejected"
+
+    def test_rejects_unknown_key_in_by_stack_entry(self):
+        schema = _load_schema()
+        manifest = {
+            "agent": "x",
+            "description": "y",
+            "variants": {
+                "ci": {
+                    "github": {
+                        "by_type": {
+                            "data": {
+                                "by_stack": {
+                                    "python-dbt": {
+                                        "governed": [],
+                                        "rogue_field": True,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        validator = Draft202012Validator(schema)
+        errors = list(validator.iter_errors(manifest))
+        assert errors, "Unknown keys inside by_stack_entry must be rejected"
 
     @pytest.mark.parametrize("ui_type", ["ui-react", "ui-angular"])
     def test_accepts_new_ui_type_in_choices_and_variants(self, ui_type):


### PR DESCRIPTION
## Summary

- Add optional `by_stack` dispatch nested under `by_type` entries in manifest resolution.
- Extend the agent manifest schema to allow narrow stack-dispatched file/shared/governed entries.
- Add regression tests for data stack-specific CI selection, unknown stack fallback, L4 merge behavior, and schema acceptance/rejection.

## Notes

This PR only enables the manifest/resolver contract for stack-aware data CI. It does not install the future dbt or Databricks CI templates yet, so existing production data installs continue to resolve the common repo-scope gate only until those template increments land.

## Validation

- `pytest tests/test_govkit.py tests/test_schemas.py tests/test_stack_select.py` -> 289 passed
- `pytest` -> 893 passed, 1 skipped