### PR TITLE
[codex] Add conservative python-dbt CI gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Data installs now include a conservative `data-common-gate.yml` for GitHub
   or Azure. The gate runs static governance checks only and leaves warehouse,
   workspace, source freshness, and pipeline execution to opt-in stack gates.
+- `python-dbt` data installs now include a conservative `dbt-gate.yml` for
+  GitHub or Azure. The gate runs dbt dependency, parse, compile, SQLFluff, and
+  static model YAML checks while keeping warehouse-backed execution opt-in.
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -325,7 +325,12 @@
           "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
+          "data":       {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+            "by_stack": {
+              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+            }
+          }
         },
         "level_4": {
           "mode": "merge",
@@ -337,7 +342,12 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
+            "data":       {
+              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+              "by_stack": {
+                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+              }
+            }
           }
         },
         "level_5": {
@@ -394,7 +404,12 @@
           "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
+          "data":       {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+            "by_stack": {
+              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+            }
+          }
         },
         "level_4": {
           "mode": "merge",
@@ -406,7 +421,12 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
+            "data":       {
+              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+              "by_stack": {
+                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+              }
+            }
           }
         },
         "level_5": {

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -341,7 +341,12 @@
           "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
+          "data":       {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+            "by_stack": {
+              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+            }
+          }
         },
         "level_4": {
           "mode": "merge",
@@ -353,7 +358,12 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
+            "data":       {
+              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+              "by_stack": {
+                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+              }
+            }
           }
         },
         "level_5": {
@@ -410,7 +420,12 @@
           "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
+          "data":       {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+            "by_stack": {
+              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+            }
+          }
         },
         "level_4": {
           "mode": "merge",
@@ -422,7 +437,12 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
+            "data":       {
+              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+              "by_stack": {
+                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+              }
+            }
           }
         },
         "level_5": {

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -323,7 +323,12 @@
           "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
+          "data":       {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+            "by_stack": {
+              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+            }
+          }
         },
         "level_4": {
           "mode": "merge",
@@ -335,7 +340,12 @@
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"] }
+            "data":       {
+              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+              "by_stack": {
+                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+              }
+            }
           }
         },
         "level_5": {
@@ -392,7 +402,12 @@
           "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
-          "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
+          "data":       {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+            "by_stack": {
+              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+            }
+          }
         },
         "level_4": {
           "mode": "merge",
@@ -404,7 +419,12 @@
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "data":       { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"] }
+            "data":       {
+              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+              "by_stack": {
+                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+              }
+            }
           }
         },
         "level_5": {

--- a/ci/README.md
+++ b/ci/README.md
@@ -35,6 +35,7 @@ Copy the relevant templates for your project type:
 | `ui-quality-gate.yml` | — | — | ✓ | — |
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `data-common-gate.yml` | — | — | — | ✓ |
+| `dbt-gate.yml` | — | — | — | `python-dbt` |
 
 ### Quick Checklist
 
@@ -56,6 +57,7 @@ Copy the relevant templates for your project type:
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |
 | `ui-eval-gate.yml` | — | FIRST/Virtue prediction, Playwright E2E, axe scans |
 | `data-common-gate.yml` | Static governance artifact, PII policy, and `govkit validate` checks | Static governance artifact, PII policy, and `govkit validate` checks |
+| `dbt-gate.yml` | dbt dependency install, `dbt deps`, `dbt parse`, `dbt compile`, SQLFluff when configured, static model YAML checks | Same conservative checks; warehouse-backed test/source freshness execution remains opt-in |
 
 Level 3 projects receive only `l3-quality-gate.yml`. Level 4 projects receive the full set. Level 5 projects receive L4 gates plus 3 additional GenAI gates.
 
@@ -167,6 +169,27 @@ See: `docs/REPO_SCOPE_ANALYSIS_GUIDANCE.md` for complete repo scope semantics.
 **Boundary:** This gate does not query warehouses, call Databricks workspaces,
 deploy bundles, run jobs, execute pipelines, or require cloud credentials.
 Those checks belong in opt-in stack-specific gates.
+
+---
+
+## dbt Gate
+
+**File:** `dbt-gate.yml` (GitHub: `ci/github/dbt-gate.yml`, Azure: `ci/azure/dbt-gate.yml`)
+
+**Purpose:** Runs conservative `python-dbt` stack checks:
+
+- install dbt dependencies declared by the project
+- `dbt deps`
+- `dbt parse`
+- `dbt compile`
+- `sqlfluff lint` when SQLFluff is configured
+- static model YAML checks for model descriptions, column descriptions,
+  `unique` + `not_null` primary-key tests, and PII metadata
+
+**Boundary:** This gate documents but does not enable `dbt test --select
+state:modified+`, `dbt source freshness`, warehouse-backed model builds, or
+warehouse-backed data-quality execution. Enable those only after CI profiles,
+secrets, isolated schemas, and cost controls are configured.
 
 ---
 

--- a/ci/azure/dbt-gate.yml
+++ b/ci/azure/dbt-gate.yml
@@ -1,0 +1,202 @@
+# dbt-gate.yml
+#
+# PURPOSE: Conservative dbt checks for python-dbt data projects.
+# Reference this file from azure-pipelines.yml or copy its stage into your
+# project pipeline.
+#
+# Blocking by default:
+# - install dbt dependencies documented by the target project
+# - dbt deps
+# - dbt parse
+# - dbt compile
+# - SQLFluff lint when SQLFluff is configured
+# - static model YAML checks for descriptions, primary-key tests, and PII meta
+#
+# Opt-in only:
+# - dbt test --select state:modified+
+# - dbt source freshness
+# - warehouse-backed model build or data-quality execution
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - dbt_project.yml
+      - packages.yml
+      - models/**
+      - macros/**
+      - tests/**
+      - .sqlfluff
+      - pyproject.toml
+      - requirements*.txt
+      - ci/azure/dbt-gate.yml
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - dbt_project.yml
+      - packages.yml
+      - models/**
+      - macros/**
+      - tests/**
+      - .sqlfluff
+      - pyproject.toml
+      - requirements*.txt
+      - ci/azure/dbt-gate.yml
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: DbtGate
+    displayName: dbt static and parse checks
+    jobs:
+      - job: DbtGate
+        displayName: dbt static and parse checks
+        steps:
+          - checkout: self
+            fetchDepth: 0
+
+          - task: Bash@3
+            displayName: Run conservative dbt checks
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -euo pipefail
+
+                if [ ! -f dbt_project.yml ]; then
+                  echo "No dbt_project.yml found; python-dbt gate has nothing to check."
+                  exit 0
+                fi
+
+                python -m pip install --upgrade pip pyyaml
+
+                if [ -f requirements-dbt.txt ]; then
+                  python -m pip install -r requirements-dbt.txt
+                elif [ -f requirements.txt ] && grep -Eq 'dbt-(core|[A-Za-z0-9_-]+)' requirements.txt; then
+                  python -m pip install -r requirements.txt
+                elif [ -f pyproject.toml ] && grep -Eq 'dbt-(core|[A-Za-z0-9_-]+)' pyproject.toml; then
+                  python -m pip install -e '.[dev]' || python -m pip install -e .
+                else
+                  echo "FAIL: dbt_project.yml exists but no dbt dependency declaration was found."
+                  echo "Add dbt-core plus your warehouse adapter to requirements-dbt.txt, requirements.txt, or pyproject.toml."
+                  exit 1
+                fi
+
+                if ! command -v dbt >/dev/null 2>&1; then
+                  echo "FAIL: dbt is not on PATH after dependency installation."
+                  exit 1
+                fi
+
+                dbt deps
+                dbt parse
+                dbt compile
+
+                if [ -f .sqlfluff ] || ([ -f pyproject.toml ] && grep -q '\[tool.sqlfluff\]' pyproject.toml); then
+                  if ! command -v sqlfluff >/dev/null 2>&1; then
+                    python -m pip install 'sqlfluff>=3.0' 'sqlfluff-templater-dbt>=3.0'
+                  fi
+                  changed_sql=$(git diff --name-only origin/main...HEAD -- 'models/**/*.sql' 2>/dev/null || true)
+                  if [ -z "$changed_sql" ]; then
+                    changed_sql=$(find models -name '*.sql' -type f 2>/dev/null || true)
+                  fi
+                  if [ -n "$changed_sql" ]; then
+                    echo "$changed_sql" | xargs sqlfluff lint
+                  fi
+                else
+                  echo "SQLFluff not configured; skipping sqlfluff lint."
+                fi
+
+                python - <<'PY'
+                from __future__ import annotations
+
+                import pathlib
+                import re
+                import sys
+
+                import yaml
+
+                model_files = sorted(pathlib.Path("models").rglob("*.yml")) + sorted(
+                    pathlib.Path("models").rglob("*.yaml")
+                )
+                if not model_files:
+                    print("FAIL: no model YAML files found under models/.")
+                    sys.exit(1)
+
+                pii_name = re.compile(r"(email|phone|ssn|dob|birth|address|name)", re.I)
+                errors: list[str] = []
+
+                def test_names(column: dict) -> set[str]:
+                    names: set[str] = set()
+                    for entry in column.get("tests") or []:
+                        if isinstance(entry, str):
+                            names.add(entry)
+                        elif isinstance(entry, dict):
+                            names.update(str(key) for key in entry)
+                    return names
+
+                for path in model_files:
+                    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+                    for model in data.get("models") or []:
+                        model_name = model.get("name", f"<unnamed:{path}>")
+                        if not str(model.get("description") or "").strip():
+                            errors.append(f"{path}: model {model_name} missing description")
+
+                        columns = model.get("columns") or []
+                        if not columns:
+                            errors.append(f"{path}: model {model_name} has no documented columns")
+
+                        has_primary_key = False
+                        for column in columns:
+                            column_name = str(column.get("name") or "")
+                            if not str(column.get("description") or "").strip():
+                                errors.append(f"{path}: {model_name}.{column_name} missing description")
+
+                            tests = test_names(column)
+                            if {"unique", "not_null"} <= tests:
+                                has_primary_key = True
+
+                            meta = column.get("meta") or {}
+                            contains_pii = bool(meta.get("contains_pii"))
+                            if contains_pii and not meta.get("pii_category"):
+                                errors.append(
+                                    f"{path}: {model_name}.{column_name} has meta.contains_pii without pii_category"
+                                )
+                            if pii_name.search(column_name) and not contains_pii:
+                                errors.append(
+                                    f"{path}: {model_name}.{column_name} looks like PII but lacks meta.contains_pii"
+                                )
+
+                        if not has_primary_key:
+                            errors.append(
+                                f"{path}: model {model_name} needs one primary key column with unique and not_null tests"
+                            )
+
+                if errors:
+                    print("dbt static model checks failed:")
+                    for error in errors:
+                        print(f"  - {error}")
+                    sys.exit(1)
+
+                print("dbt static model checks passed.")
+                PY
+
+          - task: Bash@3
+            displayName: Document opt-in warehouse checks
+            inputs:
+              targetType: 'inline'
+              script: |
+                cat <<'MSG'
+                Optional checks are disabled until configured:
+                - dbt test --select state:modified+
+                - dbt source freshness
+                - warehouse-backed model build and warehouse-backed data-quality checks
+
+                Enable these only after CI has a safe profile, secrets, target schema,
+                cost controls, and warehouse isolation.
+                MSG

--- a/ci/github/dbt-gate.yml
+++ b/ci/github/dbt-gate.yml
@@ -1,0 +1,187 @@
+# dbt-gate.yml
+#
+# PURPOSE: Conservative dbt checks for python-dbt data projects.
+# Copy this file to .github/workflows/dbt-gate.yml.
+#
+# Blocking by default:
+# - install dbt dependencies documented by the target project
+# - dbt deps
+# - dbt parse
+# - dbt compile
+# - SQLFluff lint when SQLFluff is configured
+# - static model YAML checks for descriptions, primary-key tests, and PII meta
+#
+# Opt-in only:
+# - dbt test --select state:modified+
+# - dbt source freshness
+# - warehouse-backed model build or data-quality execution
+
+name: dbt Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'dbt_project.yml'
+      - 'packages.yml'
+      - 'models/**'
+      - 'macros/**'
+      - 'tests/**'
+      - '.sqlfluff'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'ci/github/dbt-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'dbt_project.yml'
+      - 'packages.yml'
+      - 'models/**'
+      - 'macros/**'
+      - 'tests/**'
+      - '.sqlfluff'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'ci/github/dbt-gate.yml'
+
+jobs:
+  dbt-gate:
+    name: dbt static and parse checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run conservative dbt checks
+        run: |
+          set -euo pipefail
+
+          if [ ! -f dbt_project.yml ]; then
+            echo "No dbt_project.yml found; python-dbt gate has nothing to check."
+            exit 0
+          fi
+
+          python -m pip install --upgrade pip pyyaml
+
+          if [ -f requirements-dbt.txt ]; then
+            python -m pip install -r requirements-dbt.txt
+          elif [ -f requirements.txt ] && grep -Eq 'dbt-(core|[A-Za-z0-9_-]+)' requirements.txt; then
+            python -m pip install -r requirements.txt
+          elif [ -f pyproject.toml ] && grep -Eq 'dbt-(core|[A-Za-z0-9_-]+)' pyproject.toml; then
+            python -m pip install -e '.[dev]' || python -m pip install -e .
+          else
+            echo "FAIL: dbt_project.yml exists but no dbt dependency declaration was found."
+            echo "Add dbt-core plus your warehouse adapter to requirements-dbt.txt, requirements.txt, or pyproject.toml."
+            exit 1
+          fi
+
+          if ! command -v dbt >/dev/null 2>&1; then
+            echo "FAIL: dbt is not on PATH after dependency installation."
+            exit 1
+          fi
+
+          dbt deps
+          dbt parse
+          dbt compile
+
+          if [ -f .sqlfluff ] || ([ -f pyproject.toml ] && grep -q '\[tool.sqlfluff\]' pyproject.toml); then
+            if ! command -v sqlfluff >/dev/null 2>&1; then
+              python -m pip install 'sqlfluff>=3.0' 'sqlfluff-templater-dbt>=3.0'
+            fi
+            changed_sql=$(git diff --name-only origin/main...HEAD -- 'models/**/*.sql' 2>/dev/null || true)
+            if [ -z "$changed_sql" ]; then
+              changed_sql=$(find models -name '*.sql' -type f 2>/dev/null || true)
+            fi
+            if [ -n "$changed_sql" ]; then
+              echo "$changed_sql" | xargs sqlfluff lint
+            fi
+          else
+            echo "SQLFluff not configured; skipping sqlfluff lint."
+          fi
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import pathlib
+          import re
+          import sys
+
+          import yaml
+
+          model_files = sorted(pathlib.Path("models").rglob("*.yml")) + sorted(
+              pathlib.Path("models").rglob("*.yaml")
+          )
+          if not model_files:
+              print("FAIL: no model YAML files found under models/.")
+              sys.exit(1)
+
+          pii_name = re.compile(r"(email|phone|ssn|dob|birth|address|name)", re.I)
+          errors: list[str] = []
+
+          def test_names(column: dict) -> set[str]:
+              names: set[str] = set()
+              for entry in column.get("tests") or []:
+                  if isinstance(entry, str):
+                      names.add(entry)
+                  elif isinstance(entry, dict):
+                      names.update(str(key) for key in entry)
+              return names
+
+          for path in model_files:
+              data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+              for model in data.get("models") or []:
+                  model_name = model.get("name", f"<unnamed:{path}>")
+                  if not str(model.get("description") or "").strip():
+                      errors.append(f"{path}: model {model_name} missing description")
+
+                  columns = model.get("columns") or []
+                  if not columns:
+                      errors.append(f"{path}: model {model_name} has no documented columns")
+
+                  has_primary_key = False
+                  for column in columns:
+                      column_name = str(column.get("name") or "")
+                      if not str(column.get("description") or "").strip():
+                          errors.append(f"{path}: {model_name}.{column_name} missing description")
+
+                      tests = test_names(column)
+                      if {"unique", "not_null"} <= tests:
+                          has_primary_key = True
+
+                      meta = column.get("meta") or {}
+                      contains_pii = bool(meta.get("contains_pii"))
+                      if contains_pii and not meta.get("pii_category"):
+                          errors.append(
+                              f"{path}: {model_name}.{column_name} has meta.contains_pii without pii_category"
+                          )
+                      if pii_name.search(column_name) and not contains_pii:
+                          errors.append(
+                              f"{path}: {model_name}.{column_name} looks like PII but lacks meta.contains_pii"
+                          )
+
+                  if not has_primary_key:
+                      errors.append(
+                          f"{path}: model {model_name} needs one primary key column with unique and not_null tests"
+                      )
+
+          if errors:
+              print("dbt static model checks failed:")
+              for error in errors:
+                  print(f"  - {error}")
+              sys.exit(1)
+
+          print("dbt static model checks passed.")
+          PY
+
+      - name: Document opt-in warehouse checks
+        run: |
+          cat <<'MSG'
+          Optional checks are disabled until configured:
+          - dbt test --select state:modified+
+          - dbt source freshness
+          - warehouse-backed model build and warehouse-backed data-quality checks
+
+          Enable these only after CI has a safe profile, secrets, target schema,
+          cost controls, and warehouse isolation.
+          MSG

--- a/cli/cmd_apply.py
+++ b/cli/cmd_apply.py
@@ -102,6 +102,11 @@ def _apply_variant_install(
     options = resolve_options(manifest, args)
     validate_level_type(options.get("level"), options.get("type"))
     level = options.get("level", "3")
+
+    stack_meta, stack_assumption, options, profile = apply_stack_overlay(
+        target, getattr(args, "stack", None), options, prior_applied_at, force,
+    )
+
     print(f"\n  Configuration: {options}\n")
     files, shared, governed = resolve_variant_files(manifest, options)
 
@@ -116,10 +121,6 @@ def _apply_variant_install(
     copy_governed_or_shared(shared, target, prior_applied_at, force, baseline, l5_exclude)
 
     _ensure_features_dir(target, level)
-
-    stack_meta, stack_assumption, options, profile = apply_stack_overlay(
-        target, getattr(args, "stack", None), options, prior_applied_at, force,
-    )
 
     marker = write_govkit_marker(
         target, args.agent, level, options,

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -1606,6 +1606,23 @@ class TestApplyTypeDataStackDefault:
         marker = read_govkit_marker(target)
         assert marker["stack"]["id"] == "python-dbt"
 
+    def test_apply_type_data_default_stack_installs_dbt_ci_gate(self, tmp_path):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "project"
+        target.mkdir()
+        cmd_apply(argparse.Namespace(
+            agent="claude-code", target=str(target),
+            level="4", type="data", ci="github",
+            stack=None, force=False, detect=False,
+        ))
+
+        assert (target / "ci" / "github" / "repo-scope-check.yml").is_file()
+        assert (target / "ci" / "github" / "data-common-gate.yml").is_file()
+        assert (target / "ci" / "github" / "dbt-gate.yml").is_file()
+
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     def test_apply_type_data_rejects_l5(self, tmp_path, agent, capsys):
         """Data is an L3/L4 shape. L5 is GenAI-Ops for LLM app delivery and
@@ -3428,6 +3445,121 @@ class TestDataCommonCiGate:
         ]
         for command in forbidden:
             assert command not in text
+
+
+class TestPythonDbtCiGate:
+    """python-dbt data installs add conservative dbt static/parse CI gates."""
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    @pytest.mark.parametrize(
+        "platform, repo_scope, data_common, dbt_gate",
+        [
+            (
+                "github",
+                "ci/github/repo-scope-check.yml",
+                "ci/github/data-common-gate.yml",
+                "ci/github/dbt-gate.yml",
+            ),
+            (
+                "azure",
+                "ci/azure/repo-scope-check.yml",
+                "ci/azure/data-common-gate.yml",
+                "ci/azure/dbt-gate.yml",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("level", ["3", "4"])
+    def test_python_dbt_data_ci_resolves_common_plus_dbt_gate(
+        self, agent, platform, repo_scope, data_common, dbt_gate, level,
+    ):
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "python-dbt", "ci": platform, "level": level},
+        )
+
+        ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
+        assert ci_governed == [repo_scope, data_common, dbt_gate]
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    @pytest.mark.parametrize(
+        "platform, dbt_gate",
+        [
+            ("github", "ci/github/dbt-gate.yml"),
+            ("azure", "ci/azure/dbt-gate.yml"),
+        ],
+    )
+    def test_non_dbt_data_stack_does_not_resolve_dbt_gate(self, agent, platform, dbt_gate):
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "databricks-lakehouse", "ci": platform, "level": "4"},
+        )
+
+        assert dbt_gate not in governed
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/dbt-gate.yml",
+            "ci/azure/dbt-gate.yml",
+        ],
+    )
+    def test_dbt_gate_file_exists(self, path):
+        from cli.paths import REPO_ROOT
+
+        assert (REPO_ROOT / path).is_file()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/dbt-gate.yml",
+            "ci/azure/dbt-gate.yml",
+        ],
+    )
+    def test_dbt_gate_pins_conservative_blocking_checks(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        for required in [
+            "dbt_project.yml",
+            "dbt deps",
+            "dbt parse",
+            "dbt compile",
+            "sqlfluff lint",
+            "meta.contains_pii",
+            "pii_category",
+            "unique",
+            "not_null",
+        ]:
+            assert required in text
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/dbt-gate.yml",
+            "ci/azure/dbt-gate.yml",
+        ],
+    )
+    def test_dbt_gate_marks_warehouse_execution_opt_in(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        for opt_in in [
+            "dbt test --select state:modified+",
+            "dbt source freshness",
+            "warehouse-backed model build",
+            "disabled until configured",
+        ]:
+            assert opt_in in text
 
 
 class TestShapeMigrationWarning:


### PR DESCRIPTION
## Summary

- Add GitHub and Azure `dbt-gate.yml` templates for the `python-dbt` data stack.
- Wire the gate into all agent manifests through `by_stack.python-dbt` for data Level 3 and Level 4 installs.
- Move stack overlay resolution earlier in `govkit apply` so default data stack selection is available before stack-aware CI variant resolution.
- Document the new dbt gate and update release notes.

## Behavior

The dbt gate performs conservative blocking checks only: dbt dependency installation, `dbt deps`, `dbt parse`, `dbt compile`, optional SQLFluff linting when configured, and static model YAML checks for descriptions, primary key tests, and PII metadata.

Warehouse-backed execution remains opt-in and documented but disabled by default, including `dbt test --select state:modified+`, `dbt source freshness`, model builds, and data-quality execution.

## Validation

- `pytest tests/test_govkit.py::TestApplyTypeDataStackDefault::test_apply_type_data_default_stack_installs_dbt_ci_gate tests/test_govkit.py::TestPythonDbtCiGate`
- `pytest tests/test_govkit.py::TestApplyTypeDataStackDefault tests/test_govkit.py::TestDataCiContract tests/test_govkit.py::TestDataCommonCiGate tests/test_govkit.py::TestPythonDbtCiGate tests/test_schemas.py tests/test_stack_select.py tests/test_fixtures.py`
- YAML parse smoke for GitHub/Azure dbt and data-common workflow templates
- Manual apply smoke for `claude-code`, `codex`, and `copilot` data Level 4 GitHub installs with default stack selection
- `pytest`