### PR TITLE
[codex] add data stack demo fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - Databricks Asset Bundle repos with `databricks.yml` / `databricks.yaml` now
   auto-detect the `databricks-lakehouse` stack instead of falling back to the
   `python-dbt` data default.
+- Added Databricks-native demo fixtures and documented mixed-signal precedence:
+  when `dbt_project.yml` and Databricks bundle config are both present, GovKit
+  treats the repo as `python-dbt` by default unless `--stack
+  databricks-lakehouse` is passed explicitly.
 
 ### Fixed — data stack boundary and discoverability
 

--- a/README.md
+++ b/README.md
@@ -401,6 +401,8 @@ The following layer rules apply to dbt-style repos (`python-dbt`). For Databrick
 - `python-dbt` (dbt-core + Snowflake / BigQuery / Redshift / Postgres adapter, SQLfluff, dbt schema tests, optional `dbt-expectations` for L4).
 - `databricks-lakehouse` (Unity Catalog, Delta tables, Databricks Asset Bundles, Jobs, Lakeflow Pipelines, PySpark, SQL, notebooks, and optional Databricks bundle validation).
 
+If both `dbt_project.yml` and `databricks.yml` are present, GovKit treats the repo as `python-dbt` by default because dbt is the project shape. Pass `--stack databricks-lakehouse` when the repo should use the native Databricks overlay instead.
+
 **Databricks skills integration:** GovKit governs repo delivery: contracts, acceptance criteria, architecture boundaries, PII handling, lineage expectations, CI gates, ADRs, and human approvals remain the source of truth. Databricks skills provide platform-specific assistant guidance for workspace, CLI, bundle, Unity Catalog, Jobs, Lakeflow, serving, vector search, and notebook workflows. For Databricks-native repos, install those optional skills with:
 
 ```bash

--- a/cli/detect.py
+++ b/cli/detect.py
@@ -283,10 +283,12 @@ def _detect_frameworks(target: Path, prof: RepoProfile) -> None:
         detected.append("spring-boot")
     if _detect_gin(target):
         detected.append("gin")
-    if _detect_databricks_lakehouse(target):
-        detected.append("databricks-lakehouse")
     if _detect_dbt(target):
         detected.append("dbt")
+    # dbt-on-Databricks remains a dbt project shape by default. Users can still
+    # opt into the native Databricks overlay with --stack databricks-lakehouse.
+    if _detect_databricks_lakehouse(target):
+        detected.append("databricks-lakehouse")
     prof.detected_frameworks = detected
 
 

--- a/tests/fixtures/databricks-lakehouse/.github/workflows/ci.yml
+++ b/tests/fixtures/databricks-lakehouse/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Placeholder
+        run: echo "Databricks fixture CI is intentionally static."

--- a/tests/fixtures/databricks-lakehouse/.gitignore
+++ b/tests/fixtures/databricks-lakehouse/.gitignore
@@ -1,0 +1,3 @@
+.databricks/
+__pycache__/
+.pytest_cache/

--- a/tests/fixtures/databricks-lakehouse/databricks.yml
+++ b/tests/fixtures/databricks-lakehouse/databricks.yml
@@ -1,0 +1,28 @@
+bundle:
+  name: customer_lakehouse
+
+include:
+  - resources/*.yml
+
+variables:
+  catalog:
+    default: dev_catalog
+  schema:
+    default: customer_analytics
+
+targets:
+  dev:
+    mode: development
+    default: true
+    workspace:
+      host: ${DATABRICKS_HOST}
+    variables:
+      catalog: dev_catalog
+      schema: customer_analytics_dev
+  prod:
+    mode: production
+    workspace:
+      host: ${DATABRICKS_HOST}
+    variables:
+      catalog: prod_catalog
+      schema: customer_analytics

--- a/tests/fixtures/databricks-lakehouse/notebooks/customer_quality.py
+++ b/tests/fixtures/databricks-lakehouse/notebooks/customer_quality.py
@@ -1,0 +1,14 @@
+# Databricks notebook source
+
+# COMMAND ----------
+
+from src.silver.customer_quality import apply_customer_quality
+
+
+def main():
+    bronze = spark.table("dev_catalog.customer_analytics_dev.bronze_customers")
+    silver = apply_customer_quality(bronze)
+    silver.write.mode("overwrite").saveAsTable("dev_catalog.customer_analytics_dev.silver_customers")
+
+
+main()

--- a/tests/fixtures/databricks-lakehouse/pyproject.toml
+++ b/tests/fixtures/databricks-lakehouse/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "customer-lakehouse"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "pyspark",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/fixtures/databricks-lakehouse/resources/jobs.yml
+++ b/tests/fixtures/databricks-lakehouse/resources/jobs.yml
@@ -1,0 +1,16 @@
+resources:
+  jobs:
+    refresh_customer_gold:
+      name: refresh_customer_gold
+      tasks:
+        - task_key: build_customer_marts
+          python_wheel_task:
+            package_name: customer_lakehouse
+            entry_point: build_customer_marts
+          job_cluster_key: shared_job_cluster
+      job_clusters:
+        - job_cluster_key: shared_job_cluster
+          new_cluster:
+            spark_version: 15.4.x-scala2.12
+            node_type_id: Standard_DS3_v2
+            num_workers: 1

--- a/tests/fixtures/databricks-lakehouse/resources/jobs.yml
+++ b/tests/fixtures/databricks-lakehouse/resources/jobs.yml
@@ -3,10 +3,10 @@ resources:
     refresh_customer_gold:
       name: refresh_customer_gold
       tasks:
-        - task_key: build_customer_marts
+        - task_key: build_customer_dimension
           python_wheel_task:
             package_name: customer_lakehouse
-            entry_point: build_customer_marts
+            entry_point: build_customer_dimension
           job_cluster_key: shared_job_cluster
       job_clusters:
         - job_cluster_key: shared_job_cluster

--- a/tests/fixtures/databricks-lakehouse/resources/pipelines.yml
+++ b/tests/fixtures/databricks-lakehouse/resources/pipelines.yml
@@ -1,0 +1,11 @@
+resources:
+  pipelines:
+    customer_quality:
+      name: customer_quality
+      catalog: ${var.catalog}
+      schema: ${var.schema}
+      libraries:
+        - file:
+            path: ../src/silver/customer_quality.py
+      configuration:
+        bundle.sourcePath: /Workspace/${workspace.file_path}/src

--- a/tests/fixtures/databricks-lakehouse/src/bronze/customers.py
+++ b/tests/fixtures/databricks-lakehouse/src/bronze/customers.py
@@ -1,0 +1,13 @@
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+
+def normalize_raw_customers(raw: DataFrame) -> DataFrame:
+    return (
+        raw.select(
+            F.col("customer_id").cast("string").alias("customer_id"),
+            F.col("email").cast("string").alias("email"),
+            F.col("created_at").cast("timestamp").alias("created_at"),
+        )
+        .where(F.col("customer_id").isNotNull())
+    )

--- a/tests/fixtures/databricks-lakehouse/src/gold/customer_marts.py
+++ b/tests/fixtures/databricks-lakehouse/src/gold/customer_marts.py
@@ -1,0 +1,10 @@
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+
+def build_customer_dimension(silver_customers: DataFrame) -> DataFrame:
+    return (
+        silver_customers
+        .where(F.col("is_valid_email"))
+        .select("customer_id", "email_domain", "created_at")
+    )

--- a/tests/fixtures/databricks-lakehouse/src/silver/customer_quality.py
+++ b/tests/fixtures/databricks-lakehouse/src/silver/customer_quality.py
@@ -1,0 +1,10 @@
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as F
+
+
+def apply_customer_quality(bronze_customers: DataFrame) -> DataFrame:
+    return (
+        bronze_customers
+        .withColumn("email_domain", F.lower(F.substring_index("email", "@", -1)))
+        .withColumn("is_valid_email", F.col("email").contains("@"))
+    )

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -419,6 +419,21 @@ class TestInferStack:
         stack_id, _ = infer_stack(prof)
         assert stack_id == "java-spring-boot"
 
+    def test_dbt_project_repo_infers_python_dbt(self, tmp_path):
+        from cli.detect import build_profile, infer_stack
+
+        (tmp_path / "models" / "staging").mkdir(parents=True)
+        (tmp_path / "models" / "intermediate").mkdir(parents=True)
+        (tmp_path / "models" / "marts").mkdir(parents=True)
+        (tmp_path / "dbt_project.yml").write_text("name: customer_analytics\n", encoding="utf-8")
+
+        prof = build_profile(tmp_path)
+        stack_id, confidence = infer_stack(prof)
+
+        assert "dbt" in prof.detected_frameworks
+        assert stack_id == "python-dbt"
+        assert confidence == "high"
+
     def test_databricks_bundle_repo_infers_databricks_lakehouse(self, tmp_path):
         from cli.detect import build_profile, infer_stack
 
@@ -439,6 +454,29 @@ class TestInferStack:
 
         assert "databricks-lakehouse" in prof.detected_frameworks
         assert stack_id == "databricks-lakehouse"
+        assert confidence == "high"
+
+    def test_mixed_dbt_and_databricks_signals_prefer_python_dbt(self, tmp_path):
+        """dbt-on-Databricks is still a dbt project shape by default."""
+        from cli.detect import build_profile, infer_stack
+
+        (tmp_path / "resources").mkdir()
+        (tmp_path / "models" / "staging").mkdir(parents=True)
+        (tmp_path / "models" / "intermediate").mkdir(parents=True)
+        (tmp_path / "models" / "marts").mkdir(parents=True)
+        (tmp_path / "databricks.yml").write_text(
+            "bundle:\n  name: customer_analytics\ninclude:\n  - resources/*.yml\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "resources" / "jobs.yml").write_text("resources:\n  jobs: {}\n", encoding="utf-8")
+        (tmp_path / "dbt_project.yml").write_text("name: customer_analytics\n", encoding="utf-8")
+
+        prof = build_profile(tmp_path)
+        stack_id, confidence = infer_stack(prof)
+
+        assert "dbt" in prof.detected_frameworks
+        assert "databricks-lakehouse" in prof.detected_frameworks
+        assert stack_id == "python-dbt"
         assert confidence == "high"
 
     def test_empty_repo_returns_none(self, tmp_path):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -16,6 +16,7 @@ than byte-exact so timestamps and govkit version don't make tests flaky.
 """
 
 import argparse
+import ast
 import shutil
 from pathlib import Path
 
@@ -327,6 +328,18 @@ class TestDatabricksLakehouseGuidance:
         assert (target / "src" / "gold" / "customer_marts.py").is_file()
         assert (target / "notebooks" / "customer_quality.py").is_file()
         assert not (target / "dbt_project.yml").exists()
+
+    def test_databricks_job_entry_point_exists_in_fixture_source(self):
+        target = FIXTURES / "databricks-lakehouse"
+        jobs = yaml.safe_load((target / "resources" / "jobs.yml").read_text(encoding="utf-8"))
+        task = jobs["resources"]["jobs"]["refresh_customer_gold"]["tasks"][0]
+        entry_point = task["python_wheel_task"]["entry_point"]
+
+        module = ast.parse((target / "src" / "gold" / "customer_marts.py").read_text(encoding="utf-8"))
+        functions = {node.name for node in module.body if isinstance(node, ast.FunctionDef)}
+
+        assert task["task_key"] == entry_point
+        assert entry_point in functions
 
     def test_apply_type_data_detects_databricks_lakehouse_stack(self, tmp_path):
         from cli.marker import read_govkit_marker

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -6,6 +6,7 @@ PR 7. Three fixture repos under tests/fixtures/ exercise the whole apply
   - dotnet-aspnet-azure/      — *.csproj + global.json + clean layout + azure-pipelines.yml
   - python-fastapi-github/    — pyproject.toml + fastapi + hexagonal layout + .github/workflows
   - dbt-project/              — dbt_project.yml + models/{staging,intermediate,marts}
+  - databricks-lakehouse/     — databricks.yml + resources/ + src/{bronze,silver,gold}
   - empty/                    — no signals at all (worst-case fallback path)
 
 Each test class copies the fixture into a tmp_path so the source tree is
@@ -315,25 +316,22 @@ class TestDatabricksLakehouseGuidance:
             stack=stack, force=False, detect=False,
         ))
 
-    def _write_bundle(self, target: Path) -> None:
-        (target / "resources").mkdir()
-        (target / "src").mkdir()
-        (target / "databricks.yml").write_text(
-            "bundle:\n  name: customer_analytics\ninclude:\n  - resources/*.yml\n",
-            encoding="utf-8",
-        )
-        (target / "resources" / "pipelines.yml").write_text(
-            "resources:\n  pipelines:\n    customer_quality:\n      name: customer_quality\n",
-            encoding="utf-8",
-        )
+    def test_fixture_contains_representative_databricks_native_files(self):
+        target = FIXTURES / "databricks-lakehouse"
+
+        assert (target / "databricks.yml").is_file()
+        assert (target / "resources" / "jobs.yml").is_file()
+        assert (target / "resources" / "pipelines.yml").is_file()
+        assert (target / "src" / "bronze" / "customers.py").is_file()
+        assert (target / "src" / "silver" / "customer_quality.py").is_file()
+        assert (target / "src" / "gold" / "customer_marts.py").is_file()
+        assert (target / "notebooks" / "customer_quality.py").is_file()
+        assert not (target / "dbt_project.yml").exists()
 
     def test_apply_type_data_detects_databricks_lakehouse_stack(self, tmp_path):
         from cli.marker import read_govkit_marker
 
-        target = tmp_path / "databricks-project"
-        target.mkdir()
-        self._write_bundle(target)
-
+        target = _copy_fixture("databricks-lakehouse", tmp_path)
         self._apply(target, stack=None)
 
         marker = read_govkit_marker(target)
@@ -345,9 +343,50 @@ class TestDatabricksLakehouseGuidance:
         assert (target / "ci" / "github" / "databricks-gate.yml").is_file()
         assert not (target / "ci" / "github" / "dbt-gate.yml").exists()
 
+    def test_explicit_python_dbt_stack_wins_over_databricks_inference(self, tmp_path):
+        from cli.marker import read_govkit_marker
+
+        target = _copy_fixture("databricks-lakehouse", tmp_path)
+        self._apply(target, stack="python-dbt")
+
+        marker = read_govkit_marker(target)
+        assert marker["stack"]["id"] == "python-dbt"
+        assert marker["options"]["stack"] == "python-dbt"
+        stack_assumption = next(a for a in marker["assumptions"] if a["id"] == "stack.id")
+        assert stack_assumption["source"] == "flag"
+        assert (target / "ci" / "github" / "dbt-gate.yml").is_file()
+        assert not (target / "ci" / "github" / "databricks-gate.yml").exists()
+
+    def test_type_data_rejects_incompatible_backend_stack_inference(self, tmp_path):
+        from cli.marker import read_govkit_marker
+
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        self._apply(target, stack=None)
+
+        marker = read_govkit_marker(target)
+        assert marker["stack"]["id"] == "python-dbt"
+        stack_assumption = next(a for a in marker["assumptions"] if a["id"] == "stack.id")
+        assert stack_assumption["source"] == "default"
+
+    def test_mixed_dbt_databricks_signals_prefer_dbt_project_shape(self, tmp_path):
+        from cli.marker import read_govkit_marker
+
+        target = _copy_fixture("databricks-lakehouse", tmp_path)
+        (target / "models" / "staging").mkdir(parents=True)
+        (target / "models" / "intermediate").mkdir(parents=True)
+        (target / "models" / "marts").mkdir(parents=True)
+        (target / "dbt_project.yml").write_text("name: customer_analytics\n", encoding="utf-8")
+
+        self._apply(target, stack=None)
+
+        marker = read_govkit_marker(target)
+        assert marker["stack"]["id"] == "python-dbt"
+        assert marker["options"]["stack"] == "python-dbt"
+        assert (target / "ci" / "github" / "dbt-gate.yml").is_file()
+        assert not (target / "ci" / "github" / "databricks-gate.yml").exists()
+
     def test_generated_tech_stack_mentions_databricks_agent_skills_boundary(self, tmp_path):
-        target = tmp_path / "databricks-project"
-        target.mkdir()
+        target = _copy_fixture("databricks-lakehouse", tmp_path)
         self._apply(target)
 
         text = (target / "docs" / "data" / "architecture" / "TECH_STACK.md").read_text(encoding="utf-8")
@@ -360,8 +399,7 @@ class TestDatabricksLakehouseGuidance:
         assert "approvals" in text
 
     def test_databricks_skills_are_guidance_only_not_required(self, tmp_path):
-        target = tmp_path / "databricks-project"
-        target.mkdir()
+        target = _copy_fixture("databricks-lakehouse", tmp_path)
         self._apply(target)
 
         marker = target / ".govkit" / "marker.json"

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3810,6 +3810,7 @@ class TestDatabricksAgentSkillsGuidance:
         assert "The following layer rules apply to dbt-style repos (`python-dbt`)" in text
         assert "MODEL_LAYERING.md" in text
         assert "src/bronze|silver|gold" in text
+        assert "If both `dbt_project.yml` and `databricks.yml` are present" in text
 
 
 class TestShapeMigrationWarning:


### PR DESCRIPTION
## Summary

Adds Increment 9 data-stack demo fixtures and regression coverage so `python-dbt` and `databricks-lakehouse` behavior stays intentionally different.

## What changed

- Adds a representative `tests/fixtures/databricks-lakehouse/` repo with Databricks Asset Bundle config, Jobs/Pipelines resources, `src/bronze|silver|gold` modules, and a source-controlled notebook.
- Promotes Databricks apply tests to use the real fixture instead of an inline temporary repo.
- Pins detection behavior for dbt projects, Databricks-native repos, explicit `--stack` precedence, incompatible backend inference, and mixed dbt + Databricks signals.
- Documents mixed-signal precedence: if `dbt_project.yml` and `databricks.yml` are both present, GovKit defaults to `python-dbt` unless `--stack databricks-lakehouse` is explicit.
- Adds a fixture consistency regression so the Databricks job `python_wheel_task.entry_point` must match a function implemented in `src/gold/customer_marts.py`.

## Validation

- `pytest tests/test_fixtures.py` — 48 passed, 1 skipped
- `pytest` — 976 passed, 1 skipped
