### PR TITLE
refactor(govkit): consolidate one-time migration warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed — internal
 
+- The three one-time migration warnings in `cli/marker.py` (version, shape,
+  directory) now share a single `_OneTimeWarning` value object instead of
+  three copies of the flag/env-check/reset machinery. Messages, suppression
+  env vars, and test reset helpers are unchanged. See
+  `plans/MARKER_WARNING_CONSOLIDATION_PLAN.md`.
 - Stack overlays are now the single owner of per-stack facts: `overlay.yaml`
   gains a required `supported_types` list (schema-enforced), doctor D005
   reads the expected language from the overlay's `skill_context.language`,

--- a/cli/marker.py
+++ b/cli/marker.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -32,8 +33,30 @@ MARKER_FILENAME = "marker.json"
 # Version comparison + one-time migration warnings (v0.7.0 swap onward)
 # ---------------------------------------------------------------------------
 
-# Set once per process. Reset by tests via _reset_migration_warning().
-_MIGRATION_WARNING_PRINTED = False
+@dataclass
+class _OneTimeWarning:
+    """A stderr warning that fires at most once per process, suppressible
+    via an env var (checked at warn time, so module-level instances respect
+    env changes made after import). An env-suppressed call leaves the
+    warning armed. Each migration warning declares one instance; tests
+    re-arm between cases via reset().
+    """
+    env_var: str
+    printed: bool = False
+
+    def warn(self, message: str) -> None:
+        if self.printed or os.environ.get(self.env_var) == "1":
+            return
+        print(message, file=sys.stderr)
+        self.printed = True
+
+    def reset(self) -> None:
+        self.printed = False
+
+
+_VERSION_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_MIGRATION_WARNING")
+_SHAPE_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_SHAPE_MIGRATION_WARNING")
+_DIRECTORY_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_DIRECTORY_MIGRATION_WARNING")
 
 
 def _compare_version(v1: str, v2: str) -> int:
@@ -62,31 +85,20 @@ def _maybe_warn_migration(stored_version: str | None) -> None:
     Auto-suppressed once the marker is rewritten with version >= 0.7.0
     (because the version comparison stops triggering).
     """
-    global _MIGRATION_WARNING_PRINTED
-    if _MIGRATION_WARNING_PRINTED:
-        return
     if not stored_version:
         return
-    if os.environ.get("GOVKIT_NO_MIGRATION_WARNING") == "1":
-        return
     if _compare_version(stored_version, "0.7.0") < 0:
-        print(
+        _VERSION_MIGRATION_WARNING.warn(
             f"warning: .govkit marker version {stored_version} detected. "
             "The L3/L4 maturity model changed in 0.7.0. "
             "Run 'govkit upgrade --migrate-levels' to migrate. "
-            "(Set GOVKIT_NO_MIGRATION_WARNING=1 to suppress.)",
-            file=sys.stderr,
+            "(Set GOVKIT_NO_MIGRATION_WARNING=1 to suppress.)"
         )
-        _MIGRATION_WARNING_PRINTED = True
 
 
 def _reset_migration_warning() -> None:
-    """Test helper: reset the one-time warning flag between test cases."""
-    global _MIGRATION_WARNING_PRINTED
-    _MIGRATION_WARNING_PRINTED = False
-
-
-_SHAPE_MIGRATION_WARNING_PRINTED = False
+    """Test helper: re-arm the one-time warning between test cases."""
+    _VERSION_MIGRATION_WARNING.reset()
 
 
 def _maybe_warn_shape_migration(options: dict | None) -> None:
@@ -97,32 +109,21 @@ def _maybe_warn_shape_migration(options: dict | None) -> None:
     informed once per process. Suppressible via
     GOVKIT_NO_SHAPE_MIGRATION_WARNING=1.
     """
-    global _SHAPE_MIGRATION_WARNING_PRINTED
-    if _SHAPE_MIGRATION_WARNING_PRINTED:
-        return
     if not options or "ui" not in options:
         return
-    if os.environ.get("GOVKIT_NO_SHAPE_MIGRATION_WARNING") == "1":
-        return
-    print(
+    _SHAPE_MIGRATION_WARNING.warn(
         "warning: .govkit marker carries the legacy 'ui' option. "
         "The project-shape model changed in 0.8.0. The `ui` option is no "
         "longer supported. Re-run 'govkit apply --type ui-react' (or "
         "'ui-angular') to switch to a UI shape, or 'govkit apply --type api' "
         "to keep the current backend shape. "
-        "(Set GOVKIT_NO_SHAPE_MIGRATION_WARNING=1 to suppress.)",
-        file=sys.stderr,
+        "(Set GOVKIT_NO_SHAPE_MIGRATION_WARNING=1 to suppress.)"
     )
-    _SHAPE_MIGRATION_WARNING_PRINTED = True
 
 
 def _reset_shape_migration_warning() -> None:
-    """Test helper: reset the one-time shape-migration warning flag."""
-    global _SHAPE_MIGRATION_WARNING_PRINTED
-    _SHAPE_MIGRATION_WARNING_PRINTED = False
-
-
-_DIRECTORY_MIGRATION_WARNING_PRINTED = False
+    """Test helper: re-arm the one-time shape-migration warning."""
+    _SHAPE_MIGRATION_WARNING.reset()
 
 
 def _maybe_warn_directory_migration() -> None:
@@ -134,26 +135,18 @@ def _maybe_warn_directory_migration() -> None:
     are read tolerantly and migrated on first read. Suppressible via
     GOVKIT_NO_DIRECTORY_MIGRATION_WARNING=1.
     """
-    global _DIRECTORY_MIGRATION_WARNING_PRINTED
-    if _DIRECTORY_MIGRATION_WARNING_PRINTED:
-        return
-    if os.environ.get("GOVKIT_NO_DIRECTORY_MIGRATION_WARNING") == "1":
-        return
-    print(
+    _DIRECTORY_MIGRATION_WARNING.warn(
         "warning: legacy single-file .govkit marker detected — "
         "the layout changed in 0.10.0 and is now .govkit/ (directory) "
         "containing marker.json. Govkit auto-migrated this marker; no "
         "action required. "
-        "(Set GOVKIT_NO_DIRECTORY_MIGRATION_WARNING=1 to suppress.)",
-        file=sys.stderr,
+        "(Set GOVKIT_NO_DIRECTORY_MIGRATION_WARNING=1 to suppress.)"
     )
-    _DIRECTORY_MIGRATION_WARNING_PRINTED = True
 
 
 def _reset_directory_migration_warning() -> None:
-    """Test helper: reset the one-time directory-migration warning flag."""
-    global _DIRECTORY_MIGRATION_WARNING_PRINTED
-    _DIRECTORY_MIGRATION_WARNING_PRINTED = False
+    """Test helper: re-arm the one-time directory-migration warning."""
+    _DIRECTORY_MIGRATION_WARNING.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -267,24 +267,17 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
 
     tags_found = set(re.findall(r"@nfr-(\w+)", feature_text))
 
-    category_to_tag = {
-        "performance": "performance",
-        "availability": "availability",
-        "security": "security",
-        "compliance": "compliance",
-        "scalability": "scalability",
-        "observability": "observability",
-        "reliability": "reliability",
-        "compatibility": "compatibility",
-    }
+    # NFR categories whose population demands a matching @nfr-<category> tag.
+    known_categories = frozenset({
+        "performance", "availability", "security", "compliance",
+        "scalability", "observability", "reliability", "compatibility",
+    })
 
-    missing_tags = []
-    for category in populated:
-        if category not in category_to_tag:
-            continue
-        expected_tag = category_to_tag[category]
-        if expected_tag not in tags_found:
-            missing_tags.append(f"@nfr-{expected_tag}")
+    missing_tags = [
+        f"@nfr-{category}"
+        for category in populated
+        if category in known_categories and category not in tags_found
+    ]
 
     if missing_tags:
         return False, f"Gherkin missing NFR tags: {', '.join(missing_tags)}"

--- a/plans/MARKER_WARNING_CONSOLIDATION_PLAN.md
+++ b/plans/MARKER_WARNING_CONSOLIDATION_PLAN.md
@@ -1,0 +1,122 @@
+# Marker Warning Consolidation Plan
+
+Collapse the three structurally identical copies of "print a suppressible
+warning once per process" in `cli/marker.py` into one small `_OneTimeWarning`
+value object plus three declarations.
+
+## Motivation (evidence)
+
+`cli/marker.py` lines 36–156 hold three instances of the same concept, each
+repeating four elements:
+
+| Warning | Global flag | Env-var suppression | Reset helper |
+|---|---|---|---|
+| Version migration (pre-0.7 L3/L4 swap) | `_MIGRATION_WARNING_PRINTED` | `GOVKIT_NO_MIGRATION_WARNING` | `_reset_migration_warning` |
+| Shape migration (dropped `ui` option) | `_SHAPE_MIGRATION_WARNING_PRINTED` | `GOVKIT_NO_SHAPE_MIGRATION_WARNING` | `_reset_shape_migration_warning` |
+| Directory migration (legacy single-file marker) | `_DIRECTORY_MIGRATION_WARNING_PRINTED` | `GOVKIT_NO_DIRECTORY_MIGRATION_WARNING` | `_reset_directory_migration_warning` |
+
+~120 lines for one concept instanced three times. The repo has shipped a
+marker migration in 0.7, 0.8, and 0.10 — the next one currently means a
+fourth copy-paste of the whole block.
+
+Virtues: Unique (the once-per-process + env-suppression algorithm exists
+once), Brief (~120 → ~55 lines), Easy (the next migration warning is one
+declaration), Developed (the implicit "one-time warning" concept becomes a
+named thing).
+
+## Constraints discovered in the tests
+
+1. **The reset helper names are a de-facto public contract.** ~30 call
+   sites across `tests/test_govkit.py` import
+   `_reset_migration_warning` / `_reset_shape_migration_warning` /
+   `_reset_directory_migration_warning` by name. Churning 30 test sites for
+   zero behavioral value is out of scope — the three names survive as
+   one-line delegations to the new representation.
+2. **Messages are pinned byte-for-byte in spirit.** Tests assert env-var
+   names appear in stderr (`assert "GOVKIT_NO_DIRECTORY_MIGRATION_WARNING"
+   in err`) and count occurrences across multi-read scenarios. All three
+   message strings stay identical.
+3. **Trigger conditions differ per warning** (version comparison; `ui` in
+   options; unconditional on legacy read). The conditions are NOT the
+   duplication — they stay in the three `_maybe_warn_*` functions. Only the
+   fire-once/suppress/print machinery consolidates.
+
+## Target design
+
+```python
+@dataclass
+class _OneTimeWarning:
+    """A stderr warning that fires at most once per process, suppressible
+    via an env var. Migration warnings declare one instance each; tests
+    re-arm via reset()."""
+    env_var: str
+    printed: bool = False
+
+    def warn(self, message: str) -> None:
+        if self.printed or os.environ.get(self.env_var) == "1":
+            return
+        print(message, file=sys.stderr)
+        self.printed = True
+
+    def reset(self) -> None:
+        self.printed = False
+
+
+_VERSION_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_MIGRATION_WARNING")
+_SHAPE_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_SHAPE_MIGRATION_WARNING")
+_DIRECTORY_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_DIRECTORY_MIGRATION_WARNING")
+```
+
+Each `_maybe_warn_*` keeps its trigger condition and ends in
+`_X_WARNING.warn(<same message>)`. Each `_reset_*` helper becomes
+`_X_WARNING.reset()`. The three module-level `*_PRINTED` globals and the
+`global` statements disappear.
+
+Message passed at `warn()` time rather than stored on the instance: the
+version warning interpolates `stored_version`, so a stored template would
+need format-args plumbing for one caller — not worth it at three instances.
+
+## Increments
+
+### 1. `_OneTimeWarning` + port (test-first)
+
+1. Failing tests first, in `tests/test_headers.py`-style class grouping
+   (new class in `tests/test_govkit.py` next to the existing warning tests,
+   or a small `tests/test_marker.py` if none fits — decide by proximity to
+   the existing marker-warning test classes):
+   - `warn()` prints to stderr once; second call is silent
+   - `warn()` is silent when the env var is "1"
+   - `reset()` re-arms
+   - env var checked at warn time, not construction time (monkeypatch after
+     instantiation must still suppress — module-level instances outlive
+     test env changes)
+2. Implement the class; port the three warnings to instances; reduce
+   `_maybe_warn_*` to condition + `warn(message)`; reduce `_reset_*` to
+   `reset()` delegations. Delete the three `*_PRINTED` globals.
+3. The ~30 existing test sites and message assertions must stay green
+   untouched — they are the behavioral spec for the port.
+
+Diff: marker.py + one test file.
+
+### 2. Ride-along + sweep
+
+1. `validate.check_gherkin_nfr_coverage`: replace the `category_to_tag`
+   identity dict (every key maps to itself) with a `frozenset` of known
+   categories; `expected_tag = category`. Behavior identical; existing
+   NFR-coverage tests pin it.
+2. Grep for the deleted globals (`_MIGRATION_WARNING_PRINTED` etc.) — zero
+   code hits.
+3. CHANGELOG note under Unreleased. Full suite.
+
+Diff: validate.py + CHANGELOG.
+
+## Risks / non-goals
+
+- **No behavior change.** Same messages, same env vars, same once-per-
+  process semantics, same reset entry points for tests.
+- **Non-goal:** promoting `_OneTimeWarning` to a shared module. marker.py is
+  its only consumer; a second consumer elsewhere can motivate the move
+  later (rule of three applies to homes as well as helpers).
+- **Non-goal:** the section-body parser duplication in validate.py
+  (`check_nfrs_sections._populated` / `check_llm_nfrs`) — at the evidence
+  threshold, not over it; wait for a third caller.

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,0 +1,57 @@
+"""Tests for cli/marker.py — the _OneTimeWarning machinery.
+
+MARKER_WARNING_CONSOLIDATION_PLAN.md increment 1. One value object owns the
+fire-once / env-suppress / reset behavior that previously existed as three
+copies of (global flag + env check + print + reset helper). The three
+migration warnings' end-to-end behavior stays pinned by the existing
+integration tests in test_govkit.py; these tests cover the machinery itself.
+"""
+
+
+class TestOneTimeWarning:
+    ENV = "GOVKIT_TEST_WARNING"
+
+    def _fresh(self):
+        from cli.marker import _OneTimeWarning
+
+        return _OneTimeWarning(self.ENV)
+
+    def test_warn_prints_to_stderr_once(self, capsys, monkeypatch):
+        monkeypatch.delenv(self.ENV, raising=False)
+        w = self._fresh()
+        w.warn("something happened")
+        w.warn("something happened")
+        assert capsys.readouterr().err.count("something happened") == 1
+
+    def test_warn_suppressed_by_env_var(self, capsys, monkeypatch):
+        monkeypatch.setenv(self.ENV, "1")
+        w = self._fresh()
+        w.warn("something happened")
+        assert "something happened" not in capsys.readouterr().err
+
+    def test_suppression_does_not_mark_printed(self, capsys, monkeypatch):
+        """Matching the old globals: an env-suppressed call leaves the
+        warning armed, so unsetting the env var later still lets it fire."""
+        monkeypatch.setenv(self.ENV, "1")
+        w = self._fresh()
+        w.warn("something happened")
+        monkeypatch.delenv(self.ENV)
+        w.warn("something happened")
+        assert capsys.readouterr().err.count("something happened") == 1
+
+    def test_env_var_checked_at_warn_time(self, capsys, monkeypatch):
+        """Instances are module-level and outlive test env changes — the
+        env var must be read when warn() fires, not at construction."""
+        monkeypatch.delenv(self.ENV, raising=False)
+        w = self._fresh()
+        monkeypatch.setenv(self.ENV, "1")
+        w.warn("late suppression")
+        assert "late suppression" not in capsys.readouterr().err
+
+    def test_reset_rearms(self, capsys, monkeypatch):
+        monkeypatch.delenv(self.ENV, raising=False)
+        w = self._fresh()
+        w.warn("again")
+        w.reset()
+        w.warn("again")
+        assert capsys.readouterr().err.count("again") == 2


### PR DESCRIPTION
## What

Collapses the three structurally identical copies of \"print a suppressible warning once per process\" in `cli/marker.py` into one small `_OneTimeWarning` value object plus three declarations.

## Why

The version-migration (pre-0.7), shape-migration (dropped `ui` option), and directory-migration (legacy single-file marker) warnings each carried their own module-level flag, env-var suppression check, and test-reset helper — ~120 lines for one concept instanced three times. This repo has shipped a marker migration in 0.7, 0.8, and 0.10; the next one currently means a fourth copy-paste of the whole block, and afterwards it means one declaration plus its trigger condition. Full evidence and design in `plans/MARKER_WARNING_CONSOLIDATION_PLAN.md`.

## Changes

- `cli/marker.py` — new `_OneTimeWarning` dataclass (fires once per process, env-var suppression checked at warn time, `reset()` re-arms) with three module-level instances; the three `_maybe_warn_*` functions reduce to their trigger conditions plus a `warn(message)` call; the three `*_PRINTED` globals and their `global` statements are deleted
- **Deliberately unchanged:** all three message strings, the three suppression env vars, and the `_reset_migration_warning` / `_reset_shape_migration_warning` / `_reset_directory_migration_warning` helper names — ~30 test call sites import them directly, so they survive as one-line delegations
- `tests/test_marker.py` (new) — unit tests for the machinery: fires once, env suppression, suppression leaves the warning armed (matching the old globals), env var read at warn time not construction time, reset re-arms
- Ride-along: `cli/validate.py` — the `category_to_tag` identity dict (every key mapped to itself) in NFR tag coverage becomes a `frozenset` membership check
- `CHANGELOG.md` — internal-change note under Unreleased

No user-facing behavior change intended anywhere.

## Testing

- All 277 `test_govkit.py` integration tests — including the ~30 reset-helper call sites and the exact-message / occurrence-count assertions for the warnings — pass untouched; they are the behavioral spec for the port
- Full suite: `python -m pytest -q` → 1005 passed, 1 pre-existing skip
- Increment 1 was test-first (5 failing unit tests before the class existed)
- End-to-end: a legacy single-file `.govkit` marker run through `govkit validate` fired the directory-migration warning exactly once and auto-migrated to `.govkit/marker.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)