### PR TITLE
[codex] install data L4 planning skills

### DIFF
--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -306,7 +306,10 @@
           "files": [
             { "src": "claude-md/l4-data.md", "dest": "CLAUDE.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
-            { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" }
+            { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
+            { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/spec-planning/" },
+            { "src": "skills/backend/architecture-preflight/", "dest": ".claude/skills/architecture-preflight/" },
+            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/implementation-plan/" }
           ],
           "shared": [
             "features/starter_data/"

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -44,7 +44,10 @@
           "files": [
             { "src": "agents-md/l4-data.md", "dest": "AGENTS.md" },
             { "src": "rules/generic/test-first.md", "dest": ".agents/rules/test-first.md" },
-            { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" }
+            { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
+            { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/spec-planning/" },
+            { "src": "skills/backend/architecture-preflight/", "dest": ".agents/skills/architecture-preflight/" },
+            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/implementation-plan/" }
           ],
           "shared": [
             "features/starter_data/"

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -44,7 +44,10 @@
           "files": [
             { "src": "copilot-instructions/l4-data.md", "dest": ".github/copilot-instructions.md" },
             { "src": "instructions/generic/test-first.instructions.md", "dest": ".github/instructions/test-first.instructions.md" },
-            { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" }
+            { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" },
+            { "src": "skills/backend/spec-planning/", "dest": ".github/skills/spec-planning/" },
+            { "src": "skills/backend/architecture-preflight/", "dest": ".github/skills/architecture-preflight/" },
+            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/implementation-plan/" }
           ],
           "shared": [
             "features/starter_data/"

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -1623,6 +1623,30 @@ class TestApplyTypeDataStackDefault:
         assert (target / "ci" / "github" / "data-common-gate.yml").is_file()
         assert (target / "ci" / "github" / "dbt-gate.yml").is_file()
 
+    @pytest.mark.parametrize(
+        "agent, skills_dir",
+        [
+            ("claude-code", ".claude/skills"),
+            ("codex", ".agents/skills"),
+            ("copilot", ".github/skills"),
+        ],
+    )
+    def test_apply_type_data_l4_installs_planning_skills(self, tmp_path, agent, skills_dir):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "project"
+        target.mkdir()
+        cmd_apply(argparse.Namespace(
+            agent=agent, target=str(target),
+            level="4", type="data", ci="github",
+            stack="databricks-lakehouse", force=False, detect=False,
+        ))
+
+        for skill in ("architecture-preflight", "spec-planning", "implementation-plan"):
+            assert (target / skills_dir / skill / "SKILL.md").is_file()
+
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     def test_apply_type_data_rejects_l5(self, tmp_path, agent, capsys):
         """Data is an L3/L4 shape. L5 is GenAI-Ops for LLM app delivery and
@@ -3300,6 +3324,19 @@ class TestNoUiDimensionInManifests:
         )
         # data is an L3/L4 shape (dbt has no L5 GenAI-ops tier).
         assert "level_4" in data, f"{agent}: data block must declare a level_4 add-on"
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    def test_data_level_4_installs_planning_skills(self, agent):
+        """L4 data instructions require the same planning skills they name."""
+        from cli.paths import AGENTS_DIR
+
+        manifest = json.loads((AGENTS_DIR / agent / "manifest.json").read_text(encoding="utf-8"))
+        files = manifest["variants"]["type"]["data"]["level_4"]["files"]
+        destinations = {entry["dest"] for entry in files}
+        for skill in ("architecture-preflight", "spec-planning", "implementation-plan"):
+            assert any(dest.endswith(f"/{skill}/") for dest in destinations), (
+                f"{agent}: data level_4 must install {skill}"
+            )
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     def test_python_dbt_is_advertised_as_stack_choice(self, agent):


### PR DESCRIPTION
## Summary

- Install the L4 planning skills for data projects across Codex, Claude Code, and Copilot manifests.
- Add manifest-level and apply-level regression coverage so data L4 cannot reference missing planning skills again.

## Root Cause

The data L4 instructions referenced `architecture-preflight`, `spec-planning`, and `implementation-plan`, but the data L4 manifest entries only installed the generic L4 rules. As a result, `govkit apply --level 4 --type data` produced instructions that named project-local skills that were not present.

## Validation

- `python -m pytest tests/test_govkit.py::TestNoUiDimensionInManifests tests/test_govkit.py::TestApplyTypeDataStackDefault -q`
- `python -m pytest tests/test_schemas.py -q`