### PR TITLE
[codex] Add conservative data common CI gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Manifest resolution now supports optional `by_stack` entries nested under
   `by_type`, enabling stack-aware data CI gates while preserving common CI for
   unmapped future stacks.
+- Data installs now include a conservative `data-common-gate.yml` for GitHub
+  or Azure. The gate runs static governance checks only and leaves warehouse,
+  workspace, source freshness, and pipeline execution to opt-in stack gates.
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -325,7 +325,7 @@
           "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
+          "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -337,7 +337,7 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
+            "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
           }
         },
         "level_5": {
@@ -394,7 +394,7 @@
           "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
+          "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -406,7 +406,7 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
+            "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
           }
         },
         "level_5": {

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -341,7 +341,7 @@
           "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
+          "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -353,7 +353,7 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
+            "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
           }
         },
         "level_5": {
@@ -410,7 +410,7 @@
           "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
+          "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -422,7 +422,7 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
+            "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
           }
         },
         "level_5": {

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -323,7 +323,7 @@
           "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
+          "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -335,7 +335,7 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/github/repo-scope-check.yml"] }
+            "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
           }
         },
         "level_5": {
@@ -392,7 +392,7 @@
           "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
+          "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
         },
         "level_4": {
           "mode": "merge",
@@ -404,7 +404,7 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/azure/repo-scope-check.yml"] }
+            "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
           }
         },
         "level_5": {

--- a/ci/README.md
+++ b/ci/README.md
@@ -27,13 +27,14 @@ Commit and push. The job runs automatically on every PR that modifies `features/
 
 Copy the relevant templates for your project type:
 
-| Workflow | Backend | CLI | UI |
-|---|:---:|:---:|:---:|
-| `quality-gate.yml` | ✓ | ✓ | optional |
-| `eval-gate.yml` (L4+) | ✓ | ✓ | — |
-| `l3-quality-gate.yml` (L3 only) | ✓ | ✓ | — |
-| `ui-quality-gate.yml` | — | — | ✓ |
-| `ui-eval-gate.yml` (L4+) | — | — | ✓ |
+| Workflow | Backend | CLI | UI | Data |
+|---|:---:|:---:|:---:|:---:|
+| `quality-gate.yml` | ✓ | ✓ | optional | — |
+| `eval-gate.yml` (L4+) | ✓ | ✓ | — | — |
+| `l3-quality-gate.yml` (L3 only) | ✓ | ✓ | — | — |
+| `ui-quality-gate.yml` | — | — | ✓ | — |
+| `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
+| `data-common-gate.yml` | — | — | — | ✓ |
 
 ### Quick Checklist
 
@@ -54,6 +55,7 @@ Copy the relevant templates for your project type:
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |
 | `ui-eval-gate.yml` | — | FIRST/Virtue prediction, Playwright E2E, axe scans |
+| `data-common-gate.yml` | Static governance artifact, PII policy, and `govkit validate` checks | Static governance artifact, PII policy, and `govkit validate` checks |
 
 Level 3 projects receive only `l3-quality-gate.yml`. Level 4 projects receive the full set. Level 5 projects receive L4 gates plus 3 additional GenAI gates.
 
@@ -145,6 +147,26 @@ These governance rules are communicated to agents via CLAUDE.md / copilot-instru
 | "Multi-repo but does not list <repo> as owner" | Add your repo to the ownership table |
 
 See: `docs/REPO_SCOPE_ANALYSIS_GUIDANCE.md` for complete repo scope semantics.
+
+---
+
+## Data Common Gate
+
+**File:** `data-common-gate.yml` (GitHub: `ci/github/data-common-gate.yml`, Azure: `ci/azure/data-common-gate.yml`)
+
+**Purpose:** Runs conservative static governance checks for data projects:
+
+- `govkit validate --target .`
+- `architecture_preflight.md` exists before `plan.md`
+- non-starter features have `acceptance.feature` scenarios
+- `features/*/nfrs.md` has no `TBD`
+- PII policy artifacts exist:
+  - `docs/data/architecture/PII_HANDLING_CONTRACT.md`
+  - `docs/data/architecture/PII_HANDLING.md`
+
+**Boundary:** This gate does not query warehouses, call Databricks workspaces,
+deploy bundles, run jobs, execute pipelines, or require cloud credentials.
+Those checks belong in opt-in stack-specific gates.
 
 ---
 

--- a/ci/azure/data-common-gate.yml
+++ b/ci/azure/data-common-gate.yml
@@ -1,0 +1,147 @@
+# data-common-gate.yml
+#
+# PURPOSE: Conservative static governance checks for data projects.
+# Reference this file from azure-pipelines.yml or copy its stages into your
+# project pipeline.
+#
+# This gate is intentionally cloud-free:
+# - no warehouse queries
+# - no Databricks workspace calls
+# - no pipeline or job execution
+# - no cloud credentials required
+#
+# It complements repo-scope-check.yml, which should remain enabled for data
+# projects to validate cross-repository ownership in features/*/nfrs.md.
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - features/**
+      - docs/data/**
+      - governance/**
+      - ci/azure/data-common-gate.yml
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - features/**
+      - docs/data/**
+      - governance/**
+      - ci/azure/data-common-gate.yml
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: DataCommonGate
+    displayName: Static data governance checks
+    jobs:
+      - job: DataCommonGate
+        displayName: Static data governance checks
+        steps:
+          - checkout: self
+
+          - task: Bash@3
+            displayName: Install GovKit
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -euo pipefail
+                python -m pip install --upgrade pip
+                if ! command -v govkit >/dev/null 2>&1; then
+                  python -m pip install govkit
+                fi
+
+          - task: Bash@3
+            displayName: Run GovKit validation
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -euo pipefail
+                govkit validate --target .
+
+          - task: Bash@3
+            displayName: Validate data feature governance artifacts
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -euo pipefail
+
+                errors=0
+                for feature_dir in features/*; do
+                  [ -d "$feature_dir" ] || continue
+                  feature=$(basename "$feature_dir")
+                  case "$feature" in starter_*) continue;; esac
+
+                  if [ -f "$feature_dir/plan.md" ] && [ ! -f "$feature_dir/architecture_preflight.md" ]; then
+                    echo "FAIL: $feature has plan.md but no architecture_preflight.md"
+                    errors=$((errors + 1))
+                  fi
+
+                  if [ ! -f "$feature_dir/acceptance.feature" ]; then
+                    echo "FAIL: $feature missing acceptance.feature"
+                    errors=$((errors + 1))
+                  elif ! grep -Eq "^[[:space:]]*(Scenario|Scenario Outline):" "$feature_dir/acceptance.feature"; then
+                    echo "FAIL: $feature acceptance.feature has no Scenario"
+                    errors=$((errors + 1))
+                  fi
+
+                  if [ -f "$feature_dir/nfrs.md" ] && grep -nE "\bTBD\b" "$feature_dir/nfrs.md"; then
+                    echo "FAIL: $feature nfrs.md contains TBD"
+                    errors=$((errors + 1))
+                  fi
+
+                  if [ -f "$feature_dir/architecture_preflight.md" ] \
+                    && grep -qi "ADR.*required" "$feature_dir/architecture_preflight.md"; then
+                    if ! grep -qi "ADR/" "$feature_dir/architecture_preflight.md"; then
+                      echo "WARN: $feature architecture_preflight.md says ADR required but no ADR/ link was found"
+                    fi
+                  fi
+                done
+
+                if [ "$errors" -gt 0 ]; then
+                  echo "$errors data governance issue(s) found"
+                  exit 1
+                fi
+
+          - task: Bash@3
+            displayName: Validate data PII policy artifacts
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -euo pipefail
+
+                missing=0
+                for path in \
+                  docs/data/architecture/PII_HANDLING_CONTRACT.md \
+                  docs/data/architecture/PII_HANDLING.md
+                do
+                  if [ ! -f "$path" ]; then
+                    echo "FAIL: missing $path"
+                    missing=$((missing + 1))
+                  fi
+                done
+
+                if [ "$missing" -gt 0 ]; then
+                  exit 1
+                fi
+
+          - task: Bash@3
+            displayName: Confirm static-only operating model
+            inputs:
+              targetType: 'inline'
+              script: |
+                cat <<'MSG'
+                Data Common Gate complete.
+
+                This pipeline intentionally performs static governance checks only.
+                Warehouse-backed dbt execution, source freshness, Databricks workspace
+                validation, job execution, and pipeline execution are opt-in gates for
+                stack-specific pipelines.
+                MSG

--- a/ci/azure/data-common-gate.yml
+++ b/ci/azure/data-common-gate.yml
@@ -92,7 +92,7 @@ stages:
                     errors=$((errors + 1))
                   fi
 
-                  if [ -f "$feature_dir/nfrs.md" ] && grep -nE "\bTBD\b" "$feature_dir/nfrs.md"; then
+                  if [ -f "$feature_dir/nfrs.md" ] && grep -nE '(^|[^[:alnum:]_])TBD([^[:alnum:]_]|$)' "$feature_dir/nfrs.md"; then
                     echo "FAIL: $feature nfrs.md contains TBD"
                     errors=$((errors + 1))
                   fi

--- a/ci/github/data-common-gate.yml
+++ b/ci/github/data-common-gate.yml
@@ -1,0 +1,122 @@
+# data-common-gate.yml
+#
+# PURPOSE: Conservative static governance checks for data projects.
+# Copy this file to .github/workflows/data-common-gate.yml.
+#
+# This gate is intentionally cloud-free:
+# - no warehouse queries
+# - no Databricks workspace calls
+# - no pipeline or job execution
+# - no cloud credentials required
+#
+# It complements repo-scope-check.yml, which should remain enabled for data
+# projects to validate cross-repository ownership in features/*/nfrs.md.
+
+name: Data Common Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'features/**'
+      - 'docs/data/**'
+      - 'governance/**'
+      - 'ci/github/data-common-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'features/**'
+      - 'docs/data/**'
+      - 'governance/**'
+      - 'ci/github/data-common-gate.yml'
+
+jobs:
+  data-common-gate:
+    name: Static data governance checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GovKit
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          if ! command -v govkit >/dev/null 2>&1; then
+            python -m pip install govkit
+          fi
+
+      - name: Run GovKit validation
+        run: |
+          set -euo pipefail
+          govkit validate --target .
+
+      - name: Validate data feature governance artifacts
+        run: |
+          set -euo pipefail
+
+          errors=0
+          for feature_dir in features/*; do
+            [ -d "$feature_dir" ] || continue
+            feature=$(basename "$feature_dir")
+            case "$feature" in starter_*) continue;; esac
+
+            if [ -f "$feature_dir/plan.md" ] && [ ! -f "$feature_dir/architecture_preflight.md" ]; then
+              echo "FAIL: $feature has plan.md but no architecture_preflight.md"
+              errors=$((errors + 1))
+            fi
+
+            if [ ! -f "$feature_dir/acceptance.feature" ]; then
+              echo "FAIL: $feature missing acceptance.feature"
+              errors=$((errors + 1))
+            elif ! grep -Eq "^[[:space:]]*(Scenario|Scenario Outline):" "$feature_dir/acceptance.feature"; then
+              echo "FAIL: $feature acceptance.feature has no Scenario"
+              errors=$((errors + 1))
+            fi
+
+            if [ -f "$feature_dir/nfrs.md" ] && grep -nE "\bTBD\b" "$feature_dir/nfrs.md"; then
+              echo "FAIL: $feature nfrs.md contains TBD"
+              errors=$((errors + 1))
+            fi
+
+            if [ -f "$feature_dir/architecture_preflight.md" ] \
+              && grep -qi "ADR.*required" "$feature_dir/architecture_preflight.md"; then
+              if ! grep -qi "ADR/" "$feature_dir/architecture_preflight.md"; then
+                echo "WARN: $feature architecture_preflight.md says ADR required but no ADR/ link was found"
+              fi
+            fi
+          done
+
+          if [ "$errors" -gt 0 ]; then
+            echo "$errors data governance issue(s) found"
+            exit 1
+          fi
+
+      - name: Validate data PII policy artifacts
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for path in \
+            docs/data/architecture/PII_HANDLING_CONTRACT.md \
+            docs/data/architecture/PII_HANDLING.md
+          do
+            if [ ! -f "$path" ]; then
+              echo "FAIL: missing $path"
+              missing=$((missing + 1))
+            fi
+          done
+
+          if [ "$missing" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: Confirm static-only operating model
+        run: |
+          cat <<'MSG'
+          Data Common Gate complete.
+
+          This workflow intentionally performs static governance checks only.
+          Warehouse-backed dbt execution, source freshness, Databricks workspace
+          validation, job execution, and pipeline execution are opt-in gates for
+          stack-specific workflows.
+          MSG

--- a/ci/github/data-common-gate.yml
+++ b/ci/github/data-common-gate.yml
@@ -73,7 +73,7 @@ jobs:
               errors=$((errors + 1))
             fi
 
-            if [ -f "$feature_dir/nfrs.md" ] && grep -nE "\bTBD\b" "$feature_dir/nfrs.md"; then
+            if [ -f "$feature_dir/nfrs.md" ] && grep -nE '(^|[^[:alnum:]_])TBD([^[:alnum:]_]|$)' "$feature_dir/nfrs.md"; then
               echo "FAIL: $feature nfrs.md contains TBD"
               errors=$((errors + 1))
             fi

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3398,6 +3398,21 @@ class TestDataCommonCiGate:
             "ci/azure/data-common-gate.yml",
         ],
     )
+    def test_data_common_gate_uses_portable_tbd_word_boundary(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        assert r'grep -nE "\bTBD\b"' not in text
+        assert "grep -nE '(^|[^[:alnum:]_])TBD([^[:alnum:]_]|$)'" in text
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/data-common-gate.yml",
+            "ci/azure/data-common-gate.yml",
+        ],
+    )
     def test_data_common_gate_does_not_run_cloud_or_warehouse_commands(self, path):
         from cli.paths import REPO_ROOT
 

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3308,15 +3308,15 @@ class TestDataCiContract:
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(
-        "platform, repo_scope",
+        "platform, repo_scope, data_common",
         [
-            ("github", "ci/github/repo-scope-check.yml"),
-            ("azure", "ci/azure/repo-scope-check.yml"),
+            ("github", "ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"),
+            ("azure", "ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"),
         ],
     )
     @pytest.mark.parametrize("level", ["3", "4"])
     def test_data_ci_resolves_common_repo_scope_gate(
-        self, agent, platform, repo_scope, level,
+        self, agent, platform, repo_scope, data_common, level,
     ):
         from cli.paths import AGENTS_DIR
 
@@ -3327,26 +3327,92 @@ class TestDataCiContract:
         )
 
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
-        assert ci_governed == [repo_scope]
+        assert ci_governed == [repo_scope, data_common]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(
-        "platform, repo_scope",
+        "platform, repo_scope, data_common",
         [
-            ("github", "ci/github/repo-scope-check.yml"),
-            ("azure", "ci/azure/repo-scope-check.yml"),
+            ("github", "ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"),
+            ("azure", "ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"),
         ],
     )
-    def test_data_ci_contract_is_explicit_in_manifest(self, agent, platform, repo_scope):
+    def test_data_ci_contract_is_explicit_in_manifest(
+        self, agent, platform, repo_scope, data_common,
+    ):
         from cli.paths import AGENTS_DIR
 
         manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
         ci_block = manifest["variants"]["ci"][platform]
+        expected = [repo_scope, data_common]
 
         assert ci_block.get("governed", []) == []
-        assert ci_block["by_type"]["data"]["governed"] == [repo_scope]
+        assert ci_block["by_type"]["data"]["governed"] == expected
         assert ci_block["level_4"].get("governed", []) == []
-        assert ci_block["level_4"]["by_type"]["data"]["governed"] == [repo_scope]
+        assert ci_block["level_4"]["by_type"]["data"]["governed"] == expected
+
+
+class TestDataCommonCiGate:
+    """Conservative static data CI gates avoid warehouse/workspace execution."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/data-common-gate.yml",
+            "ci/azure/data-common-gate.yml",
+        ],
+    )
+    def test_data_common_gate_file_exists(self, path):
+        from cli.paths import REPO_ROOT
+
+        assert (REPO_ROOT / path).is_file()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/data-common-gate.yml",
+            "ci/azure/data-common-gate.yml",
+        ],
+    )
+    def test_data_common_gate_pins_conservative_static_checks(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        for required in [
+            "govkit validate --target .",
+            "architecture_preflight.md",
+            "plan.md",
+            "acceptance.feature",
+            "TBD",
+            "PII_HANDLING_CONTRACT.md",
+            "PII_HANDLING.md",
+            "repo-scope-check.yml",
+        ]:
+            assert required in text
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/data-common-gate.yml",
+            "ci/azure/data-common-gate.yml",
+        ],
+    )
+    def test_data_common_gate_does_not_run_cloud_or_warehouse_commands(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        forbidden = [
+            "dbt test",
+            "dbt build",
+            "dbt source freshness",
+            "databricks bundle deploy",
+            "databricks jobs run-now",
+            "databricks pipelines start-update",
+        ]
+        for command in forbidden:
+            assert command not in text
 
 
 class TestShapeMigrationWarning:


### PR DESCRIPTION
## Summary

- Add `ci/github/data-common-gate.yml` and `ci/azure/data-common-gate.yml` for conservative static data governance checks.
- Wire all production agent manifests so `--type data --ci github|azure --level 3|4` installs repo-scope plus the data common gate.
- Extend data CI contract tests and CI README guidance for the new gate.

## Notes

The new gate intentionally avoids warehouse queries, Databricks workspace calls, cloud credentials, source freshness, job execution, and pipeline execution. Those remain opt-in stack-specific gates for later increments.

## Validation

- `pytest tests/test_govkit.py::TestDataCiContract tests/test_govkit.py::TestDataCommonCiGate` -> 24 passed
- `pytest tests/test_govkit.py::TestDataCiContract tests/test_govkit.py::TestDataCommonCiGate tests/test_schemas.py` -> 104 passed
- `pytest tests/test_govkit.py` -> 209 passed
- Manual smoke apply for `claude-code`, `codex`, and `copilot` with `--type data --level 4 --ci github` verified both `repo-scope-check.yml` and `data-common-gate.yml` install
- `pytest` -> 899 passed, 1 skipped
- YAML parse sanity check for both new gate templates -> OK