### PR TITLE
refactor(govkit): single owner for per-agent on-disk layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed — internal
+
+- Per-agent on-disk layout facts (instruction file, rules dir, rules glob,
+  frontmatter glob key/shape) now have a single owner: `cli/agent_layout.py`.
+  Replaces four private copies in `calibrate`, `setup_review`, `doctor`, and
+  `rule_templating`. No user-facing behavior change; a bundle-parity test
+  keeps the table and `agents/` in sync. See
+  `plans/AGENT_LAYOUT_REFACTOR_PLAN.md`.
+
 ---
 
 ## [0.13.0] — 2026-06-07

--- a/cli/agent_layout.py
+++ b/cli/agent_layout.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Per-agent on-disk layout — the single owner of where each agent's files land.
+
+Kernel leaf module (imports nothing internal, like cli/paths.py) so commands
+and domain modules depend on it inward without cycles.
+
+Boundary: agents/<agent>/manifest.json owns *what installs*. This table owns
+the derived facts commands need *after* install — where the instruction file
+and rules live, and how rule frontmatter scopes globs. Consumers: doctor
+(D001 glob resolution), calibrate + setup_review (review paths), and
+rule_templating (template expansion).
+
+Codex has no glob-scoped rules dir (placement of nested AGENTS.md files IS its
+rule scope), so its rules/glob fields are None — consumers skip on that rather
+than dispatching on the agent name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True)
+class AgentLayout:
+    """One agent's file-layout facts. All paths are target-relative strings."""
+
+    instruction_file: str
+    rules_dir: str | None
+    rules_glob: str | None
+    frontmatter_glob_key: str | None
+    glob_value_shape: Literal["list", "comma-string"] | None
+
+
+AGENT_LAYOUTS: dict[str, AgentLayout] = {
+    "claude-code": AgentLayout(
+        instruction_file="CLAUDE.md",
+        rules_dir=".claude/rules",
+        rules_glob=".claude/rules/*.md",
+        frontmatter_glob_key="paths",
+        glob_value_shape="list",
+    ),
+    "copilot": AgentLayout(
+        instruction_file=".github/copilot-instructions.md",
+        rules_dir=".github/instructions",
+        rules_glob=".github/instructions/*.instructions.md",
+        frontmatter_glob_key="applyTo",
+        glob_value_shape="comma-string",
+    ),
+    "codex": AgentLayout(
+        instruction_file="AGENTS.md",
+        rules_dir=None,
+        rules_glob=None,
+        frontmatter_glob_key=None,
+        glob_value_shape=None,
+    ),
+}

--- a/cli/calibrate.py
+++ b/cli/calibrate.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .agent_layout import AGENT_LAYOUTS
 from .marker import read_govkit_marker, write_govkit_marker
 from .stack_select import STACK_ID_ASSUMPTION
 
@@ -69,25 +70,8 @@ class CalibrationResult:
 
 
 # ---------------------------------------------------------------------------
-# Agent + type helpers (mirror cli/setup_review.py conventions)
+# Type helpers (mirror cli/setup_review.py conventions)
 # ---------------------------------------------------------------------------
-
-
-def _agent_paths(agent: str) -> dict[str, str]:
-    if agent == "copilot":
-        return {
-            "agent_instruction_file": ".github/copilot-instructions.md",
-            "rules_dir": ".github/instructions",
-        }
-    if agent == "codex":
-        return {
-            "agent_instruction_file": "AGENTS.md",
-            "rules_dir": "AGENTS.md",  # codex uses nested placement, not a dir
-        }
-    return {
-        "agent_instruction_file": "CLAUDE.md",
-        "rules_dir": ".claude/rules",
-    }
 
 
 def _architecture_root(type_value: str) -> str:
@@ -117,7 +101,10 @@ def build_checklist(target: Path, marker: dict) -> list[CalibrationStep]:
     options = marker.get("options", {})
     type_value = options.get("type", "api")
     arch = _architecture_root(type_value)
-    paths = _agent_paths(agent)
+    layout = AGENT_LAYOUTS.get(agent, AGENT_LAYOUTS["claude-code"])
+    # Codex has no glob-scoped rules dir; its nested AGENTS.md files are the
+    # reviewable rules surface, so the step points there instead.
+    rules_path = layout.rules_dir or layout.instruction_file
     stack = marker.get("stack") or {}
 
     profile = build_profile(target)
@@ -263,9 +250,9 @@ def build_checklist(target: Path, marker: dict) -> list[CalibrationStep]:
     # 6. Top-level agent guidance
     steps.append(CalibrationStep(
         id="step.agent_instructions",
-        title=f"Top-level agent guidance ({paths['agent_instruction_file']})",
+        title=f"Top-level agent guidance ({layout.instruction_file})",
         description="Confirm references to architecture docs are accurate.",
-        file_path=paths["agent_instruction_file"],
+        file_path=layout.instruction_file,
         installed_summary=f"agent={agent} baseline govkit@{marker.get('version', '?')}",
         detected_value=None,
         suggestion=(
@@ -279,9 +266,9 @@ def build_checklist(target: Path, marker: dict) -> list[CalibrationStep]:
     # 7. Rules / instructions tree
     steps.append(CalibrationStep(
         id="step.rules",
-        title=f"Agent rules ({paths['rules_dir']})",
+        title=f"Agent rules ({rules_path})",
         description="Per-rule globs/applyTo patterns must match your folder layout.",
-        file_path=paths["rules_dir"],
+        file_path=rules_path,
         installed_summary=(
             f"agent={agent} — rules ship with the baseline; "
             "`govkit doctor` D001 flags rules whose globs resolve to zero files"

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -25,6 +25,7 @@ from typing import Literal
 # ---------------------------------------------------------------------------
 # Finding model
 # ---------------------------------------------------------------------------
+from .agent_layout import AGENT_LAYOUTS
 from .marker import MARKER_DIRNAME, MARKER_FILENAME, read_govkit_marker
 
 Severity = Literal["error", "warning", "info"]
@@ -65,21 +66,6 @@ def _register_check(check_id: str):
 # ---------------------------------------------------------------------------
 # Rule-tree resolution (agent-aware)
 # ---------------------------------------------------------------------------
-
-
-def _rules_spec_for_agent(agent: str) -> tuple[Path | None, str] | None:
-    """Return (rules_dir_relative, frontmatter_key) for the active agent.
-
-    Returns None for codex (which uses nested AGENTS.md placement, not
-    globs — D001 doesn't apply).
-    """
-    if agent == "claude-code":
-        return Path(".claude") / "rules", "paths"
-    if agent == "copilot":
-        return Path(".github") / "instructions", "applyTo"
-    if agent == "codex":
-        return None  # path-based, no glob frontmatter
-    return None
 
 
 def _parse_frontmatter(text: str) -> dict | None:
@@ -160,10 +146,11 @@ def _check_rule_globs_resolve(target: Path, marker: dict) -> list[ValidationFind
     strings, codex skips (no glob frontmatter; placement IS the rule scope).
     """
     agent = marker.get("agent", "claude-code")
-    spec = _rules_spec_for_agent(agent)
-    if spec is None:
+    layout = AGENT_LAYOUTS.get(agent)
+    if layout is None or layout.frontmatter_glob_key is None:
         return []
-    rules_dir, key = spec
+    rules_dir = Path(layout.rules_dir)
+    key = layout.frontmatter_glob_key
 
     findings: list[ValidationFinding] = []
     for rule_file in _iter_rule_files(target, rules_dir):

--- a/cli/rule_templating.py
+++ b/cli/rule_templating.py
@@ -27,24 +27,20 @@ from pathlib import Path
 
 import yaml
 
+from .agent_layout import AGENT_LAYOUTS
 
 # Each agent uses its own frontmatter shape:
 #   claude-code → paths_template: layers.<k>  →  paths: [<globs>]      (list)
 #   copilot     → applyTo_template: layers.<k>→  applyTo: "<glob,...>" (string)
-# _TEMPLATE_SCHEMAS encodes the per-key (template_key, output_key, list_vs_string)
-# so the helper can handle both shapes from one entry point.
+# The per-key (template_key, output_key, list_vs_string) schemas derive from
+# AGENT_LAYOUTS; expansion stays agent-agnostic — every schema is tried against
+# every file so the helper handles both shapes from one entry point.
 _TEMPLATE_SCHEMAS: list[tuple[str, str, str]] = [
-    ("paths_template", "paths", "list"),
-    ("applyTo_template", "applyTo", "comma-string"),
+    (f"{layout.frontmatter_glob_key}_template",
+     layout.frontmatter_glob_key, layout.glob_value_shape)
+    for layout in AGENT_LAYOUTS.values()
+    if layout.frontmatter_glob_key
 ]
-
-# Where each agent's rule files land. Codex uses nested AGENTS.md placement —
-# no glob frontmatter, so nothing to template.
-_RULES_DIRS_BY_AGENT: dict[str, list[str]] = {
-    "claude-code": [".claude/rules"],
-    "copilot":     [".github/instructions"],
-    "codex":       [],
-}
 
 
 def expand_rule_template(text: str, layers: dict[str, list[str]]) -> str:
@@ -132,18 +128,20 @@ def template_installed_rules(
     doesn't call this — architecture style is a property of the repo, not
     the stack.
     """
+    layout = AGENT_LAYOUTS.get(agent)
+    if layout is None or layout.rules_dir is None:
+        return 0
+    rules_root = target / layout.rules_dir
+    if not rules_root.is_dir():
+        return 0
     modified = 0
-    for rules_rel in _RULES_DIRS_BY_AGENT.get(agent, []):
-        rules_root = target / rules_rel
-        if not rules_root.is_dir():
+    for md in rules_root.rglob("*.md"):
+        try:
+            text = md.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
             continue
-        for md in rules_root.rglob("*.md"):
-            try:
-                text = md.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
-                continue
-            new_text = expand_rule_template(text, layers)
-            if new_text != text:
-                md.write_text(new_text, encoding="utf-8")
-                modified += 1
+        new_text = expand_rule_template(text, layers)
+        if new_text != text:
+            md.write_text(new_text, encoding="utf-8")
+            modified += 1
     return modified

--- a/cli/setup_review.py
+++ b/cli/setup_review.py
@@ -13,31 +13,23 @@ shape and a generic checklist so the discipline starts on day one.
 
 from pathlib import Path
 
+from .agent_layout import AGENT_LAYOUTS, AgentLayout
 
-def _agent_doc_paths(agent: str) -> dict[str, str]:
-    """Return the (label, path) pairs an agent installs at the top level.
 
-    Path conventions differ per agent (CLAUDE.md vs .github/copilot-instructions.md
-    vs AGENTS.md). This keeps the review file's references accurate per install.
-    """
-    if agent == "copilot":
-        return {
-            "agent_instruction_file": ".github/copilot-instructions.md",
-            "rules_dir": ".github/instructions/",
-            "rules_glob": ".github/instructions/*.instructions.md",
-        }
-    if agent == "codex":
-        return {
-            "agent_instruction_file": "AGENTS.md",
-            "rules_dir": "(nested AGENTS.md per layer)",
-            "rules_glob": "AGENTS.md",
-        }
-    # claude-code (default)
-    return {
-        "agent_instruction_file": "CLAUDE.md",
-        "rules_dir": ".claude/rules/",
-        "rules_glob": ".claude/rules/*.md",
-    }
+def _layout_for(agent: str) -> AgentLayout:
+    """Layout for `agent`, defaulting to claude-code for unknown names so a
+    hand-edited marker still yields a readable review file."""
+    return AGENT_LAYOUTS.get(agent, AGENT_LAYOUTS["claude-code"])
+
+
+def _rules_display(layout: AgentLayout) -> tuple[str, str]:
+    """Human-readable (rules_dir, rules_glob) for the review file and banner.
+
+    Agents without a glob-scoped rules dir (codex) get descriptive text — a
+    presentation concern, so it lives here rather than in the layout table."""
+    if layout.rules_dir is None:
+        return "(nested AGENTS.md per layer)", layout.instruction_file
+    return f"{layout.rules_dir}/", layout.rules_glob
 
 
 def _architecture_root(type_value: str) -> str:
@@ -90,7 +82,8 @@ def _format_review_checklist(agent: str, type_value: str) -> str:
     """Generic per-install review checklist. Path conventions vary by
     agent/type; the items themselves are stable for PR 1."""
     arch = _architecture_root(type_value)
-    paths = _agent_doc_paths(agent)
+    layout = _layout_for(agent)
+    rules_dir, rules_glob = _rules_display(layout)
     items = [
         (f"{arch}/TECH_STACK.md",
          "Confirm the language, framework, persistence, messaging, observability, "
@@ -103,10 +96,10 @@ def _format_review_checklist(agent: str, type_value: str) -> str:
         (f"{arch}/TESTING.md",
          "Confirm the unit/BDD framework, mocking library, and any framework-as-L4-gate "
          "decisions (set BDD to 'none' if your team does not practise BDD)."),
-        (paths["agent_instruction_file"],
+        (layout.instruction_file,
          "Top-level agent guidance. Confirm references to architecture docs are accurate."),
-        (paths["rules_dir"],
-         f"Agent rules ({paths['rules_glob']}). Confirm globs/applyTo patterns match your "
+        (rules_dir,
+         f"Agent rules ({rules_glob}). Confirm globs/applyTo patterns match your "
          "folder layout — rules that don't match anything provide no guidance."),
     ]
     lines = ["Please read these files before relying on the installed governance:\n"]
@@ -222,7 +215,8 @@ def print_review_checklist(target: Path, marker: dict) -> None:
     agent = marker.get("agent", "claude-code")
     type_value = marker.get("options", {}).get("type", "api")
     arch = _architecture_root(type_value)
-    paths = _agent_doc_paths(agent)
+    layout = _layout_for(agent)
+    rules_dir, _ = _rules_display(layout)
     needs_review_count = sum(
         1 for a in (marker.get("assumptions") or []) if a.get("review_required")
     )
@@ -239,8 +233,8 @@ def print_review_checklist(target: Path, marker: dict) -> None:
         f"    1. {arch}/TECH_STACK.md      — language / framework / libraries",
         f"    2. {arch}/BOUNDARIES.md      — architecture style + folder mappings",
         f"    3. {arch}/TESTING.md         — test framework + BDD policy",
-        f"    4. {paths['agent_instruction_file']:32s} — top-level agent guidance",
-        f"    5. {paths['rules_dir']:32s} — rule globs / applyTo patterns",
+        f"    4. {layout.instruction_file:32s} — top-level agent guidance",
+        f"    5. {rules_dir:32s} — rule globs / applyTo patterns",
     ]
     if needs_review_count:
         lines.append("")

--- a/plans/AGENT_LAYOUT_REFACTOR_PLAN.md
+++ b/plans/AGENT_LAYOUT_REFACTOR_PLAN.md
@@ -1,0 +1,141 @@
+# Agent Layout Refactor Plan
+
+Give "an agent's on-disk layout" a single owner: a new kernel-leaf module
+`cli/agent_layout.py` holding one frozen dataclass and one table, replacing the
+four private copies of the same facts in `calibrate.py`, `setup_review.py`,
+`doctor.py`, and `rule_templating.py`.
+
+## Motivation (evidence)
+
+Four modules independently translate the marker's `agent` string into
+filesystem facts, each with its own `if/elif` chain or private table:
+
+| Fact | calibrate.py `_agent_paths` | setup_review.py `_agent_doc_paths` | doctor.py `_rules_spec_for_agent` | rule_templating.py `_RULES_DIRS_BY_AGENT` / `_TEMPLATE_SCHEMAS` |
+|---|---|---|---|---|
+| Instruction file | copy | copy | — | — |
+| Rules directory | copy | copy | copy | copy |
+| Rules glob | — | copy | — | — |
+| Frontmatter glob key | — | — | copy | copy |
+| Glob value shape | — | — | implicit | copy |
+| Codex "no rules dir" | `"AGENTS.md"` | `"(nested AGENTS.md per layer)"` | `None` | `[]` |
+
+Adding a fourth agent today means editing four modules with four idioms —
+including four different spellings of "this agent has no glob-scoped rules".
+Agent parity is a maintained invariant of this repo; this table makes it
+structural instead of remembered.
+
+## Target design
+
+```python
+# cli/agent_layout.py — kernel leaf, imports nothing internal (like paths.py)
+
+@dataclass(frozen=True)
+class AgentLayout:
+    instruction_file: str               # "CLAUDE.md"
+    rules_dir: str | None               # None = no glob-scoped rules (codex)
+    rules_glob: str | None
+    frontmatter_glob_key: str | None    # "paths" | "applyTo"
+    glob_value_shape: str | None        # "list" | "comma-string"
+
+AGENT_LAYOUTS: dict[str, AgentLayout] = {
+    "claude-code": AgentLayout("CLAUDE.md", ".claude/rules",
+                               ".claude/rules/*.md", "paths", "list"),
+    "copilot": AgentLayout(".github/copilot-instructions.md",
+                           ".github/instructions",
+                           ".github/instructions/*.instructions.md",
+                           "applyTo", "comma-string"),
+    "codex": AgentLayout("AGENTS.md", None, None, None, None),
+}
+```
+
+Boundary: `agents/<agent>/manifest.json` continues to own *what installs*.
+`agent_layout.py` owns the derived facts commands need *after* install (where
+rules live, how their frontmatter is scoped, what to tell the user to review).
+
+## Increments
+
+Each increment is independently committable, keeps the full suite green, and
+runs `ruff check` scoped to the files it touched. Increment 1 is test-first
+(new code). Increments 2–5 are behavior-preserving refactors where the
+existing per-agent tests are the specification — if a gap is found mid-
+increment, add the failing test before changing the module.
+
+### 1. Create `cli/agent_layout.py` (test-first)
+
+1. Write `tests/test_agent_layout.py` — failing (module doesn't exist):
+   - the three production agents are present with exactly the field values above
+   - `AgentLayout` is frozen (assignment raises `FrozenInstanceError`)
+   - codex has `rules_dir is None` and all glob fields `None`
+   - parity guard: `set(AGENT_LAYOUTS) == {bundled agent dirs with a
+     manifest.json under paths.AGENTS_DIR}` — a fourth agent cannot be added
+     to the bundle without a layout row, or vice versa
+2. Create the module to make them pass. No consumer changes.
+
+Diff: 2 new files.
+
+### 2. Migrate `doctor.py`
+
+Pinned behavior: `test_d001_handles_copilot_applyto_format`,
+`test_d001_codex_agent_skips_glob_check` (tests/test_doctor.py:207, 224).
+
+1. In `_check_rule_globs_resolve` (D001), replace `_rules_spec_for_agent`
+   with `AGENT_LAYOUTS.get(agent)`; skip when the layout is missing or
+   `frontmatter_glob_key is None`. Convert `rules_dir` with `Path(...)` at
+   the use site (the helper returned a `Path`).
+2. Delete `_rules_spec_for_agent`.
+
+Diff: doctor.py only.
+
+### 3. Migrate `rule_templating.py`
+
+Pinned behavior: `test_copilot_applyto_template_expands_to_comma_string`,
+`test_copilot_applyto_fallback_preserved_when_layer_empty`
+(tests/test_rule_templating.py:132, 153).
+
+1. Derive the schema list from the table instead of hardcoding it:
+   `[(f"{l.frontmatter_glob_key}_template", l.frontmatter_glob_key,
+   l.glob_value_shape) for l in AGENT_LAYOUTS.values() if
+   l.frontmatter_glob_key]`. `expand_rule_template(text, layers)` keeps its
+   signature and its agent-agnostic try-both-schemas behavior — narrowing it
+   to per-agent expansion would be a behavior change with no payoff; out of
+   scope here.
+2. In `template_installed_rules`, replace `_RULES_DIRS_BY_AGENT.get(agent, [])`
+   with the layout lookup (`layout.rules_dir` or skip when `None`).
+3. Delete `_RULES_DIRS_BY_AGENT` and the hardcoded `_TEMPLATE_SCHEMAS` literal.
+
+Diff: rule_templating.py only.
+
+### 4. Migrate `calibrate.py` and `setup_review.py`
+
+Pinned behavior: per-agent path assertions in tests/test_calibrate.py:130–148
+and tests/test_setup_review.py:65–80 — including the codex display strings.
+
+1. `setup_review.py`: delete `_agent_doc_paths`; read `layout.instruction_file`,
+   and render codex's absence at the two format sites:
+   `layout.rules_dir or "(nested AGENTS.md per layer)"` /
+   `layout.rules_glob or "AGENTS.md"`. Display fallbacks are presentation,
+   not layout facts — they stay at the print site.
+2. `calibrate.py`: delete `_agent_paths`; same lookup, fallback
+   `layout.rules_dir or "AGENTS.md"` for the step's `file_path`.
+
+Diff: calibrate.py + setup_review.py (both display-only consumers).
+
+### 5. Sweep and close
+
+1. `grep` the repo for `_agent_paths`, `_agent_doc_paths`,
+   `_rules_spec_for_agent`, `_RULES_DIRS_BY_AGENT` — zero hits expected.
+2. Full suite + ruff on all files touched by the branch.
+3. Note in CHANGELOG.md under Unreleased (internal refactor, no user-facing
+   behavior change).
+
+## Risks / non-goals
+
+- **No behavior change intended anywhere.** Every consumer's per-agent output
+  is already pinned by tests; any red test in increments 2–4 means the
+  refactor drifted, not that the test needs updating.
+- **Non-goal:** moving layout facts into `agents/<agent>/manifest.json`.
+  Defensible future home, but it costs a schema change across three manifests
+  plus load-failure handling for zero present benefit. The table gives the
+  facts one owner; consumers won't care if the storage moves later.
+- **Non-goal:** per-agent narrowing of `expand_rule_template` (see
+  increment 3).

--- a/tests/test_agent_layout.py
+++ b/tests/test_agent_layout.py
@@ -1,0 +1,71 @@
+"""Tests for cli/agent_layout.py — the single owner of per-agent on-disk layout.
+
+AGENT_LAYOUT_REFACTOR_PLAN.md increment 1. One frozen dataclass + one table
+replaces the four private copies of these facts that previously lived in
+calibrate.py, setup_review.py, doctor.py, and rule_templating.py.
+"""
+
+import dataclasses
+
+import pytest
+
+
+class TestAgentLayoutTable:
+    def test_all_three_production_agents_present(self):
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        assert set(AGENT_LAYOUTS) == {"claude-code", "copilot", "codex"}
+
+    def test_claude_code_layout(self):
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        layout = AGENT_LAYOUTS["claude-code"]
+        assert layout.instruction_file == "CLAUDE.md"
+        assert layout.rules_dir == ".claude/rules"
+        assert layout.rules_glob == ".claude/rules/*.md"
+        assert layout.frontmatter_glob_key == "paths"
+        assert layout.glob_value_shape == "list"
+
+    def test_copilot_layout(self):
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        layout = AGENT_LAYOUTS["copilot"]
+        assert layout.instruction_file == ".github/copilot-instructions.md"
+        assert layout.rules_dir == ".github/instructions"
+        assert layout.rules_glob == ".github/instructions/*.instructions.md"
+        assert layout.frontmatter_glob_key == "applyTo"
+        assert layout.glob_value_shape == "comma-string"
+
+    def test_codex_has_no_glob_scoped_rules(self):
+        """Codex places nested AGENTS.md files instead of a glob-scoped rules
+        dir. Its absence is one typed None, not per-consumer sentinel strings."""
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        layout = AGENT_LAYOUTS["codex"]
+        assert layout.instruction_file == "AGENTS.md"
+        assert layout.rules_dir is None
+        assert layout.rules_glob is None
+        assert layout.frontmatter_glob_key is None
+        assert layout.glob_value_shape is None
+
+    def test_layout_is_frozen(self):
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            AGENT_LAYOUTS["claude-code"].rules_dir = "elsewhere"
+
+
+class TestBundleParity:
+    def test_layout_keys_match_bundled_agents(self):
+        """Every bundled agent (a dir under agents/ with a manifest.json) has a
+        layout row, and every layout row has a bundled agent. A fourth agent
+        cannot be added to one without the other."""
+        from cli import paths
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        bundled = {
+            d.name
+            for d in paths.AGENTS_DIR.iterdir()
+            if d.is_dir() and (d / "manifest.json").is_file()
+        }
+        assert set(AGENT_LAYOUTS) == bundled


### PR DESCRIPTION
## What

Gives \"an agent's on-disk layout\" a single owner — a new kernel-leaf module `cli/agent_layout.py` (one frozen `AgentLayout` dataclass + one `AGENT_LAYOUTS` table) — replacing four private copies of the same facts.

## Why

Four modules independently translated the marker's `agent` string into filesystem facts (instruction file, rules dir, rules glob, frontmatter glob key/shape), each with its own `if/elif` chain or private table: `calibrate._agent_paths`, `setup_review._agent_doc_paths`, `doctor._rules_spec_for_agent`, and `rule_templating._RULES_DIRS_BY_AGENT`/`_TEMPLATE_SCHEMAS`. Codex's \"no glob-scoped rules\" fact alone had three different encodings (`None`, `[]`, and a display string). Adding a fourth agent meant shotgun surgery across all four. Full evidence and design in `plans/AGENT_LAYOUT_REFACTOR_PLAN.md`.

## Changes

- **New:** `cli/agent_layout.py` — frozen `AgentLayout` dataclass + `AGENT_LAYOUTS` table for claude-code / copilot / codex; codex's absence of glob-scoped rules is one typed `None`
- **New:** `tests/test_agent_layout.py` — field values per agent, frozen-ness, and a bundle-parity guard (table keys must match `agents/` dirs with a `manifest.json`, so a fourth agent can't be added to one without the other)
- `doctor.py` — D001 reads the table; codex skip is data-driven (`frontmatter_glob_key is None`); deleted `_rules_spec_for_agent`
- `rule_templating.py` — `_TEMPLATE_SCHEMAS` derives from the table (expansion stays agent-agnostic, signature unchanged); deleted `_RULES_DIRS_BY_AGENT`
- `calibrate.py` + `setup_review.py` — read the table; deleted `_agent_paths` and `_agent_doc_paths`; codex display strings stay at the format sites as presentation fallbacks (review-file output is byte-identical)
- `CHANGELOG.md` — internal-change note under Unreleased

No user-facing behavior change intended anywhere.

## Testing

- Full suite green after every increment: `python -m pytest -q` → 988 passed, 1 pre-existing skip
- Increment 1 was test-first (6 failing tests before the module existed); increments 2–4 are behavior-preserving refactors specified by the existing per-agent tests (D001 copilot/codex in `test_doctor.py`, per-agent paths in `test_calibrate.py`/`test_setup_review.py`, applyTo expansion in `test_rule_templating.py`)
- End-to-end against a scratch target: `govkit apply --agent claude-code` (byte-identical review banner), `govkit doctor` (D001 findings resolve through the table, with globs proving template expansion ran), `govkit calibrate --non-interactive` (9-step checklist with correct per-agent paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)