### PR TITLE
refactor(govkit): stack overlays own per-stack facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed — internal
 
+- Stack overlays are now the single owner of per-stack facts: `overlay.yaml`
+  gains a required `supported_types` list (schema-enforced), doctor D005
+  reads the expected language from the overlay's `skill_context.language`,
+  and type-gating in stack selection reads `supported_types`. Deletes the
+  parallel `_STACK_PRIMARY_LANGUAGE` and `_STACK_SUPPORTED_TYPES` code
+  tables — adding a stack is now purely additive. Guard tests keep every
+  bundled overlay declaring both facts. No user-facing behavior change and
+  no overlay version bumps. See `plans/STACK_METADATA_UNIFICATION_PLAN.md`.
 - Per-agent on-disk layout facts (instruction file, rules dir, rules glob,
   frontmatter glob key/shape) now have a single owner: `cli/agent_layout.py`.
   Replaces four private copies in `calibrate`, `setup_review`, `doctor`, and

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -244,34 +244,29 @@ def _check_ci_ambiguous(target: Path, marker: dict) -> list[ValidationFinding]:
     return []
 
 
-# stack.id → primary language. Used by D005 to compare against detection.
-_STACK_PRIMARY_LANGUAGE = {
-    "python-fastapi":   "python",
-    "dotnet-aspnet":    "csharp",
-    "java-spring-boot": "java",
-    "nodejs-fastify":   "typescript",
-    "go-gin":           "go",
-    "python-dbt":       "python",
-    "databricks-lakehouse": "python",
-}
-
-
 @_register_check("D005")
 def _check_stack_language_mismatch(target: Path, marker: dict) -> list[ValidationFinding]:
     """D005 — marker.stack.id implies a language; detected languages disagree.
 
+    The expected language comes from the bundled overlay's
+    skill_context.language (the overlay owns per-stack facts; a guard test
+    keeps every bundled overlay declaring one).
+
     Silent when:
       - marker has no stack block (legacy)
-      - stack.id isn't one we know how to map to a language
+      - stack.id doesn't resolve to a bundled overlay declaring a language
       - no language detected in repo (nothing to disagree with)
       - detected languages include the expected one
     """
+    from .overlay import load_overlay
+
     stack = marker.get("stack")
     if not stack:
         return []
     stack_id = stack.get("id")
-    expected_lang = _STACK_PRIMARY_LANGUAGE.get(stack_id)
-    if expected_lang is None:
+    overlay = load_overlay(stack_id) if stack_id else None
+    expected_lang = (overlay.skill_context or {}).get("language") if overlay else None
+    if not expected_lang:
         return []
 
     from .detect import build_profile

--- a/cli/overlay.py
+++ b/cli/overlay.py
@@ -39,6 +39,7 @@ class Overlay:
     version: str
     display_name: str
     summary: str
+    supported_types: list = field(default_factory=list)
     default_assumptions: list = field(default_factory=list)
     docs: list = field(default_factory=list)
     skill_context: dict = field(default_factory=dict)
@@ -78,6 +79,7 @@ def _build_overlay(stack_dir: Path) -> Overlay | None:
         version=version,
         display_name=display_name,
         summary=data.get("summary", ""),
+        supported_types=data.get("supported_types") or [],
         default_assumptions=data.get("default_assumptions") or [],
         docs=data.get("docs") or [],
         skill_context=data.get("skill_context") or {},

--- a/cli/stack_select.py
+++ b/cli/stack_select.py
@@ -36,32 +36,27 @@ _DEFAULT_STACK_BY_TYPE = {
     "data": "python-dbt",
 }
 
-# Which `--type` shapes each stack supports. An inferred stack that doesn't
-# support the user's chosen --type is treated as an ambient signal from a
-# different shape (e.g. fastapi in pyproject.toml of a dbt workshop dir) and
-# does NOT override the type-default. The user's explicit --type intent wins.
-_STACK_SUPPORTED_TYPES = {
-    "python-fastapi":    frozenset({"api", "cli"}),
-    "dotnet-aspnet":     frozenset({"api", "cli"}),
-    "java-spring-boot":  frozenset({"api", "cli"}),
-    "nodejs-fastify":    frozenset({"api", "cli"}),
-    "go-gin":            frozenset({"api", "cli"}),
-    "python-dbt":        frozenset({"data"}),
-    "databricks-lakehouse": frozenset({"data"}),
-}
-
-
 def _stack_supports_type(stack_id: str | None, type_value: str) -> bool:
     """True when `stack_id` is a sensible overlay for `type_value`.
 
-    Unknown stack_ids return True so future-added stacks aren't accidentally
-    rejected by an out-of-date map — the type-default is a safety net, not a
+    An inferred stack that doesn't support the user's chosen --type is
+    treated as an ambient signal from a different shape (e.g. fastapi in
+    pyproject.toml of a dbt workshop dir) and does NOT override the
+    type-default. The user's explicit --type intent wins.
+
+    Reads the overlay's declared supported_types. Unknown stack ids and
+    overlays declaring no restriction return True so future-added stacks
+    aren't accidentally rejected — the type-default is a safety net, not a
     gatekeeper.
     """
     if not stack_id:
         return False
-    supported = _STACK_SUPPORTED_TYPES.get(stack_id)
-    return True if supported is None else type_value in supported
+    from .overlay import load_overlay
+
+    overlay = load_overlay(stack_id)
+    if overlay is None or not overlay.supported_types:
+        return True
+    return type_value in overlay.supported_types
 
 
 def resolve_stack_choice(

--- a/cli/stacks/databricks-lakehouse/overlay.yaml
+++ b/cli/stacks/databricks-lakehouse/overlay.yaml
@@ -3,6 +3,7 @@ id: databricks-lakehouse
 version: "0.10.0"
 display_name: "Databricks Lakehouse (Unity Catalog / Delta / Asset Bundles)"
 summary: "Databricks-native data delivery with Unity Catalog, Delta tables, Asset Bundles, Jobs, Lakeflow Pipelines, PySpark, SQL, and notebooks"
+supported_types: [data]
 default_assumptions:
   - id: stack.language
     value: python

--- a/cli/stacks/dotnet-aspnet/overlay.yaml
+++ b/cli/stacks/dotnet-aspnet/overlay.yaml
@@ -3,6 +3,7 @@ id: dotnet-aspnet
 version: "0.10.0"
 display_name: "C# 12 / .NET 8 / ASP.NET Core Minimal APIs"
 summary: "ASP.NET Core Minimal APIs, xUnit, Moq, optional SpecFlow/Reqnroll for L4 BDD"
+supported_types: [api, cli]
 default_assumptions:
   - id: stack.language
     value: csharp

--- a/cli/stacks/go-gin/overlay.yaml
+++ b/cli/stacks/go-gin/overlay.yaml
@@ -3,6 +3,7 @@ id: go-gin
 version: "0.10.0"
 display_name: "Go 1.22+ / Gin"
 summary: "Gin + standard library testing + testify + optional godog for L4 BDD"
+supported_types: [api, cli]
 default_assumptions:
   - id: stack.language
     value: go

--- a/cli/stacks/java-spring-boot/overlay.yaml
+++ b/cli/stacks/java-spring-boot/overlay.yaml
@@ -3,6 +3,7 @@ id: java-spring-boot
 version: "0.10.0"
 display_name: "Java 21 / Spring Boot 3 / Spring Web MVC"
 summary: "Spring Boot 3 + JUnit 5 + Mockito + optional Cucumber for L4 BDD"
+supported_types: [api, cli]
 default_assumptions:
   - id: stack.language
     value: java

--- a/cli/stacks/nodejs-fastify/overlay.yaml
+++ b/cli/stacks/nodejs-fastify/overlay.yaml
@@ -3,6 +3,7 @@ id: nodejs-fastify
 version: "0.10.0"
 display_name: "Node.js 20 LTS / TypeScript 5 / Fastify 4"
 summary: "Fastify 4 + TypeScript 5 + Vitest + optional Cucumber-JS for L4 BDD"
+supported_types: [api, cli]
 default_assumptions:
   - id: stack.language
     value: typescript

--- a/cli/stacks/python-dbt/overlay.yaml
+++ b/cli/stacks/python-dbt/overlay.yaml
@@ -3,6 +3,7 @@ id: python-dbt
 version: "0.10.0"
 display_name: "Python 3.11+ / dbt-core (staging / intermediate / marts)"
 summary: "dbt-core + a warehouse adapter (Snowflake / BigQuery / Redshift / Postgres); SQLfluff + dbt schema tests + optional dbt-expectations for L4"
+supported_types: [data]
 default_assumptions:
   - id: stack.language
     value: python

--- a/cli/stacks/python-fastapi/overlay.yaml
+++ b/cli/stacks/python-fastapi/overlay.yaml
@@ -3,6 +3,7 @@ id: python-fastapi
 version: "0.10.0"
 display_name: "Python 3.11+ / FastAPI"
 summary: "FastAPI + pydantic + SQLAlchemy + pytest + pytest-bdd"
+supported_types: [api, cli]
 default_assumptions:
   - id: stack.language
     value: python

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -29,7 +29,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from .marker import read_govkit_marker
+from .marker import read_govkit_level
 
 # ---------------------------------------------------------------------------
 # Artifact file name constants
@@ -434,16 +434,6 @@ def check_l5_preflight_sections(feature_dir: Path) -> tuple[bool, str]:
 # Runner
 # ---------------------------------------------------------------------------
 
-def _read_govkit_level(target: Path) -> str | None:
-    """Read the maturity level from the .govkit marker file.
-
-    Delegates to read_govkit_marker so the one-time v0.6→v0.7
-    migration warning fires from `govkit validate` too.
-    """
-    data = read_govkit_marker(target)
-    return data.get("level") if data else None
-
-
 def _build_checks(level: str) -> tuple[list[str], list]:
     """Return the artifact list and check functions for a given level.
 
@@ -531,7 +521,7 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
         return 1
 
     if level is None:
-        level = _read_govkit_level(target) or "3"
+        level = read_govkit_level(target) or "3"
 
     ext_exit = _run_extension_checks(target, strict)
 

--- a/governance/schemas/stack-overlay.schema.json
+++ b/governance/schemas/stack-overlay.schema.json
@@ -3,7 +3,7 @@
   "title": "GovKit Stack Overlay Schema",
   "description": "Schema for cli/stacks/<id>/overlay.yaml - the metadata file shipped alongside stack-specific architecture docs. Loaded by cli/overlay.py.",
   "type": "object",
-  "required": ["id", "version", "display_name", "summary", "docs"],
+  "required": ["id", "version", "display_name", "summary", "supported_types", "docs"],
   "additionalProperties": false,
   "properties": {
     "id": {
@@ -25,6 +25,12 @@
       "type": "string",
       "minLength": 1,
       "description": "One-line description of the stack's tooling. Surfaces alongside display_name in `govkit stack list`."
+    },
+    "supported_types": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"enum": ["api", "cli", "data", "ui-react", "ui-angular"]},
+      "description": "Project types (`--type` values) this stack overlay applies to. Consulted by stack selection so an inferred stack that doesn't fit the requested type falls back to the type default instead of overriding it."
     },
     "default_assumptions": {
       "type": "array",

--- a/plans/STACK_METADATA_UNIFICATION_PLAN.md
+++ b/plans/STACK_METADATA_UNIFICATION_PLAN.md
@@ -1,0 +1,131 @@
+# Stack Metadata Unification Plan
+
+Make `cli/stacks/<id>/overlay.yaml` the single owner of per-stack facts, as
+`cli/overlay.py` already claims ("the single source of truth for resolving
+stacks"). Two parallel code tables currently contradict that claim, and both
+fail silently when a new stack is added without editing them.
+
+## Motivation (evidence)
+
+| Fact | Owner today | Duplicate | Failure mode when a new stack skips the table |
+|---|---|---|---|
+| Primary language | `skill_context.language` in all 7 overlay.yaml | `doctor._STACK_PRIMARY_LANGUAGE` (doctor.py:248) | D005 silently stops covering the stack |
+| Supported `--type` shapes | — (code only) | `stack_select._STACK_SUPPORTED_TYPES` (stack_select.py:43) | type-gating silently permits everything (`None` → `True`) |
+
+I verified all 7 `_STACK_PRIMARY_LANGUAGE` entries match their overlay's
+`skill_context.language` value-for-value — pure duplication. The stacks
+dimension is actively growing (0.13.0 added `databricks-lakehouse`), so the
+"remember to edit two code tables" tax is recurring, and the silent failure
+modes mean nobody notices when it isn't paid.
+
+Virtues: Unique (each fact lives once, in the stack's own manifest), Easy
+(adding a stack becomes purely additive — drop in a directory, no code
+edits), Coherent (restores overlay.py's documented contract).
+
+## Target design
+
+1. `overlay.yaml` gains a **required** `supported_types` list; the `Overlay`
+   dataclass exposes it. Values per stack (copied from today's code table):
+   - `python-fastapi`, `dotnet-aspnet`, `java-spring-boot`, `nodejs-fastify`,
+     `go-gin` → `[api, cli]`
+   - `python-dbt`, `databricks-lakehouse` → `[data]`
+2. `stack_select._stack_supports_type` consults the loaded overlay; the
+   permissive fallback survives (unknown stack id or empty list → `True`,
+   preserving "safety net, not gatekeeper").
+3. Doctor D005 reads `load_overlay(stack_id).skill_context.get("language")`
+   (same local-import pattern D006 already uses) and
+   `_STACK_PRIMARY_LANGUAGE` is deleted.
+
+Contract enforcement, two layers:
+
+- **Schema**: `governance/schemas/stack-overlay.schema.json` has
+  `additionalProperties: false` and is enforced by
+  `test_bundled_overlay_validates_against_schema` — so `supported_types`
+  must be added to the schema in the same increment as the YAML edits.
+  Make it `required` with items enum'd to the five `--type` values
+  (`api`, `cli`, `data`, `ui-react`, `ui-angular`).
+- **Guard test**: every bundled overlay must declare a non-empty
+  `supported_types` AND a `skill_context.language`. The language guard stays
+  a test (not a schema `required`) because `skill_context` is deliberately
+  free-form per the schema's own description; the guard pins the one key
+  doctor depends on without freezing the rest.
+
+Explicitly NOT bumping overlay `version` fields: `supported_types` is
+metadata, not doc content. A version bump would trigger D006 stale-baseline
+warnings on every existing install for zero user benefit.
+
+## Increments
+
+Each increment is independently committable, full suite green, ruff scoped
+to changed files.
+
+### 1. `supported_types` joins the overlay contract (test-first)
+
+1. Failing tests first:
+   - `tests/test_overlay.py`: `load_overlay("python-fastapi").supported_types
+     == ["api", "cli"]`; `load_overlay("python-dbt").supported_types ==
+     ["data"]`; malformed/missing key → `[]` (loader default, not a crash)
+   - `tests/test_overlay.py` guard: every bundled overlay declares non-empty
+     `supported_types` and a `skill_context.language`
+   - `tests/test_schemas.py` picks up the schema change automatically via
+     `test_bundled_overlay_validates_against_schema` (required key missing →
+     red until the YAMLs are edited; unknown key → red until the schema is)
+2. Then, in one change set: schema property (+ `required`), all 7
+   overlay.yaml files, `Overlay` dataclass field + `_build_overlay` wiring.
+
+Diff: schema, 7 overlay.yaml, overlay.py, test_overlay.py.
+
+### 2. Doctor D005 reads the overlay
+
+Pinned behavior: five D005 tests in tests/test_doctor.py:351-428 (fires on
+mismatch incl. databricks-lakehouse→python; silent on match, no stack, no
+detected language, unknown stack id).
+
+1. Replace `_STACK_PRIMARY_LANGUAGE.get(stack_id)` with a `load_overlay`
+   lookup; `expected_lang = (overlay.skill_context or {}).get("language")`
+   when the overlay loads, else `None` (unknown stack stays silent —
+   identical to today).
+2. Delete `_STACK_PRIMARY_LANGUAGE`.
+
+Diff: doctor.py only.
+
+### 3. Type-gating reads the overlay
+
+Pinned behavior: tests/test_stack_select.py (explicit flag wins; `--type
+data` overrides fastapi inference; `--type api` overrides dbt inference;
+compatible inference honored).
+
+1. `_stack_supports_type` loads the overlay: `None` or empty
+   `supported_types` → `True` (permissive fallback unchanged); else
+   membership test.
+2. Delete `_STACK_SUPPORTED_TYPES`.
+
+Diff: stack_select.py only.
+
+### 4. Ride-along + sweep
+
+1. Delete `validate._read_govkit_level` (verbatim copy of
+   `marker.read_govkit_level`); import and call the original at the one use
+   site (run_validation).
+2. Grep for `_STACK_PRIMARY_LANGUAGE`, `_STACK_SUPPORTED_TYPES`,
+   `_read_govkit_level` — plan docs may reference them as history; code must
+   not.
+3. CHANGELOG note under Unreleased. Full suite + end-to-end smoke
+   (`apply --type data` on a scratch dir → confirms python-dbt default and
+   type-gating through the overlay; `doctor` on a mismatched-language
+   fixture → confirms D005 through the overlay).
+
+## Risks / non-goals
+
+- **No behavior change intended.** All current stacks keep identical
+  language mappings and type support; unknown stacks stay permissive in
+  stack_select and silent in D005, exactly as today.
+- **Perf**: `_stack_supports_type` and D005 now read a YAML file per call.
+  Both are called at most once per command run; negligible.
+- **Non-goal**: deriving `supported_types` from the overlay's docs `dest`
+  paths (`docs/data/...` implies data) — too clever, breaks the moment a
+  stack ships mixed docs. Declared metadata is the honest representation.
+- **Non-goal**: folding `_DEFAULT_STACK_BY_TYPE` into overlays. "Which stack
+  is the default for a type" is govkit policy about the *set* of stacks, not
+  a fact about any single stack — one default per type cannot live in seven
+  files without inventing a precedence rule. It stays in code.

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -5,7 +5,6 @@ describing metadata + docs + default_assumptions + skill_context +
 review_checklist. Loader is the single source of truth for resolving stacks.
 """
 
-import pytest
 
 
 class TestStacksDirResolver:
@@ -44,6 +43,28 @@ class TestListOverlays:
 
         ids = [o.id for o in list_overlays()]
         assert ids == sorted(ids), "list_overlays should return overlays sorted by id"
+
+    def test_every_overlay_declares_supported_types(self):
+        """Guard: type-gating (stack_select) reads supported_types from the
+        overlay. A bundled stack without it would silently permit every
+        --type, so the contract requires a non-empty declaration."""
+        from cli.overlay import list_overlays
+
+        known_types = {"api", "cli", "data", "ui-react", "ui-angular"}
+        for ov in list_overlays():
+            assert ov.supported_types, f"{ov.id} missing supported_types"
+            unknown = set(ov.supported_types) - known_types
+            assert not unknown, f"{ov.id} has unknown supported_types: {unknown}"
+
+    def test_every_overlay_declares_language(self):
+        """Guard: doctor D005 reads skill_context.language from the overlay.
+        A bundled stack without it would silently drop out of D005 coverage."""
+        from cli.overlay import list_overlays
+
+        for ov in list_overlays():
+            assert ov.skill_context.get("language"), (
+                f"{ov.id} missing skill_context.language"
+            )
 
 
 class TestLoadOverlay:
@@ -99,6 +120,38 @@ class TestLoadOverlay:
         assert ov.skill_context.get("language") == "python"
         assert ov.skill_context.get("api_framework") == "fastapi"
 
+    def test_supported_types_for_backend_stack(self):
+        from cli.overlay import load_overlay
+
+        ov = load_overlay("python-fastapi")
+        assert ov is not None
+        assert ov.supported_types == ["api", "cli"]
+
+    def test_supported_types_for_data_stack(self):
+        from cli.overlay import load_overlay
+
+        ov = load_overlay("python-dbt")
+        assert ov is not None
+        assert ov.supported_types == ["data"]
+
+    def test_supported_types_defaults_to_empty_when_absent(self, tmp_path, monkeypatch):
+        """The loader tolerates an overlay without supported_types (empty
+        list, not a crash) — consumers treat empty as 'no restriction'.
+        The schema + guard test keep bundled overlays from actually
+        shipping that way."""
+        stack_dir = tmp_path / "minimal-stack"
+        stack_dir.mkdir()
+        (stack_dir / "overlay.yaml").write_text(
+            'id: minimal-stack\nversion: "0.1.0"\ndisplay_name: "Minimal"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("cli.overlay.STACKS_DIR", tmp_path)
+        from cli.overlay import load_overlay
+
+        ov = load_overlay("minimal-stack")
+        assert ov is not None
+        assert ov.supported_types == []
+
     def test_databricks_lakehouse_overlay_metadata(self):
         from cli.overlay import load_overlay
 
@@ -153,6 +206,7 @@ class TestApplyOverlay:
         so user-edited stack docs are not silently clobbered."""
         import os
         from datetime import datetime, timezone
+
         from cli.headers import format_editable_header
         from cli.overlay import apply_overlay, load_overlay
 


### PR DESCRIPTION
## What

Makes `cli/stacks/<id>/overlay.yaml` the single owner of per-stack facts by adding a required `supported_types` list to the overlay contract and deleting the two parallel code tables that duplicated overlay knowledge.

## Why

`cli/overlay.py` documents itself as \"the single source of truth for resolving stacks\", but two code tables contradicted that: `doctor._STACK_PRIMARY_LANGUAGE` duplicated `skill_context.language` from all 7 overlays (verified value-for-value), and `stack_select._STACK_SUPPORTED_TYPES` kept per-stack type support in code. Both failed silently when a new stack skipped them — D005 just stopped covering the stack, and type-gating permitted everything. With the stacks dimension actively growing (0.13.0 added `databricks-lakehouse`), that drift trap is recurring. Full evidence and design in `plans/STACK_METADATA_UNIFICATION_PLAN.md`.

## Changes

- **Overlay contract**: `supported_types` added to `governance/schemas/stack-overlay.schema.json` as a required property (items enum'd to the five `--type` values) and declared in all 7 bundled `overlay.yaml` files; `Overlay` dataclass exposes it (loader defaults to `[]` for tolerance)
- **Guard tests** in `tests/test_overlay.py`: every bundled overlay must declare non-empty `supported_types` and a `skill_context.language` — new stacks cannot silently drop out of type-gating or D005 coverage
- `doctor.py` — D005 reads the expected language from `load_overlay(stack_id).skill_context`; deleted `_STACK_PRIMARY_LANGUAGE`
- `stack_select.py` — `_stack_supports_type` reads the overlay's `supported_types`; deleted `_STACK_SUPPORTED_TYPES`; permissive fallback preserved (unknown stack id or no declared restriction → permitted)
- Ride-along: deleted `validate._read_govkit_level`, a verbatim copy of `marker.read_govkit_level`
- `CHANGELOG.md` — internal-change note under Unreleased

Deliberately **no overlay version bumps** — `supported_types` is metadata, not doc content; bumping would fire D006 stale-baseline warnings on existing installs for nothing. No user-facing behavior change intended anywhere.

## Testing

- Full suite green after every increment: `python -m pytest -q` → 1000 passed, 1 pre-existing skip
- Increment 1 was test-first (4 failing tests before the contract change); increments 2–4 are behavior-preserving refactors specified by existing tests (five D005 tests in `test_doctor.py`, type-precedence tests in `test_stack_select.py`, schema validation of all overlays in `test_schemas.py`)
- End-to-end smoke: `apply --type data` on a repo with an ambient fastapi signal correctly rejected the fastapi inference via the overlay's `[api, cli]` declaration and defaulted to `python-dbt`; `doctor` on a `python-fastapi` install in a csharp repo raised D005 with the language read from the overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)