### PR TITLE
[codex] Add Databricks lakehouse stack overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - `python-dbt` data installs now include a conservative `dbt-gate.yml` for
   GitHub or Azure. The gate runs dbt dependency, parse, compile, SQLFluff, and
   static model YAML checks while keeping warehouse-backed execution opt-in.
+- Added a `databricks-lakehouse` data stack overlay for Databricks-native repos
+  using Unity Catalog, Delta tables, Asset Bundles, Jobs, Lakeflow Pipelines,
+  PySpark, SQL, and notebooks.
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -18,7 +18,7 @@
       "default": "github"
     },
     "stack": {
-      "choices": ["python-fastapi", "dotnet-aspnet", "java-spring-boot", "nodejs-fastify", "go-gin", "python-dbt"],
+      "choices": ["python-fastapi", "dotnet-aspnet", "java-spring-boot", "nodejs-fastify", "go-gin", "python-dbt", "databricks-lakehouse"],
       "default": "python-fastapi"
     }
   },

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -18,7 +18,7 @@
       "default": "github"
     },
     "stack": {
-      "choices": ["python-fastapi", "dotnet-aspnet", "java-spring-boot", "nodejs-fastify", "go-gin", "python-dbt"],
+      "choices": ["python-fastapi", "dotnet-aspnet", "java-spring-boot", "nodejs-fastify", "go-gin", "python-dbt", "databricks-lakehouse"],
       "default": "python-fastapi"
     }
   },

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -18,7 +18,7 @@
       "default": "github"
     },
     "stack": {
-      "choices": ["python-fastapi", "dotnet-aspnet", "java-spring-boot", "nodejs-fastify", "go-gin", "python-dbt"],
+      "choices": ["python-fastapi", "dotnet-aspnet", "java-spring-boot", "nodejs-fastify", "go-gin", "python-dbt", "databricks-lakehouse"],
       "default": "python-fastapi"
     }
   },

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -264,6 +264,8 @@ _STACK_PRIMARY_LANGUAGE = {
     "java-spring-boot": "java",
     "nodejs-fastify":   "typescript",
     "go-gin":           "go",
+    "python-dbt":       "python",
+    "databricks-lakehouse": "python",
 }
 
 

--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -86,7 +86,10 @@ class SkillContext:
     stack_id: str | None
     stack_version: str | None
     language: str | None
+    framework: str | None
     api_framework: str | None
+    deployment: str | None
+    orchestration: str | None
     unit_test: str | None
     bdd_test: str | None
     ci: str | None
@@ -287,7 +290,10 @@ def load_skill_context(target: Path) -> SkillContext | None:
         stack_id=stack.get("id") if isinstance(stack.get("id"), str) else None,
         stack_version=stack.get("version") if isinstance(stack.get("version"), str) else None,
         language=stack.get("language") if isinstance(stack.get("language"), str) else None,
+        framework=stack.get("framework") if isinstance(stack.get("framework"), str) else None,
         api_framework=stack.get("api_framework") if isinstance(stack.get("api_framework"), str) else None,
+        deployment=stack.get("deployment") if isinstance(stack.get("deployment"), str) else None,
+        orchestration=stack.get("orchestration") if isinstance(stack.get("orchestration"), str) else None,
         unit_test=stack.get("unit_test") if isinstance(stack.get("unit_test"), str) else None,
         bdd_test=stack.get("bdd_test") if isinstance(stack.get("bdd_test"), str) else None,
         ci=data.get("ci") if isinstance(data.get("ci"), str) else None,

--- a/cli/stack_select.py
+++ b/cli/stack_select.py
@@ -47,6 +47,7 @@ _STACK_SUPPORTED_TYPES = {
     "nodejs-fastify":    frozenset({"api", "cli"}),
     "go-gin":            frozenset({"api", "cli"}),
     "python-dbt":        frozenset({"data"}),
+    "databricks-lakehouse": frozenset({"data"}),
 }
 
 

--- a/cli/stacks/README.md
+++ b/cli/stacks/README.md
@@ -1,8 +1,8 @@
 # Stack Overlays
 
-This directory contains GovKit's bundled stack overlays. Each overlay is a small bundle of 6 stack-specific architecture docs (`TECH_STACK.md`, `API_CONVENTIONS.md`, `TESTING.md`, `LAYER_IMPLEMENTATION.md`, `SECURITY_AUTH_PATTERNS.md`, `OBSERVABILITY_PORT_CONTRACT.md`) plus an `overlay.yaml` describing metadata, default assumptions, skill context, and a review checklist.
+This directory contains GovKit's bundled stack overlays. Each overlay is a small bundle of stack-specific architecture docs plus an `overlay.yaml` describing metadata, default assumptions, skill context, and a review checklist.
 
-These overlays ship inside the GovKit Python wheel under `cli/stacks/`. Client repos never see this directory directly — they receive only the docs from the selected overlay, copied into their own `docs/backend/architecture/`.
+These overlays ship inside the GovKit Python wheel under `cli/stacks/`. Client repos never see this directory directly - they receive only the docs from the selected overlay, copied into their own `docs/backend/architecture/` or `docs/data/architecture/`.
 
 ---
 
@@ -20,13 +20,15 @@ govkit apply --agent claude-code --target . --level 4 --type api --ci github \
 govkit stack apply java-spring-boot --target .
 ```
 
-`govkit stack apply` honors edit-protection — any of the 6 stack docs you've modified since the last apply are preserved unless you pass `--force`. The chosen stack is recorded in `.govkit/marker.json` under `stack` and as a `stack.id` assumption.
+`govkit stack apply` honors edit-protection - any stack docs you've modified since the last apply are preserved unless you pass `--force`. The chosen stack is recorded in `.govkit/marker.json` under `stack` and as a `stack.id` assumption.
 
 ---
 
-## Why only 6 files?
+## Why Stack Docs?
 
-The agent rules (`agents/*/rules/`) and the majority of architecture docs are language-agnostic — they enforce hexagonal architecture, FIRST principles, and the 7 Code Virtues regardless of language. Only these 6 vary per stack:
+The agent rules (`agents/*/rules/`) and the majority of architecture docs are shape-agnostic. Stack overlays provide only the docs that vary by runtime, framework, data platform, or delivery surface.
+
+Backend/API stacks typically vary these files:
 
 | File | What it defines |
 |---|---|
@@ -39,6 +41,8 @@ The agent rules (`agents/*/rules/`) and the majority of architecture docs are la
 
 All other docs (DESIGN_PRINCIPLES, ARCH_CONTRACT, BOUNDARIES, GHERKIN_CONVENTIONS, ERROR_MAPPING, etc.) are universal and ship from the baseline `governed` install.
 
+Data stacks install their stack-specific docs under `docs/data/architecture/` and may use data-oriented names such as `MODEL_LAYERING.md`, `PIPELINE_CONTRACT.md`, and `PII_HANDLING.md`.
+
 ---
 
 ## Bundled overlays
@@ -50,6 +54,8 @@ All other docs (DESIGN_PRINCIPLES, ARCH_CONTRACT, BOUNDARIES, GHERKIN_CONVENTION
 | `java-spring-boot` | Java 21 / Spring Boot 3 / Spring Web MVC / JUnit 5 |
 | `nodejs-fastify` | Node.js 20 LTS / TypeScript 5 / Fastify 4 / Vitest |
 | `go-gin` | Go 1.22+ / Gin / standard library testing + testify |
+| `python-dbt` | Python 3.11+ / dbt-core / dbt tests |
+| `databricks-lakehouse` | Databricks Lakehouse / Unity Catalog / Delta / Asset Bundles |
 
 ---
 
@@ -57,7 +63,7 @@ All other docs (DESIGN_PRINCIPLES, ARCH_CONTRACT, BOUNDARIES, GHERKIN_CONVENTION
 
 To add a stack not listed here:
 
-1. Create `cli/stacks/<id>/` with all 6 stack docs (mirror the section structure of an existing overlay for consistency).
+1. Create `cli/stacks/<id>/` with the stack docs the overlay declares (mirror the section structure of a similar overlay for consistency).
 2. Add `cli/stacks/<id>/overlay.yaml` declaring `id`, `version`, `display_name`, `summary`, `default_assumptions`, `docs`, `skill_context`, and `review_checklist`. See [`python-fastapi/overlay.yaml`](python-fastapi/overlay.yaml) as a template.
 3. Submit a PR — the only constraint is that each doc must preserve the section headings so the agent rules can reference them consistently.
 

--- a/cli/stacks/databricks-lakehouse/LINEAGE_OBSERVABILITY.md
+++ b/cli/stacks/databricks-lakehouse/LINEAGE_OBSERVABILITY.md
@@ -1,0 +1,65 @@
+# Lineage and Observability - Databricks Lakehouse
+
+This document defines the minimum observability and lineage expectations for
+Databricks-native data delivery.
+
+---
+
+# 1. Lineage
+
+Unity Catalog lineage is the preferred lineage source where available.
+
+Each governed change should identify:
+
+- upstream tables, files, streams, or external sources
+- transformed Delta tables or views
+- downstream jobs, dashboards, ML features, or consumers
+- ownership and support route for each published asset
+
+When automated lineage is unavailable, document manual lineage in the feature
+plan or architecture notes.
+
+---
+
+# 2. Operational Observability
+
+Jobs and pipelines should expose:
+
+- success/failure status
+- duration and retry count
+- rows read/written where available
+- late, missing, or duplicated source data indicators
+- data quality failures and quarantined records
+- cost or compute usage signals for expensive workloads
+
+Alerts must route to an accountable team, not only to an individual developer.
+
+---
+
+# 3. Data Quality Signals
+
+Data quality findings should name:
+
+- asset and layer
+- failed expectation
+- affected row count or bounded sample
+- severity and release impact
+- owner and remediation path
+
+Warnings may be acceptable for exploratory or bronze assets. Published silver
+and gold assets need explicit blocking criteria.
+
+---
+
+# 4. Cost and Runtime Review
+
+Expensive workloads require a review of:
+
+- cluster/serverless policy
+- expected schedule and concurrency
+- input data volume
+- backfill behavior
+- budget or alert threshold
+
+Pipeline execution should not be enabled in CI until these controls are
+documented.

--- a/cli/stacks/databricks-lakehouse/MODEL_LAYERING.md
+++ b/cli/stacks/databricks-lakehouse/MODEL_LAYERING.md
@@ -1,0 +1,57 @@
+# Model Layering - Databricks Lakehouse
+
+This document defines how Databricks-native data assets are layered.
+
+---
+
+# 1. Default Layering
+
+Use medallion layering unless the team documents a different convention:
+
+- bronze: raw or lightly normalized source-shaped data
+- silver: cleaned, conformed, deduplicated, and quality-checked data
+- gold: serving models for BI, ML, operational consumers, or published data
+  products
+
+The repository may use folder names such as `src/bronze`, `src/silver`, and
+`src/gold`, or bundle resource names that make the layer explicit.
+
+---
+
+# 2. Dependency Rules
+
+Layer rules:
+
+- gold assets should not read directly from bronze unless an ADR approves it.
+- bronze assets should avoid business joins and derived metrics.
+- silver assets own standardization, deduplication, and entity conformance.
+- gold assets own consumer contracts, metric definitions, and serving shape.
+
+Cross-layer shortcuts require a documented rationale because they make lineage,
+quality ownership, and rollback harder to reason about.
+
+---
+
+# 3. Delta Table Contracts
+
+Each durable table should document:
+
+- owner and support channel
+- catalog, schema, and table naming convention
+- primary key or uniqueness expectation
+- partitioning or clustering rationale when used
+- update mode: append, merge, overwrite, streaming, or materialized view
+- retention, vacuum, and backfill expectations
+
+Schema evolution must be explicit. Breaking changes need an ADR and downstream
+consumer notification.
+
+---
+
+# 4. Notebooks and Modules
+
+Notebooks may orchestrate or demonstrate a transformation, but reusable logic
+belongs in versioned modules under `src/` when feasible.
+
+Notebook-only production logic must still satisfy review, testing, PII, and
+lineage requirements.

--- a/cli/stacks/databricks-lakehouse/PII_HANDLING.md
+++ b/cli/stacks/databricks-lakehouse/PII_HANDLING.md
@@ -1,0 +1,59 @@
+# PII Handling - Databricks Lakehouse
+
+This document defines sensitive data expectations for Databricks-native data
+assets.
+
+---
+
+# 1. Classification
+
+Sensitive columns must be classified before release. At minimum, document:
+
+- direct identifiers such as email, phone, address, government id, or account id
+- quasi-identifiers such as name, date of birth, postal code, or device id
+- financial, health, employment, or other regulated attributes
+- derived features that can reveal sensitive status
+
+Unknown classification is not acceptable for gold/public serving assets.
+
+---
+
+# 2. Unity Catalog Controls
+
+Use Unity Catalog as the governance boundary where available:
+
+- catalog/schema/table ownership must be explicit
+- permissions must follow least privilege
+- sensitive columns should use tags or documented policy metadata
+- row filters, column masks, or views should be used where appropriate
+- non-prod access to sensitive data must be minimized or masked
+
+Repos without Unity Catalog need a documented transitional control plan.
+
+---
+
+# 3. Development and CI Data
+
+Development and CI must not require production PII by default.
+
+Rules:
+
+- use synthetic, masked, sampled, or isolated data for tests
+- never commit extracted production data
+- never commit Databricks tokens, PATs, secrets, or workspace credentials
+- avoid personal workspace paths in bundle/job/pipeline configs
+
+If live data access is required, document the identity, table scope, purpose,
+and approval path.
+
+---
+
+# 4. Release Expectations
+
+Before release, every sensitive table or column must have:
+
+- classification
+- owner
+- masking or access policy
+- downstream consumer awareness
+- retention or deletion expectation when applicable

--- a/cli/stacks/databricks-lakehouse/PIPELINE_CONTRACT.md
+++ b/cli/stacks/databricks-lakehouse/PIPELINE_CONTRACT.md
@@ -1,0 +1,69 @@
+# Pipeline Contract - Databricks Lakehouse
+
+This document defines deployment and orchestration expectations for Databricks
+Jobs and Lakeflow Pipelines.
+
+---
+
+# 1. Asset Bundle Contract
+
+Databricks Asset Bundles are the preferred packaging contract.
+
+Required when bundles are used:
+
+- `databricks.yml` at the repo root or documented bundle root
+- named targets for dev, ci, staging, and prod where applicable
+- resource definitions in reviewable YAML files
+- variables for catalog, schema, workspace host, and environment names
+- no personal workspace paths or user-specific compute in committed resources
+
+If the repo does not use Asset Bundles, document the alternate deployment
+contract and why it is acceptable.
+
+---
+
+# 2. Job and Pipeline Rules
+
+Jobs and Lakeflow Pipelines must define:
+
+- owner and on-call/support expectation
+- schedule or trigger policy
+- input and output data assets
+- retry and timeout behavior
+- compute policy or serverless/runtime expectation
+- alerting or failure notification route
+
+Production schedules require approval and should not be inferred from examples
+or development notebooks.
+
+---
+
+# 3. CI Boundary
+
+Allowed by default:
+
+- static bundle/config checks
+- source linting and unit tests
+- validation commands that do not require paid compute when credentials are
+  absent
+
+Opt-in only:
+
+- `databricks bundle deploy`
+- Jobs or Lakeflow Pipeline runs
+- data quality checks against a live warehouse
+- source freshness or table scans
+
+Opt-in execution requires documented identity, target environment, isolated
+schema/catalog, and cost controls.
+
+---
+
+# 4. Rollback and Replay
+
+Every production pipeline must document the rollback or replay path:
+
+- how to disable a schedule or trigger
+- how to rerun a bounded date/key range
+- how to repair partially written Delta tables
+- how downstream consumers are notified

--- a/cli/stacks/databricks-lakehouse/TECH_STACK.md
+++ b/cli/stacks/databricks-lakehouse/TECH_STACK.md
@@ -1,0 +1,78 @@
+# Technology Stack - Databricks Lakehouse
+
+This document defines the approved Databricks-native stack for this data
+repository. GovKit governs repository delivery contracts; Databricks provides
+the platform runtime.
+
+---
+
+# 1. Platform Boundary
+
+Approved platform surfaces:
+
+- Unity Catalog for catalog, schema, table, volume, permission, and lineage
+  governance
+- Delta tables for durable storage contracts
+- Databricks Asset Bundles for deployable configuration
+- Databricks Jobs and Lakeflow Pipelines for orchestration
+- PySpark and SQL for transformations
+- Notebooks only when source-controlled and reviewable
+
+Workspace calls, deployments, and pipeline/job execution are not assumed to be
+available in CI. Treat them as opt-in once service principals, secrets, target
+schemas, and cost controls are configured.
+
+---
+
+# 2. Repository Layout
+
+Preferred layout:
+
+```text
+databricks.yml
+resources/
+  jobs.yml
+  pipelines.yml
+src/
+  transforms/
+  quality/
+  shared/
+notebooks/
+tests/
+docs/data/architecture/
+```
+
+Rules:
+
+- Put reusable transformation logic in `src/`, not only in notebooks.
+- Keep bundle resources in `resources/` or another documented bundle include.
+- Keep environment-specific names in bundle targets or variables.
+- Do not commit workspace personal paths, tokens, or ad hoc cluster ids.
+
+---
+
+# 3. Runtime Defaults
+
+Approved defaults:
+
+- Python 3.11 or the Databricks Runtime default documented by the platform team
+- PySpark APIs for production transformations
+- SQL for simple views, quality checks, and analyst-owned transformations
+- Delta table constraints and expectations where the runtime supports them
+
+New runtime families, external orchestrators, or non-Delta storage contracts
+require an ADR.
+
+---
+
+# 4. Environment Separation
+
+Each environment must have an explicit catalog and schema strategy:
+
+- dev: individual or team-isolated schemas
+- ci: short-lived schemas or validation-only targets
+- staging: production-like permissions and data shape
+- prod: least-privilege production catalog/schema permissions
+
+CI must not deploy or execute Databricks workloads unless the repo documents
+the target workspace, identity, isolation strategy, and cost guardrails.

--- a/cli/stacks/databricks-lakehouse/TESTING.md
+++ b/cli/stacks/databricks-lakehouse/TESTING.md
@@ -1,0 +1,60 @@
+# Testing - Databricks Lakehouse
+
+This document defines the testing floor for Databricks-native data delivery.
+
+---
+
+# 1. Local Static Checks
+
+Blocking by default:
+
+- Python unit tests for pure transformation modules with `pytest`
+- import and syntax checks for source-controlled notebooks when tooling exists
+- bundle configuration validation when Databricks CLI authentication is
+  available
+- static scans for secrets, personal paths, hardcoded workspace URLs, and
+  unreviewed catalog/schema names
+
+Tests that require Databricks compute are opt-in until CI identity, workspace,
+target schema, and cost controls are approved.
+
+---
+
+# 2. Transformation Unit Tests
+
+Write business logic in testable Python modules whenever possible.
+
+Rules:
+
+- Isolate DataFrame transformation functions from Jobs/Pipeline wiring.
+- Test schema changes, null behavior, joins, deduplication, and error branches.
+- Use small in-memory fixtures; do not require production data for unit tests.
+- Keep notebooks as orchestration or exploration surfaces, not the only testable
+  implementation.
+
+---
+
+# 3. Data Quality Tests
+
+Required data quality coverage:
+
+- primary key uniqueness where a table has a natural or surrogate key
+- not-null checks for required columns
+- referential integrity or documented exceptions
+- freshness or latency expectations for externally consumed tables
+- PII tag and masking expectations for sensitive columns
+
+Warehouse-backed data quality execution is opt-in in CI. If enabled, it must
+run against isolated schemas with bounded data and compute.
+
+---
+
+# 4. Acceptance Criteria
+
+Every governed data feature should include acceptance criteria that name:
+
+- affected tables, views, jobs, or pipelines
+- expected input and output data shape
+- quality checks that must block release
+- lineage or downstream consumers impacted
+- rollback or replay expectations

--- a/cli/stacks/databricks-lakehouse/overlay.yaml
+++ b/cli/stacks/databricks-lakehouse/overlay.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=../../../governance/schemas/stack-overlay.schema.json
+id: databricks-lakehouse
+version: "0.10.0"
+display_name: "Databricks Lakehouse (Unity Catalog / Delta / Asset Bundles)"
+summary: "Databricks-native data delivery with Unity Catalog, Delta tables, Asset Bundles, Jobs, Lakeflow Pipelines, PySpark, SQL, and notebooks"
+default_assumptions:
+  - id: stack.language
+    value: python
+  - id: stack.framework
+    value: databricks-lakehouse
+  - id: databricks.unity_catalog
+    value: required
+    review_required: true
+  - id: databricks.asset_bundles
+    value: preferred
+    review_required: true
+  - id: databricks.ci_workspace_auth
+    value: not-assumed
+    review_required: true
+docs:
+  - src: TECH_STACK.md
+    dest: docs/data/architecture/TECH_STACK.md
+    editable: true
+  - src: TESTING.md
+    dest: docs/data/architecture/TESTING.md
+    editable: true
+  - src: MODEL_LAYERING.md
+    dest: docs/data/architecture/MODEL_LAYERING.md
+    editable: true
+  - src: PIPELINE_CONTRACT.md
+    dest: docs/data/architecture/PIPELINE_CONTRACT.md
+    editable: true
+  - src: PII_HANDLING.md
+    dest: docs/data/architecture/PII_HANDLING.md
+    editable: true
+  - src: LINEAGE_OBSERVABILITY.md
+    dest: docs/data/architecture/LINEAGE_OBSERVABILITY.md
+    editable: true
+skill_context:
+  language: python
+  framework: databricks-lakehouse
+  deployment: databricks-asset-bundles
+  orchestration: databricks-jobs-lakeflow
+  unit_test: pytest
+  package_files: ["pyproject.toml", "requirements.txt", "databricks.yml"]
+  source_folder_hint: ["src/", "notebooks/", "resources/", "pipelines/"]
+review_checklist:
+  - "Confirm Unity Catalog is enabled and name the dev/ci/staging/prod catalogs and schemas."
+  - "Confirm whether Databricks Asset Bundles are the deployment contract for this repo."
+  - "Confirm whether notebooks are source-controlled, generated from modules, or limited to exploration."
+  - "Confirm whether CI can authenticate to a Databricks workspace; workspace execution is opt-in until approved."
+  - "Confirm compute policies, serverless/runtime defaults, and cost controls for Jobs and Lakeflow Pipelines."
+  - "Confirm PII tagging, masking, and non-prod data handling expectations."

--- a/governance/schemas/stack-overlay.schema.json
+++ b/governance/schemas/stack-overlay.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "GovKit Stack Overlay Schema",
-  "description": "Schema for cli/stacks/<id>/overlay.yaml — the metadata file shipped alongside the 6 stack-specific architecture docs (TECH_STACK, API_CONVENTIONS, TESTING, LAYER_IMPLEMENTATION, SECURITY_AUTH_PATTERNS, OBSERVABILITY_PORT_CONTRACT). Loaded by cli/overlay.py.",
+  "description": "Schema for cli/stacks/<id>/overlay.yaml - the metadata file shipped alongside stack-specific architecture docs. Loaded by cli/overlay.py.",
   "type": "object",
   "required": ["id", "version", "display_name", "summary", "docs"],
   "additionalProperties": false,

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -385,6 +385,27 @@ class TestMonorepoDiscovery:
         findings = run_doctor(tmp_path)
         assert not any(f.id == "D005" for f in findings)
 
+    def test_d005_recognizes_databricks_lakehouse_as_python_stack(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, stack={
+            "id": "databricks-lakehouse", "version": "0.10.0",
+            "display_name": "Databricks Lakehouse",
+            "applied_at": "2026-05-27T10:00:00+00:00",
+        })
+        (tmp_path / "package.json").write_text(
+            '{"devDependencies":{"typescript":"^5.0.0"}}\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "tsconfig.json").write_text('{}\n', encoding="utf-8")
+
+        findings = run_doctor(tmp_path)
+        d005s = [f for f in findings if f.id == "D005"]
+        assert len(d005s) == 1
+        assert d005s[0].severity == "warning"
+        assert "databricks-lakehouse" in d005s[0].message
+        assert "typescript" in d005s[0].message
+
     def test_d005_does_not_fire_when_no_language_detected(self, tmp_path):
         """Empty repo has nothing to disagree with — D005 silent."""
         from cli.doctor import run_doctor

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2948,7 +2948,8 @@ class TestCmdStackList:
         out = capsys.readouterr().out
 
         for stack_id in ("python-fastapi", "dotnet-aspnet", "java-spring-boot",
-                         "nodejs-fastify", "go-gin"):
+                         "nodejs-fastify", "go-gin", "python-dbt",
+                         "databricks-lakehouse"):
             assert stack_id in out
 
     def test_includes_display_name_and_summary(self, capsys):
@@ -3311,6 +3312,17 @@ class TestNoUiDimensionInManifests:
             f"{agent}: options.stack.choices must include python-dbt"
         )
 
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    def test_databricks_lakehouse_is_advertised_as_stack_choice(self, agent):
+        """Databricks-native data repos must be discoverable without knowing
+        the stack id ahead of time."""
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+        assert "databricks-lakehouse" in manifest["options"]["stack"]["choices"], (
+            f"{agent}: options.stack.choices must include databricks-lakehouse"
+        )
+
     def test_govkit_list_prints_python_dbt_stack(self, capsys):
         from cli.cmd_list import cmd_list
 
@@ -3318,6 +3330,14 @@ class TestNoUiDimensionInManifests:
 
         out = capsys.readouterr().out
         assert "python-dbt" in out
+
+    def test_govkit_list_prints_databricks_lakehouse_stack(self, capsys):
+        from cli.cmd_list import cmd_list
+
+        cmd_list(argparse.Namespace())
+
+        out = capsys.readouterr().out
+        assert "databricks-lakehouse" in out
 
 
 class TestDataCiContract:
@@ -3560,6 +3580,51 @@ class TestPythonDbtCiGate:
             "disabled until configured",
         ]:
             assert opt_in in text
+
+
+class TestDatabricksLakehouseStack:
+    """Databricks-native data repos can opt into a separate stack overlay."""
+
+    def test_apply_type_data_explicit_databricks_stack_installs_overlay(self, tmp_path):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+        from cli.marker import read_govkit_marker
+        from cli.skill_context import load_skill_context
+
+        target = tmp_path / "project"
+        target.mkdir()
+
+        cmd_apply(argparse.Namespace(
+            agent="claude-code", target=str(target),
+            level="4", type="data", ci="github",
+            stack="databricks-lakehouse", force=False, detect=False,
+        ))
+
+        marker = read_govkit_marker(target)
+        assert marker["stack"]["id"] == "databricks-lakehouse"
+        assert marker["options"]["stack"] == "databricks-lakehouse"
+
+        arch_dir = target / "docs" / "data" / "architecture"
+        for filename in [
+            "TECH_STACK.md",
+            "TESTING.md",
+            "MODEL_LAYERING.md",
+            "PIPELINE_CONTRACT.md",
+            "PII_HANDLING.md",
+            "LINEAGE_OBSERVABILITY.md",
+        ]:
+            path = arch_dir / filename
+            assert path.is_file(), f"{filename} must be installed"
+            assert "baseline: databricks-lakehouse@" in path.read_text(encoding="utf-8")
+
+        ctx = load_skill_context(target)
+        assert ctx is not None
+        assert ctx.stack_id == "databricks-lakehouse"
+        assert ctx.language == "python"
+        assert ctx.framework == "databricks-lakehouse"
+        assert ctx.deployment == "databricks-asset-bundles"
+        assert ctx.orchestration == "databricks-jobs-lakeflow"
 
 
 class TestShapeMigrationWarning:

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -23,9 +23,10 @@ class TestListOverlays:
         from cli.overlay import list_overlays
 
         ids = {o.id for o in list_overlays()}
-        # The five stacks shipped in PR 2:
+        # The original API/CLI stacks plus data stacks.
         assert {"python-fastapi", "dotnet-aspnet", "java-spring-boot",
-                "nodejs-fastify", "go-gin"}.issubset(ids)
+                "nodejs-fastify", "go-gin", "python-dbt",
+                "databricks-lakehouse"}.issubset(ids)
 
     def test_each_overlay_has_minimum_metadata(self):
         from cli.overlay import list_overlays
@@ -79,7 +80,8 @@ class TestLoadOverlay:
         from cli.overlay import load_overlay
 
         for stack_id in ("python-fastapi", "dotnet-aspnet", "java-spring-boot",
-                         "nodejs-fastify", "go-gin"):
+                         "nodejs-fastify", "go-gin", "python-dbt",
+                         "databricks-lakehouse"):
             ov = load_overlay(stack_id)
             assert ov is not None, f"{stack_id} should load"
             for doc in ov.docs:
@@ -96,6 +98,25 @@ class TestLoadOverlay:
         assert ov is not None
         assert ov.skill_context.get("language") == "python"
         assert ov.skill_context.get("api_framework") == "fastapi"
+
+    def test_databricks_lakehouse_overlay_metadata(self):
+        from cli.overlay import load_overlay
+
+        ov = load_overlay("databricks-lakehouse")
+        assert ov is not None
+        assert "Databricks" in ov.display_name
+        assert ov.skill_context.get("language") == "python"
+        assert ov.skill_context.get("framework") == "databricks-lakehouse"
+        assert ov.skill_context.get("deployment") == "databricks-asset-bundles"
+        dests = {doc["dest"] for doc in ov.docs}
+        assert {
+            "docs/data/architecture/TECH_STACK.md",
+            "docs/data/architecture/TESTING.md",
+            "docs/data/architecture/MODEL_LAYERING.md",
+            "docs/data/architecture/PIPELINE_CONTRACT.md",
+            "docs/data/architecture/PII_HANDLING.md",
+            "docs/data/architecture/LINEAGE_OBSERVABILITY.md",
+        }.issubset(dests)
 
 
 class TestApplyOverlay:


### PR DESCRIPTION
## Summary

- Add the `databricks-lakehouse` stack overlay with Databricks-native data architecture docs for Unity Catalog, Delta tables, Asset Bundles, Jobs, Lakeflow Pipelines, PySpark, SQL, notebooks, PII, lineage, and observability.
- Advertise `databricks-lakehouse` in all production agent manifest stack choices.
- Mark the stack as compatible with `--type data` and recognized as a Python stack for doctor mismatch checks.
- Update stack overlay documentation, schema description text, changelog, and regression coverage.

## Behavior

This increment keeps automatic inference conservative. The Databricks stack is available through explicit selection with `--stack databricks-lakehouse`; detection/fixture precedence is still left for the later plan increment.

The overlay does not add Databricks CI execution yet. Databricks workspace calls, bundle deploys, job runs, Lakeflow execution, and warehouse-backed checks remain opt-in and are planned for the next CI gate increment.

## Validation

- Red/green focused tests for overlay discovery, manifest discoverability, explicit apply, skill context, and doctor D005 recognition
- `pytest tests/test_overlay.py tests/test_stack_select.py tests/test_fixtures.py tests/test_schemas.py tests/test_doctor.py`
- `pytest tests/test_govkit.py::TestNoUiDimensionInManifests tests/test_govkit.py::TestCmdStackList tests/test_govkit.py::TestDatabricksLakehouseStack tests/test_govkit.py::TestPythonDbtCiGate tests/test_govkit.py::TestApplyTypeDataStackDefault`
- Manual smoke apply for `claude-code`, `codex`, and `copilot` with `--type data --stack databricks-lakehouse`
- Full `pytest` (`935 passed, 1 skipped`)