### PR TITLE
[codex] Add conservative Databricks CI gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Added a `databricks-lakehouse` data stack overlay for Databricks-native repos
   using Unity Catalog, Delta tables, Asset Bundles, Jobs, Lakeflow Pipelines,
   PySpark, SQL, and notebooks.
+- `databricks-lakehouse` data installs now include a conservative
+  `databricks-gate.yml` for GitHub or Azure. The gate runs static Databricks
+  configuration checks and optional bundle validation only when CLI auth is
+  configured; workspace-backed execution remains opt-in.
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -328,7 +328,8 @@
           "data":       {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
             "by_stack": {
-              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
+              "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
             }
           }
         },
@@ -345,7 +346,8 @@
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
               "by_stack": {
-                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
+                "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
               }
             }
           }
@@ -407,7 +409,8 @@
           "data":       {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
             "by_stack": {
-              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
+              "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
             }
           }
         },
@@ -424,7 +427,8 @@
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
               "by_stack": {
-                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
+                "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
               }
             }
           }

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -344,7 +344,8 @@
           "data":       {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
             "by_stack": {
-              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
+              "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
             }
           }
         },
@@ -361,7 +362,8 @@
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
               "by_stack": {
-                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
+                "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
               }
             }
           }
@@ -423,7 +425,8 @@
           "data":       {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
             "by_stack": {
-              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
+              "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
             }
           }
         },
@@ -440,7 +443,8 @@
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
               "by_stack": {
-                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
+                "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
               }
             }
           }

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -326,7 +326,8 @@
           "data":       {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
             "by_stack": {
-              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+              "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
+              "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
             }
           }
         },
@@ -343,7 +344,8 @@
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
               "by_stack": {
-                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] }
+                "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
+                "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
               }
             }
           }
@@ -405,7 +407,8 @@
           "data":       {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
             "by_stack": {
-              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+              "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
+              "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
             }
           }
         },
@@ -422,7 +425,8 @@
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
               "by_stack": {
-                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] }
+                "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
+                "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
               }
             }
           }

--- a/ci/README.md
+++ b/ci/README.md
@@ -36,6 +36,7 @@ Copy the relevant templates for your project type:
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `data-common-gate.yml` | — | — | — | ✓ |
 | `dbt-gate.yml` | — | — | — | `python-dbt` |
+| `databricks-gate.yml` | — | — | — | `databricks-lakehouse` |
 
 ### Quick Checklist
 
@@ -58,6 +59,7 @@ Copy the relevant templates for your project type:
 | `ui-eval-gate.yml` | — | FIRST/Virtue prediction, Playwright E2E, axe scans |
 | `data-common-gate.yml` | Static governance artifact, PII policy, and `govkit validate` checks | Static governance artifact, PII policy, and `govkit validate` checks |
 | `dbt-gate.yml` | dbt dependency install, `dbt deps`, `dbt parse`, `dbt compile`, SQLFluff when configured, static model YAML checks | Same conservative checks; warehouse-backed test/source freshness execution remains opt-in |
+| `databricks-gate.yml` | Databricks bundle/config static checks, optional `databricks bundle validate` when CLI auth exists, secret/path/PII scans, pytest when configured | Same conservative checks; deploys, jobs, pipelines, and warehouse-backed data-quality checks remain opt-in |
 
 Level 3 projects receive only `l3-quality-gate.yml`. Level 4 projects receive the full set. Level 5 projects receive L4 gates plus 3 additional GenAI gates.
 
@@ -190,6 +192,27 @@ Those checks belong in opt-in stack-specific gates.
 state:modified+`, `dbt source freshness`, warehouse-backed model builds, or
 warehouse-backed data-quality execution. Enable those only after CI profiles,
 secrets, isolated schemas, and cost controls are configured.
+
+---
+
+## Databricks Gate
+
+**File:** `databricks-gate.yml` (GitHub: `ci/github/databricks-gate.yml`, Azure: `ci/azure/databricks-gate.yml`)
+
+**Purpose:** Runs conservative `databricks-lakehouse` stack checks:
+
+- detect Databricks Asset Bundle files such as `databricks.yml`
+- run `databricks bundle validate` only when the Databricks CLI and auth are configured
+- scan Databricks configs, notebooks, pipelines, and source for hardcoded
+  workspace URLs, tokens, secrets, and personal workspace paths
+- warn on missing catalog/schema placeholders and PII metadata gaps
+- run `pytest` for pure transformation modules when tests are configured
+
+**Boundary:** This gate documents but does not enable `databricks bundle deploy
+--target dev`, `databricks jobs run-now`, `databricks pipelines start-update`,
+or Databricks SQL warehouse data-quality checks. Enable those only after CI has
+a safe workspace identity, target catalog/schema, secret management, compute
+policy, and cost controls.
 
 ---
 

--- a/ci/azure/databricks-gate.yml
+++ b/ci/azure/databricks-gate.yml
@@ -1,0 +1,208 @@
+# databricks-gate.yml
+#
+# PURPOSE: Conservative Databricks static/config checks for
+# databricks-lakehouse data projects.
+# Reference this file from azure-pipelines.yml or copy its stage into your
+# project pipeline.
+#
+# Blocking by default:
+# - detect Databricks Asset Bundle files such as databricks.yml
+# - run databricks bundle validate only when the Databricks CLI and auth are configured
+# - static checks for hardcoded workspace URLs, tokens, personal workspace paths,
+#   catalog/schema placeholders, notebook/job/pipeline secrets, and PII metadata
+# - run Python unit tests for pure transformation modules when pytest is configured
+#
+# Opt-in only:
+# - databricks bundle deploy --target dev
+# - databricks jobs run-now
+# - databricks pipelines start-update
+# - Databricks SQL warehouse data-quality checks
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - databricks.yml
+      - resources/**
+      - pipelines/**
+      - src/**
+      - notebooks/**
+      - tests/**
+      - pyproject.toml
+      - requirements*.txt
+      - ci/azure/databricks-gate.yml
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - databricks.yml
+      - resources/**
+      - pipelines/**
+      - src/**
+      - notebooks/**
+      - tests/**
+      - pyproject.toml
+      - requirements*.txt
+      - ci/azure/databricks-gate.yml
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: DatabricksGate
+    displayName: Databricks static and bundle checks
+    jobs:
+      - job: DatabricksGate
+        displayName: Databricks static and bundle checks
+        steps:
+          - checkout: self
+            fetchDepth: 0
+
+          - task: Bash@3
+            displayName: Run conservative Databricks checks
+            inputs:
+              targetType: 'inline'
+              script: |
+                set -euo pipefail
+
+                if [ -f databricks.yml ]; then
+                  echo "Databricks Asset Bundle detected: databricks.yml"
+                  if command -v databricks >/dev/null 2>&1 && [ -n "${DATABRICKS_HOST:-}" ] && { [ -n "${DATABRICKS_TOKEN:-}" ] || [ -n "${DATABRICKS_CLIENT_ID:-}" ] || [ -n "${DATABRICKS_CONFIG_PROFILE:-}" ]; }; then
+                    databricks bundle validate
+                  else
+                    echo "Databricks CLI/auth not configured; skipping databricks bundle validate."
+                    echo "Set DATABRICKS_HOST plus DATABRICKS_TOKEN, OAuth env vars, or DATABRICKS_CONFIG_PROFILE before enabling workspace-backed validation."
+                  fi
+                else
+                  echo "No databricks.yml found; bundle validation has nothing to check."
+                fi
+
+                python - <<'PY'
+                from __future__ import annotations
+
+                import json
+                import pathlib
+                import re
+                import sys
+
+                roots = [
+                    pathlib.Path("databricks.yml"),
+                    pathlib.Path("resources"),
+                    pathlib.Path("pipelines"),
+                    pathlib.Path("src"),
+                    pathlib.Path("notebooks"),
+                ]
+                suffixes = {".py", ".sql", ".yml", ".yaml", ".json", ".ipynb"}
+                files: list[pathlib.Path] = []
+                for root in roots:
+                    if root.is_file() and root.suffix.lower() in suffixes:
+                        files.append(root)
+                    elif root.is_dir():
+                        files.extend(
+                            path for path in root.rglob("*")
+                            if path.is_file() and path.suffix.lower() in suffixes
+                        )
+
+                workspace_url = re.compile(r"https://[A-Za-z0-9.-]+(?:azuredatabricks\.net|cloud\.databricks\.com)")
+                token_value = re.compile(r"\bdapi[a-f0-9]{20,}\b", re.I)
+                token_assignment = re.compile(r"\b(DATABRICKS_TOKEN|token|pat|password)\s*[:=]\s*['\"]?[^'\"\s{}$]+", re.I)
+                personal_path = re.compile(r"(/Workspace)?/Users/[^/\s]+@[^/\s]+", re.I)
+                catalog_schema_placeholder = re.compile(r"\$\{(?:var\.)?(catalog|schema)\}|{{\s*(catalog|schema)\s*}}", re.I)
+                pii_name = re.compile(r"\b(email|phone|ssn|dob|birth|address|first_name|last_name|full_name)\b", re.I)
+                pii_marker = re.compile(r"(contains_pii|pii_category|pii|sensitive|mask)", re.I)
+
+                errors: list[str] = []
+                warnings: list[str] = []
+
+                for path in sorted(files):
+                    try:
+                        text = path.read_text(encoding="utf-8")
+                    except UnicodeDecodeError:
+                        continue
+
+                    if workspace_url.search(text):
+                        errors.append(f"{path}: hardcoded workspace URL found; use DATABRICKS_HOST or bundle variables")
+                    if token_value.search(text) or token_assignment.search(text):
+                        errors.append(f"{path}: possible Databricks token/secret committed")
+                    if personal_path.search(text):
+                        errors.append(f"{path}: personal workspace path found; use bundle variables or shared paths")
+
+                    if path.name == "databricks.yml" and not catalog_schema_placeholder.search(text):
+                        warnings.append(f"{path}: no catalog/schema placeholder found; confirm environment separation")
+
+                    if path.suffix.lower() in {".yml", ".yaml", ".json"}:
+                        for match in pii_name.finditer(text):
+                            window = text[max(0, match.start() - 120): match.end() + 120]
+                            if not pii_marker.search(window):
+                                warnings.append(
+                                    f"{path}: {match.group(0)!r} looks sensitive; add contains_pii, pii_category, tag, mask, or documented exception"
+                                )
+                                break
+
+                    if path.suffix.lower() == ".ipynb":
+                        try:
+                            notebook = json.loads(text)
+                        except json.JSONDecodeError:
+                            errors.append(f"{path}: notebook JSON is invalid")
+                            continue
+                        cells = notebook.get("cells") if isinstance(notebook, dict) else None
+                        if not isinstance(cells, list):
+                            errors.append(f"{path}: notebook has no cells list")
+
+                if warnings:
+                    print("Databricks static warnings:")
+                    for warning in warnings:
+                        print(f"  - {warning}")
+
+                if errors:
+                    print("Databricks static checks failed:")
+                    for error in errors:
+                        print(f"  - {error}")
+                    sys.exit(1)
+
+                print("Databricks static checks passed.")
+                PY
+
+                pytest_configured=false
+                if [ -f pyproject.toml ] && grep -Eqi '(^|[^A-Za-z0-9_-])pytest([^A-Za-z0-9_-]|$)' pyproject.toml; then
+                  pytest_configured=true
+                fi
+                for req in requirements*.txt; do
+                  if [ -f "$req" ] && grep -Eqi '(^|[^A-Za-z0-9_-])pytest([^A-Za-z0-9_-]|$)' "$req"; then
+                    pytest_configured=true
+                  fi
+                done
+
+                if [ "$pytest_configured" = "true" ]; then
+                  python -m pip install --upgrade pip
+                  if [ -f requirements.txt ]; then
+                    python -m pip install -r requirements.txt
+                  elif [ -f pyproject.toml ]; then
+                    python -m pip install -e '.[dev]' || python -m pip install -e .
+                  fi
+                  python -m pip install pytest
+                  python -m pytest
+                else
+                  echo "pytest not configured; skipping pure transformation unit tests."
+                fi
+
+          - task: Bash@3
+            displayName: Document opt-in workspace checks
+            inputs:
+              targetType: 'inline'
+              script: |
+                cat <<'MSG'
+                Optional checks are disabled until configured:
+                - databricks bundle deploy --target dev
+                - databricks jobs run-now
+                - databricks pipelines start-update
+                - Databricks SQL warehouse data-quality checks
+
+                Enable these only after CI has a safe workspace identity, target
+                catalog/schema, secret management, compute policy, and cost controls.
+                MSG

--- a/ci/github/databricks-gate.yml
+++ b/ci/github/databricks-gate.yml
@@ -1,0 +1,193 @@
+# databricks-gate.yml
+#
+# PURPOSE: Conservative Databricks static/config checks for
+# databricks-lakehouse data projects.
+# Copy this file to .github/workflows/databricks-gate.yml.
+#
+# Blocking by default:
+# - detect Databricks Asset Bundle files such as databricks.yml
+# - run databricks bundle validate only when the Databricks CLI and auth are configured
+# - static checks for hardcoded workspace URLs, tokens, personal workspace paths,
+#   catalog/schema placeholders, notebook/job/pipeline secrets, and PII metadata
+# - run Python unit tests for pure transformation modules when pytest is configured
+#
+# Opt-in only:
+# - databricks bundle deploy --target dev
+# - databricks jobs run-now
+# - databricks pipelines start-update
+# - Databricks SQL warehouse data-quality checks
+
+name: Databricks Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'databricks.yml'
+      - 'resources/**'
+      - 'pipelines/**'
+      - 'src/**'
+      - 'notebooks/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'ci/github/databricks-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'databricks.yml'
+      - 'resources/**'
+      - 'pipelines/**'
+      - 'src/**'
+      - 'notebooks/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - 'ci/github/databricks-gate.yml'
+
+jobs:
+  databricks-gate:
+    name: Databricks static and bundle checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run conservative Databricks checks
+        run: |
+          set -euo pipefail
+
+          if [ -f databricks.yml ]; then
+            echo "Databricks Asset Bundle detected: databricks.yml"
+            if command -v databricks >/dev/null 2>&1 && [ -n "${DATABRICKS_HOST:-}" ] && { [ -n "${DATABRICKS_TOKEN:-}" ] || [ -n "${DATABRICKS_CLIENT_ID:-}" ] || [ -n "${DATABRICKS_CONFIG_PROFILE:-}" ]; }; then
+              databricks bundle validate
+            else
+              echo "Databricks CLI/auth not configured; skipping databricks bundle validate."
+              echo "Set DATABRICKS_HOST plus DATABRICKS_TOKEN, OAuth env vars, or DATABRICKS_CONFIG_PROFILE before enabling workspace-backed validation."
+            fi
+          else
+            echo "No databricks.yml found; bundle validation has nothing to check."
+          fi
+
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import pathlib
+          import re
+          import sys
+
+          roots = [
+              pathlib.Path("databricks.yml"),
+              pathlib.Path("resources"),
+              pathlib.Path("pipelines"),
+              pathlib.Path("src"),
+              pathlib.Path("notebooks"),
+          ]
+          suffixes = {".py", ".sql", ".yml", ".yaml", ".json", ".ipynb"}
+          files: list[pathlib.Path] = []
+          for root in roots:
+              if root.is_file() and root.suffix.lower() in suffixes:
+                  files.append(root)
+              elif root.is_dir():
+                  files.extend(
+                      path for path in root.rglob("*")
+                      if path.is_file() and path.suffix.lower() in suffixes
+                  )
+
+          workspace_url = re.compile(r"https://[A-Za-z0-9.-]+(?:azuredatabricks\.net|cloud\.databricks\.com)")
+          token_value = re.compile(r"\bdapi[a-f0-9]{20,}\b", re.I)
+          token_assignment = re.compile(r"\b(DATABRICKS_TOKEN|token|pat|password)\s*[:=]\s*['\"]?[^'\"\s{}$]+", re.I)
+          personal_path = re.compile(r"(/Workspace)?/Users/[^/\s]+@[^/\s]+", re.I)
+          catalog_schema_placeholder = re.compile(r"\$\{(?:var\.)?(catalog|schema)\}|{{\s*(catalog|schema)\s*}}", re.I)
+          pii_name = re.compile(r"\b(email|phone|ssn|dob|birth|address|first_name|last_name|full_name)\b", re.I)
+          pii_marker = re.compile(r"(contains_pii|pii_category|pii|sensitive|mask)", re.I)
+
+          errors: list[str] = []
+          warnings: list[str] = []
+
+          for path in sorted(files):
+              try:
+                  text = path.read_text(encoding="utf-8")
+              except UnicodeDecodeError:
+                  continue
+
+              if workspace_url.search(text):
+                  errors.append(f"{path}: hardcoded workspace URL found; use DATABRICKS_HOST or bundle variables")
+              if token_value.search(text) or token_assignment.search(text):
+                  errors.append(f"{path}: possible Databricks token/secret committed")
+              if personal_path.search(text):
+                  errors.append(f"{path}: personal workspace path found; use bundle variables or shared paths")
+
+              if path.name == "databricks.yml" and not catalog_schema_placeholder.search(text):
+                  warnings.append(f"{path}: no catalog/schema placeholder found; confirm environment separation")
+
+              if path.suffix.lower() in {".yml", ".yaml", ".json"}:
+                  for match in pii_name.finditer(text):
+                      window = text[max(0, match.start() - 120): match.end() + 120]
+                      if not pii_marker.search(window):
+                          warnings.append(
+                              f"{path}: {match.group(0)!r} looks sensitive; add contains_pii, pii_category, tag, mask, or documented exception"
+                          )
+                          break
+
+              if path.suffix.lower() == ".ipynb":
+                  try:
+                      notebook = json.loads(text)
+                  except json.JSONDecodeError:
+                      errors.append(f"{path}: notebook JSON is invalid")
+                      continue
+                  cells = notebook.get("cells") if isinstance(notebook, dict) else None
+                  if not isinstance(cells, list):
+                      errors.append(f"{path}: notebook has no cells list")
+
+          if warnings:
+              print("Databricks static warnings:")
+              for warning in warnings:
+                  print(f"  - {warning}")
+
+          if errors:
+              print("Databricks static checks failed:")
+              for error in errors:
+                  print(f"  - {error}")
+              sys.exit(1)
+
+          print("Databricks static checks passed.")
+          PY
+
+          pytest_configured=false
+          if [ -f pyproject.toml ] && grep -Eqi '(^|[^A-Za-z0-9_-])pytest([^A-Za-z0-9_-]|$)' pyproject.toml; then
+            pytest_configured=true
+          fi
+          for req in requirements*.txt; do
+            if [ -f "$req" ] && grep -Eqi '(^|[^A-Za-z0-9_-])pytest([^A-Za-z0-9_-]|$)' "$req"; then
+              pytest_configured=true
+            fi
+          done
+
+          if [ "$pytest_configured" = "true" ]; then
+            python -m pip install --upgrade pip
+            if [ -f requirements.txt ]; then
+              python -m pip install -r requirements.txt
+            elif [ -f pyproject.toml ]; then
+              python -m pip install -e '.[dev]' || python -m pip install -e .
+            fi
+            python -m pip install pytest
+            python -m pytest
+          else
+            echo "pytest not configured; skipping pure transformation unit tests."
+          fi
+
+      - name: Document opt-in workspace checks
+        run: |
+          cat <<'MSG'
+          Optional checks are disabled until configured:
+          - databricks bundle deploy --target dev
+          - databricks jobs run-now
+          - databricks pipelines start-update
+          - Databricks SQL warehouse data-quality checks
+
+          Enable these only after CI has a safe workspace identity, target
+          catalog/schema, secret management, compute policy, and cost controls.
+          MSG

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3627,6 +3627,173 @@ class TestDatabricksLakehouseStack:
         assert ctx.orchestration == "databricks-jobs-lakeflow"
 
 
+class TestDatabricksCiGate:
+    """databricks-lakehouse data installs add conservative Databricks static gates."""
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    @pytest.mark.parametrize(
+        "platform, repo_scope, data_common, databricks_gate",
+        [
+            (
+                "github",
+                "ci/github/repo-scope-check.yml",
+                "ci/github/data-common-gate.yml",
+                "ci/github/databricks-gate.yml",
+            ),
+            (
+                "azure",
+                "ci/azure/repo-scope-check.yml",
+                "ci/azure/data-common-gate.yml",
+                "ci/azure/databricks-gate.yml",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("level", ["3", "4"])
+    def test_databricks_data_ci_resolves_common_plus_databricks_gate(
+        self, agent, platform, repo_scope, data_common, databricks_gate, level,
+    ):
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "databricks-lakehouse", "ci": platform, "level": level},
+        )
+
+        ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
+        assert ci_governed == [repo_scope, data_common, databricks_gate]
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    @pytest.mark.parametrize(
+        "platform, databricks_gate",
+        [
+            ("github", "ci/github/databricks-gate.yml"),
+            ("azure", "ci/azure/databricks-gate.yml"),
+        ],
+    )
+    def test_python_dbt_stack_does_not_resolve_databricks_gate(self, agent, platform, databricks_gate):
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+
+        _, _, governed = resolve_variant_files(
+            manifest,
+            {"type": "data", "stack": "python-dbt", "ci": platform, "level": "4"},
+        )
+
+        assert databricks_gate not in governed
+
+    def test_apply_type_data_explicit_databricks_stack_installs_ci_gate(self, tmp_path):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "project"
+        target.mkdir()
+        cmd_apply(argparse.Namespace(
+            agent="claude-code", target=str(target),
+            level="4", type="data", ci="github",
+            stack="databricks-lakehouse", force=False, detect=False,
+        ))
+
+        assert (target / "ci" / "github" / "repo-scope-check.yml").is_file()
+        assert (target / "ci" / "github" / "data-common-gate.yml").is_file()
+        assert (target / "ci" / "github" / "databricks-gate.yml").is_file()
+        assert not (target / "ci" / "github" / "dbt-gate.yml").exists()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/databricks-gate.yml",
+            "ci/azure/databricks-gate.yml",
+        ],
+    )
+    def test_databricks_gate_file_exists(self, path):
+        from cli.paths import REPO_ROOT
+
+        assert (REPO_ROOT / path).is_file()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/databricks-gate.yml",
+            "ci/azure/databricks-gate.yml",
+        ],
+    )
+    def test_databricks_gate_pins_conservative_blocking_checks(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        for required in [
+            "databricks.yml",
+            "databricks bundle validate",
+            "DATABRICKS_HOST",
+            "DATABRICKS_TOKEN",
+            "hardcoded workspace URL",
+            "personal workspace path",
+            "catalog/schema",
+            "contains_pii",
+            "pytest",
+        ]:
+            assert required in text
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/databricks-gate.yml",
+            "ci/azure/databricks-gate.yml",
+        ],
+    )
+    def test_databricks_gate_uses_bounded_pii_name_heuristic(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        assert "birth|address|name" not in text
+        assert r"\b(email|phone|ssn|dob|birth|address|first_name|last_name|full_name)\b" in text
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/databricks-gate.yml",
+            "ci/azure/databricks-gate.yml",
+        ],
+    )
+    def test_databricks_gate_runs_pytest_only_when_declared(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        assert "ls tests/test_*.py" not in text
+        assert "requirements*.txt" in text
+        assert "grep -Eqi '(^|[^A-Za-z0-9_-])pytest([^A-Za-z0-9_-]|$)'" in text
+        assert "python -m pip install pytest" in text
+        assert "python -m pytest" in text
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "ci/github/databricks-gate.yml",
+            "ci/azure/databricks-gate.yml",
+        ],
+    )
+    def test_databricks_gate_marks_workspace_execution_opt_in(self, path):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / path).read_text(encoding="utf-8")
+
+        for opt_in in [
+            "databricks bundle deploy --target dev",
+            "databricks jobs run-now",
+            "databricks pipelines start-update",
+            "Databricks SQL warehouse",
+            "disabled until configured",
+        ]:
+            assert opt_in in text
+
+
 class TestShapeMigrationWarning:
     """read_govkit_marker emits a one-time warning when marker carries legacy `ui` option."""
 


### PR DESCRIPTION
## Summary

- Add GitHub and Azure `databricks-gate.yml` templates for the `databricks-lakehouse` data stack.
- Wire `by_stack.databricks-lakehouse` into all production agent manifests for GitHub/Azure, L3/L4.
- Add regression tests proving Databricks installs common + Databricks gates and `python-dbt` does not receive the Databricks gate.
- Document the new gate in `ci/README.md` and update the changelog.

## Behavior

The Databricks gate is conservative by default. It performs static Databricks config checks, secret/path/workspace URL scans, PII metadata warnings, optional `databricks bundle validate` only when the Databricks CLI and auth signals are configured, and `pytest` when Python tests are configured.

Workspace-backed execution remains opt-in and documented but disabled by default, including `databricks bundle deploy --target dev`, `databricks jobs run-now`, `databricks pipelines start-update`, and Databricks SQL warehouse data-quality checks.

## Validation

- YAML parse smoke for Databricks, dbt, and data-common CI templates
- Manual apply smoke for `claude-code`, `codex`, and `copilot` with `--type data --stack databricks-lakehouse`
- `pytest tests/test_govkit.py::TestDataCiContract tests/test_govkit.py::TestDataCommonCiGate tests/test_govkit.py::TestPythonDbtCiGate tests/test_govkit.py::TestDatabricksCiGate tests/test_govkit.py::TestDatabricksLakehouseStack tests/test_govkit.py::TestApplyTypeDataStackDefault tests/test_fixtures.py tests/test_schemas.py tests/test_stack_select.py tests/test_overlay.py`
- Full `pytest` (`960 passed, 1 skipped`)