### PR TITLE
[codex] add Databricks agent skills guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - README data-stack guidance now describes the conservative CI model: common
   governance is installed by default, while stack-specific execution gates
   remain opt-in until configured.
+- README and Databricks stack guidance now document how GovKit and Databricks
+  agent skills work together: GovKit remains authoritative for repo delivery
+  governance, while `databricks aitools install` provides optional
+  platform-specific assistant guidance.
 
 ### Fixed — data stack boundary and discoverability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   agent skills work together: GovKit remains authoritative for repo delivery
   governance, while `databricks aitools install` provides optional
   platform-specific assistant guidance.
+- Databricks Asset Bundle repos with `databricks.yml` / `databricks.yaml` now
+  auto-detect the `databricks-lakehouse` stack instead of falling back to the
+  `python-dbt` data default.
 
 ### Fixed — data stack boundary and discoverability
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Each `govkit apply` configures **one project shape**. Pick one value per flag:
 | `--type` | `api` · `cli` · `ui-react` · `ui-angular` · `data` | …describes this repo (or subdir) — backend service, CLI, React/Angular UI, or dbt data project |
 | `--level` | `3` · `4` · `5` | …`3` governed foundations (default) · `4` spec-driven delivery · `5` GenAI operations — see [Maturity Levels](#maturity-levels) |
 | `--ci` | `github` · `azure` | …your CI platform |
-| `--stack` | `python-fastapi` · `dotnet-aspnet` · `java-spring-boot` · `nodejs-fastify` · `go-gin` · `python-dbt` | …backend/data only; auto-detected, defaults by type (`python-fastapi` for `api` / `cli`, `python-dbt` for `data`). See [Switching Tech Stacks](#switching-tech-stacks) |
+| `--stack` | `python-fastapi` · `dotnet-aspnet` · `java-spring-boot` · `nodejs-fastify` · `go-gin` · `python-dbt` · `databricks-lakehouse` | …backend/data only; auto-detected, defaults by type (`python-fastapi` for `api` / `cli`, `python-dbt` for `data`). See [Switching Tech Stacks](#switching-tech-stacks) |
 
 Running `govkit apply` with no `--type`/`--ci`/`--stack` flags prompts interactively and auto-detects sensible defaults from your repo. A `.govkit` marker records every choice so later commands (`calibrate`, `validate`, `upgrade`, `doctor`) need no re-specification.
 
@@ -384,9 +384,9 @@ The 8-step lifecycle above applies to all project types. Key differences by type
 
 **CI gates:** `ci/github/ui-quality-gate.yml`, `ci/github/ui-eval-gate.yml`
 
-### Data (dbt)
+### Data
 
-**Architecture:** dbt-layered — Staging → Intermediate → Marts. Staging cleans source data (one source per model), Intermediate holds joins and business logic, Marts are the downstream contracts. See `docs/data/architecture/BOUNDARIES.md` and the `python-dbt` stack overlay's `MODEL_LAYERING.md`.
+**Architecture:** governed data delivery — Staging → Intermediate → Marts for dbt projects, or Bronze → Silver → Gold / curated Delta layers for Databricks lakehouse projects. Staging/Bronze cleans source data, Intermediate/Silver holds joins and business logic, and Marts/Gold are the downstream contracts. See `docs/data/architecture/BOUNDARIES.md` plus the selected stack overlay's layering guidance.
 
 **Layer rules** (load automatically):
 - `staging.md` for `**/models/staging/**`
@@ -395,7 +395,15 @@ The 8-step lifecycle above applies to all project types. Key differences by type
 - `data-quality.md` for `**/tests/**` (dbt schema + singular tests)
 - `pii.md` for `**/models/**`, `**/macros/**`, `**/seeds/**` (PII tagging + masking)
 
-**Stack overlay:** `python-dbt` (dbt-core + Snowflake / BigQuery / Redshift / Postgres adapter, SQLfluff, dbt schema tests, optional `dbt-expectations` for L4).
+**Stack overlays:**
+- `python-dbt` (dbt-core + Snowflake / BigQuery / Redshift / Postgres adapter, SQLfluff, dbt schema tests, optional `dbt-expectations` for L4).
+- `databricks-lakehouse` (Unity Catalog, Delta tables, Databricks Asset Bundles, Jobs, Lakeflow Pipelines, PySpark, SQL, notebooks, and optional Databricks bundle validation).
+
+**Databricks skills integration:** GovKit governs repo delivery: contracts, acceptance criteria, architecture boundaries, PII handling, lineage expectations, CI gates, ADRs, and human approvals remain the source of truth. Databricks skills provide platform-specific assistant guidance for workspace, CLI, bundle, Unity Catalog, Jobs, Lakeflow, serving, vector search, and notebook workflows. For Databricks-native repos, install those optional skills with:
+
+```bash
+databricks aitools install
+```
 
 **Worked starter:** `govkit init <feature> --starter data` scaffolds a `customer_dim_freshness` feature with `@nfr-freshness / @nfr-quality / @nfr-pii / @nfr-lineage / @nfr-reliability / @nfr-cost` Gherkin scenarios.
 
@@ -435,7 +443,7 @@ If your backend and UI live in **separate repositories** instead of subdirectori
 GovKit ships **stack overlays** — small bundles of 6 stack-specific architecture docs plus metadata. Pick one at install time with `--stack`, or swap later with `govkit stack apply`. Stack overlays apply to backend types (`api`, `cli`) and the `data` type; UI installs ignore `--stack`. The 6 docs vary per shape:
 
 - **Backend stacks** (`python-fastapi`, `dotnet-aspnet`, `java-spring-boot`, `nodejs-fastify`, `go-gin`): `TECH_STACK.md`, `API_CONVENTIONS.md`, `TESTING.md`, `LAYER_IMPLEMENTATION.md`, `SECURITY_AUTH_PATTERNS.md`, `OBSERVABILITY_PORT_CONTRACT.md`.
-- **Data stacks** (`python-dbt`): `TECH_STACK.md`, `QUERY_CONVENTIONS.md`, `TESTING.md`, `MODEL_LAYERING.md`, `PII_HANDLING.md`, `LINEAGE_OBSERVABILITY.md`.
+- **Data stacks** (`python-dbt`, `databricks-lakehouse`): `TECH_STACK.md`, `TESTING.md`, `MODEL_LAYERING.md`, `PII_HANDLING.md`, `LINEAGE_OBSERVABILITY.md`, plus stack-specific query or pipeline contracts.
 
 ### See what's available
 
@@ -485,6 +493,7 @@ The agent rules and most architecture docs (DESIGN_PRINCIPLES, ARCH_CONTRACT, BO
 | `nodejs-fastify` | backend | Node.js 20 LTS / TypeScript 5 / Fastify 4 / Vitest |
 | `go-gin` | backend | Go 1.22+ / Gin / standard library testing + testify |
 | `python-dbt` | data | Python 3.11+ / dbt-core (staging → intermediate → marts) / Snowflake \| BigQuery \| Redshift \| Postgres adapter / SQLfluff / dbt schema tests (default for `data`) |
+| `databricks-lakehouse` | data | Databricks Lakehouse / Unity Catalog / Delta tables / Asset Bundles / Jobs / Lakeflow Pipelines / PySpark / SQL |
 
 After applying a stack, review the installed files and adapt anything specific to your repo (approved library versions, internal service names, etc.) — `govkit calibrate` walks you through this. `GOVKIT_SETUP_REVIEW.md` at the target root lists each stack doc with a one-line review prompt. Consider raising an ADR to document the stack decision.
 
@@ -770,6 +779,15 @@ A: Your predicted FIRST or Virtue average is below 4.0, or a predicted accessibi
 - [MODEL_LAYERING.md](cli/stacks/python-dbt/MODEL_LAYERING.md) — staging / intermediate / marts materialization defaults
 - [PII_HANDLING.md](cli/stacks/python-dbt/PII_HANDLING.md) — `mask_pii()` macro pattern
 - [LINEAGE_OBSERVABILITY.md](cli/stacks/python-dbt/LINEAGE_OBSERVABILITY.md) — Exposure docs, OpenLineage hooks
+
+### Data (Stack overlay — databricks-lakehouse)
+
+- [TECH_STACK.md](cli/stacks/databricks-lakehouse/TECH_STACK.md) — Databricks Lakehouse platform boundary and agent skills guidance
+- [TESTING.md](cli/stacks/databricks-lakehouse/TESTING.md) — unit, static, bundle, and opt-in workspace validation
+- [MODEL_LAYERING.md](cli/stacks/databricks-lakehouse/MODEL_LAYERING.md) — Bronze / Silver / Gold and curated Delta layering
+- [PIPELINE_CONTRACT.md](cli/stacks/databricks-lakehouse/PIPELINE_CONTRACT.md) — Jobs, Lakeflow Pipelines, bundle resources, and environment targets
+- [PII_HANDLING.md](cli/stacks/databricks-lakehouse/PII_HANDLING.md) — Unity Catalog tags, masking, secrets, and token handling
+- [LINEAGE_OBSERVABILITY.md](cli/stacks/databricks-lakehouse/LINEAGE_OBSERVABILITY.md) — Unity Catalog lineage, run metadata, and observability expectations
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ Each `govkit apply` configures **one project shape**. Pick one value per flag:
 | Flag | Options | Pick this if… |
 |---|---|---|
 | `--agent` | `claude-code` · `copilot` · `codex` | …matches the AI tool your team uses |
-| `--type` | `api` · `cli` · `ui-react` · `ui-angular` · `data` | …describes this repo (or subdir) — backend service, CLI, React/Angular UI, or dbt data project |
+| `--type` | `api` · `cli` · `ui-react` · `ui-angular` · `data` | …describes this repo (or subdir) — backend service, CLI, React/Angular UI, or governed data project |
 | `--level` | `3` · `4` · `5` | …`3` governed foundations (default) · `4` spec-driven delivery · `5` GenAI operations — see [Maturity Levels](#maturity-levels) |
 | `--ci` | `github` · `azure` | …your CI platform |
 | `--stack` | `python-fastapi` · `dotnet-aspnet` · `java-spring-boot` · `nodejs-fastify` · `go-gin` · `python-dbt` · `databricks-lakehouse` | …backend/data only; auto-detected, defaults by type (`python-fastapi` for `api` / `cli`, `python-dbt` for `data`). See [Switching Tech Stacks](#switching-tech-stacks) |
 
-Running `govkit apply` with no `--type`/`--ci`/`--stack` flags prompts interactively and auto-detects sensible defaults from your repo. A `.govkit` marker records every choice so later commands (`calibrate`, `validate`, `upgrade`, `doctor`) need no re-specification.
+Running `govkit apply` with no `--type`/`--ci`/`--stack` flags prompts interactively and auto-detects sensible defaults from your repo, including `python-dbt` from `dbt_project.yml` and `databricks-lakehouse` from `databricks.yml` / `databricks.yaml`. A `.govkit` marker records every choice so later commands (`calibrate`, `validate`, `upgrade`, `doctor`) need no re-specification.
 
 <details>
 <summary><b>Full example commands for every combination</b></summary>

--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ The 8-step lifecycle above applies to all project types. Key differences by type
 
 **Architecture:** governed data delivery — Staging → Intermediate → Marts for dbt projects, or Bronze → Silver → Gold / curated Delta layers for Databricks lakehouse projects. Staging/Bronze cleans source data, Intermediate/Silver holds joins and business logic, and Marts/Gold are the downstream contracts. See `docs/data/architecture/BOUNDARIES.md` plus the selected stack overlay's layering guidance.
 
+The following layer rules apply to dbt-style repos (`python-dbt`). For Databricks lakehouse repos, follow the `databricks-lakehouse` overlay's `MODEL_LAYERING.md` (Bronze/Silver/Gold) and adjust rule globs if your repo uses `src/bronze|silver|gold`.
+
 **Layer rules** (load automatically):
 - `staging.md` for `**/models/staging/**`
 - `intermediate.md` for `**/models/intermediate/**`

--- a/cli/detect.py
+++ b/cli/detect.py
@@ -261,6 +261,11 @@ def _detect_dbt(target: Path) -> bool:
     return bool(_find_recursive(target, "dbt_project.yml"))
 
 
+def _detect_databricks_lakehouse(target: Path) -> bool:
+    """Presence of Databricks Asset Bundle config indicates a Databricks repo."""
+    return bool(_find_recursive(target, "databricks.yml") or _find_recursive(target, "databricks.yaml"))
+
+
 def _detect_frameworks(target: Path, prof: RepoProfile) -> None:
     """Detect frameworks from manifest contents directly. We don't gate on
     language detection because framework presence is the more specific
@@ -278,6 +283,8 @@ def _detect_frameworks(target: Path, prof: RepoProfile) -> None:
         detected.append("spring-boot")
     if _detect_gin(target):
         detected.append("gin")
+    if _detect_databricks_lakehouse(target):
+        detected.append("databricks-lakehouse")
     if _detect_dbt(target):
         detected.append("dbt")
     prof.detected_frameworks = detected
@@ -378,6 +385,7 @@ _FRAMEWORK_TO_STACK = {
     "fastify":      "nodejs-fastify",
     "spring-boot":  "java-spring-boot",
     "gin":          "go-gin",
+    "databricks-lakehouse": "databricks-lakehouse",
     "dbt":          "python-dbt",
 }
 

--- a/cli/stacks/databricks-lakehouse/TECH_STACK.md
+++ b/cli/stacks/databricks-lakehouse/TECH_STACK.md
@@ -76,3 +76,23 @@ Each environment must have an explicit catalog and schema strategy:
 
 CI must not deploy or execute Databricks workloads unless the repo documents
 the target workspace, identity, isolation strategy, and cost guardrails.
+
+---
+
+# 5. Agent Skills Integration
+
+Databricks agent skills are optional platform guidance for assistant workflows.
+Recommended install:
+
+```bash
+databricks aitools install
+```
+
+Use Databricks agent skills for Databricks-specific CLI and platform workflows:
+Asset Bundles, workspace authentication, Jobs, Lakeflow Pipelines, Unity
+Catalog, model serving, vector search, and notebook/platform conventions.
+
+GovKit contracts remain authoritative for repo delivery governance: acceptance criteria,
+architecture boundaries, PII handling, lineage expectations, CI gates, ADR requirements,
+and human approvals. Databricks skills must not override GovKit contracts or approval
+boundaries.

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -419,6 +419,28 @@ class TestInferStack:
         stack_id, _ = infer_stack(prof)
         assert stack_id == "java-spring-boot"
 
+    def test_databricks_bundle_repo_infers_databricks_lakehouse(self, tmp_path):
+        from cli.detect import build_profile, infer_stack
+
+        (tmp_path / "resources").mkdir()
+        (tmp_path / "src").mkdir()
+        (tmp_path / "databricks.yml").write_text(
+            "bundle:\n  name: customer_analytics\ninclude:\n  - resources/*.yml\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "resources" / "jobs.yml").write_text(
+            "resources:\n  jobs:\n    refresh_customer_dim:\n      name: refresh_customer_dim\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "pyproject.toml").write_text('[project]\nname="x"\n', encoding="utf-8")
+
+        prof = build_profile(tmp_path)
+        stack_id, confidence = infer_stack(prof)
+
+        assert "databricks-lakehouse" in prof.detected_frameworks
+        assert stack_id == "databricks-lakehouse"
+        assert confidence == "high"
+
     def test_empty_repo_returns_none(self, tmp_path):
         from cli.detect import build_profile, infer_stack
 

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -306,14 +306,44 @@ class TestDbtProjectFixture:
 class TestDatabricksLakehouseGuidance:
     """Databricks stack docs explain how GovKit and Databricks agent skills coexist."""
 
-    def _apply(self, target: Path) -> None:
+    def _apply(self, target: Path, stack: str | None = "databricks-lakehouse") -> None:
         from cli.cmd_apply import cmd_apply
 
         cmd_apply(argparse.Namespace(
             agent="claude-code", target=str(target),
             level="4", type="data", ci="github",
-            stack="databricks-lakehouse", force=False, detect=False,
+            stack=stack, force=False, detect=False,
         ))
+
+    def _write_bundle(self, target: Path) -> None:
+        (target / "resources").mkdir()
+        (target / "src").mkdir()
+        (target / "databricks.yml").write_text(
+            "bundle:\n  name: customer_analytics\ninclude:\n  - resources/*.yml\n",
+            encoding="utf-8",
+        )
+        (target / "resources" / "pipelines.yml").write_text(
+            "resources:\n  pipelines:\n    customer_quality:\n      name: customer_quality\n",
+            encoding="utf-8",
+        )
+
+    def test_apply_type_data_detects_databricks_lakehouse_stack(self, tmp_path):
+        from cli.marker import read_govkit_marker
+
+        target = tmp_path / "databricks-project"
+        target.mkdir()
+        self._write_bundle(target)
+
+        self._apply(target, stack=None)
+
+        marker = read_govkit_marker(target)
+        assert marker["stack"]["id"] == "databricks-lakehouse"
+        assert marker["options"]["stack"] == "databricks-lakehouse"
+        stack_assumption = next(a for a in marker["assumptions"] if a["id"] == "stack.id")
+        assert stack_assumption["source"] == "detected"
+        assert stack_assumption["confidence"] == "high"
+        assert (target / "ci" / "github" / "databricks-gate.yml").is_file()
+        assert not (target / "ci" / "github" / "dbt-gate.yml").exists()
 
     def test_generated_tech_stack_mentions_databricks_agent_skills_boundary(self, tmp_path):
         target = tmp_path / "databricks-project"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -303,6 +303,45 @@ class TestDbtProjectFixture:
         )
 
 
+class TestDatabricksLakehouseGuidance:
+    """Databricks stack docs explain how GovKit and Databricks agent skills coexist."""
+
+    def _apply(self, target: Path) -> None:
+        from cli.cmd_apply import cmd_apply
+
+        cmd_apply(argparse.Namespace(
+            agent="claude-code", target=str(target),
+            level="4", type="data", ci="github",
+            stack="databricks-lakehouse", force=False, detect=False,
+        ))
+
+    def test_generated_tech_stack_mentions_databricks_agent_skills_boundary(self, tmp_path):
+        target = tmp_path / "databricks-project"
+        target.mkdir()
+        self._apply(target)
+
+        text = (target / "docs" / "data" / "architecture" / "TECH_STACK.md").read_text(encoding="utf-8")
+
+        assert "databricks aitools install" in text
+        assert "Databricks agent skills" in text
+        assert "GovKit contracts remain authoritative" in text
+        assert "acceptance criteria" in text
+        assert "PII" in text
+        assert "approvals" in text
+
+    def test_databricks_skills_are_guidance_only_not_required(self, tmp_path):
+        target = tmp_path / "databricks-project"
+        target.mkdir()
+        self._apply(target)
+
+        marker = target / ".govkit" / "marker.json"
+        tech_stack = target / "docs" / "data" / "architecture" / "TECH_STACK.md"
+
+        assert marker.is_file()
+        assert tech_stack.is_file()
+        assert not (target / ".databricks-agent-skills").exists()
+
+
 class TestEmptyFixture:
     """The empty fixture has no signals — every detection should be 'unknown'
     and the install should still succeed (defaults to python-fastapi)."""

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3803,6 +3803,7 @@ class TestDatabricksAgentSkillsGuidance:
         text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
 
         assert "databricks-lakehouse" in text
+        assert "databricks.yml" in text
         assert "databricks aitools install" in text
         assert "Databricks skills provide platform-specific assistant guidance" in text
         assert "GovKit governs repo delivery" in text

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3794,6 +3794,20 @@ class TestDatabricksCiGate:
             assert opt_in in text
 
 
+class TestDatabricksAgentSkillsGuidance:
+    """Docs clarify that Databricks skills complement GovKit governance."""
+
+    def test_readme_documents_databricks_skills_integration(self):
+        from cli.paths import REPO_ROOT
+
+        text = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+
+        assert "databricks-lakehouse" in text
+        assert "databricks aitools install" in text
+        assert "Databricks skills provide platform-specific assistant guidance" in text
+        assert "GovKit governs repo delivery" in text
+
+
 class TestShapeMigrationWarning:
     """read_govkit_marker emits a one-time warning when marker carries legacy `ui` option."""
 

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3807,6 +3807,9 @@ class TestDatabricksAgentSkillsGuidance:
         assert "databricks aitools install" in text
         assert "Databricks skills provide platform-specific assistant guidance" in text
         assert "GovKit governs repo delivery" in text
+        assert "The following layer rules apply to dbt-style repos (`python-dbt`)" in text
+        assert "MODEL_LAYERING.md" in text
+        assert "src/bronze|silver|gold" in text
 
 
 class TestShapeMigrationWarning:


### PR DESCRIPTION
## Summary

Adds Increment 8 guidance for Databricks-native data repos so teams understand how GovKit governance and Databricks agent skills should work together.

## What changed

- Documents `databricks-lakehouse` in the README stack options, data-stack section, bundled stack table, and architecture reference.
- Adds a Databricks Agent Skills Integration section to the Databricks lakehouse stack `TECH_STACK.md`.
- Implements Databricks Asset Bundle detection from `databricks.yml` / `databricks.yaml` so `govkit apply --type data` can infer the `databricks-lakehouse` overlay instead of falling back to `python-dbt`.
- Clarifies that README layer-rule globs are dbt-oriented and points Databricks lakehouse repos to the `databricks-lakehouse` `MODEL_LAYERING.md` Bronze/Silver/Gold guidance.
- Clarifies that GovKit remains authoritative for repo delivery contracts, acceptance criteria, PII, lineage, CI, ADRs, and human approvals, while Databricks skills provide platform-specific assistant guidance.
- Adds fixture, detection, and README regression tests for the guidance, stack inference, layer-rule scope, and ensuring Databricks skills remain optional.

## Validation

- `pytest` — 969 passed, 1 skipped
