### PR TITLE
fix(govkit): upgrade preserves the team's calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- `govkit upgrade` no longer erases the team's calibration. It wrote the marker
+  without threading the stored `stack`, `assumptions`, and `calibration`
+  blocks, so every upgrade reset them to `null` / `[]` / no decisions —
+  discarding each `calibration.decisions[]` entry, every `review_required:
+  false` an assumption had earned, and the selected stack. The loss cascaded:
+  `post_install_finalize` regenerates `.govkit/skill_context.yaml` from the
+  marker, so a wiped `stack` silently blanked the stack facts the agent reads
+  (`stack.id: null`). `apply`, `stack apply`, and `calibrate` already carried
+  these through; `upgrade` was the lone writer that did not. `applied_at` still
+  advances on upgrade — that is a re-install, and edit-protection depends on it.
+
 ### Changed — internal
 
 - The three one-time migration warnings in `cli/marker.py` (version, shape,

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -130,7 +130,16 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
         shared, target, prior_applied_at, args.force, baseline, l5_exclude,
     )
 
-    marker = write_govkit_marker(target, agent, stored_level, options)
+    # Upgrade re-installs govkit's own files; it does not re-decide anything the
+    # team decided. Carry stack/assumptions/calibration across or they reset to
+    # empty — which also blanks the stack facts skill_context.yaml derives below.
+    # applied_at still defaults to now: upgrade IS a re-install.
+    marker = write_govkit_marker(
+        target, agent, stored_level, options,
+        stack=stored.get("stack"),
+        assumptions=stored.get("assumptions") or [],
+        calibration=stored.get("calibration"),
+    )
     post_install_finalize(target, agent, marker=marker)
 
     print(f"\nDone. '{agent}' upgraded to govkit {version.GOVKIT_VERSION} at {target}")

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2278,6 +2278,90 @@ class TestCmdUpgrade:
         marker = read_govkit_marker(target)
         assert marker["version"] == "0.2.0"
 
+    def _calibrated_marker(self, target: Path) -> tuple[dict, list, dict]:
+        """Stamp a completed calibration onto the target's marker.
+
+        Mirrors what `calibrate` records: the selected stack, an assumption
+        cleared by the team, and the decisions they made per checklist step.
+        """
+        stack = {
+            "id": "python-fastapi",
+            "version": "1.0.0",
+            "display_name": "Python + FastAPI",
+        }
+        # Shape mirrors stack_select._build_stack_assumption after the team has
+        # calibrated it: review_required cleared, calibrated_* stamped.
+        assumptions = [{
+            "id": "stack.id",
+            "value": "python-fastapi",
+            "source": "detected",
+            "confidence": "high",
+            "evidence": ["pyproject.toml: fastapi"],
+            "files_affected": [],
+            "review_required": False,
+            "warning_message": None,
+            "calibrated_at": "2026-01-02T00:00:00+00:00",
+            "calibrated_against_overlay_version": "1.0.0",
+        }]
+        calibration = {
+            "completed_at": "2026-01-02T00:00:00+00:00",
+            "decisions": [
+                {"step": "step.tech_stack", "decision": "confirmed"},
+                {"step": "step.boundaries", "decision": "modified: medallion layers"},
+            ],
+        }
+        marker_path = target / ".govkit"
+        stored = json.loads(marker_path.read_text(encoding="utf-8"))
+        stored.update(stack=stack, assumptions=assumptions, calibration=calibration)
+        marker_path.write_text(json.dumps(stored), encoding="utf-8")
+        return stack, assumptions, calibration
+
+    def test_upgrade_preserves_calibration_stack_and_assumptions(
+        self, tmp_path, monkeypatch,
+    ):
+        """Upgrade refreshes govkit's files; it must not reset the team's calibration.
+
+        `calibrate` records decisions/assumptions and `apply` records the
+        selected stack. Upgrade re-installs govkit-owned content — that is
+        not a reason to forget what the team decided. Losing `stack` also
+        cascades: post_install_finalize regenerates skill_context.yaml from
+        the marker, so a wiped stack silently blanks the facts the agent reads.
+        """
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version="0.1.0")
+        stack, assumptions, calibration = self._calibrated_marker(target)
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.2.0")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        marker = read_govkit_marker(target)
+        assert marker["stack"] == stack
+        assert marker["assumptions"] == assumptions
+        assert marker["calibration"] == calibration
+
+    def test_upgrade_still_bumps_applied_at(self, tmp_path, monkeypatch):
+        """applied_at must keep moving — upgrade IS a re-install.
+
+        Guards the fix above from over-correcting: preserving calibration
+        must not turn into preserving applied_at, which would leave
+        edit-protection comparing mtimes against a stale install time.
+        """
+
+        repo = _make_upgrade_repo(tmp_path)
+        target = self._target_with_marker(tmp_path, repo, version="0.1.0")
+        self._calibrated_marker(target)
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.2.0")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        marker = read_govkit_marker(target)
+        assert marker["applied_at"] != "2025-01-01T00:00:00+00:00"
+
     def test_upgrade_no_marker_exits(self, tmp_path, monkeypatch):
         """cmd_upgrade exits 1 when no .govkit marker exists."""
 


### PR DESCRIPTION
## The bug

`govkit upgrade` erased every calibration decision a team had recorded.

`cmd_upgrade` called `write_govkit_marker(target, agent, stored_level, options)` with four positional args, so the `stack`, `assumptions`, and `calibration` slots fell to their defaults (`marker.py:307-312`) — `None`, `[]`, and an empty decisions list.

Each upgrade therefore discarded:
- every `calibration.decisions[]` entry the team recorded during `govkit calibrate`
- every `review_required: false` an assumption had earned
- the selected stack

**The loss cascaded past the marker.** `post_install_finalize` regenerates `.govkit/skill_context.yaml` from it, so a wiped `stack` silently blanked the stack facts the agent actually reads:

```yaml
stack:
  id: null          # was python-fastapi
  display_name: null
```

`GOVKIT_SETUP_REVIEW.md` likewise reverted to `Stack: _(not yet selected…)_`.

This punished exactly the teams who adopted govkit properly: they calibrate, they upgrade, and their calibration quietly evaporates.

## Why it happened

`apply`, `stack apply`, and `calibrate` all thread these values through already — `upgrade` was the lone writer that did not. No test covered a `calibrate` → `upgrade` round trip, which is how it drifted out of sync with its three siblings.

`calibrate.py:638-640` even carries a comment showing the author was alive to this bug class:

> `# Preserve the original applied_at — calibrate is not a re-install.`
> `# Bumping it would silently un-protect files edited before calibration.`

That reasoning was never applied to upgrade's other three slots.

## The fix

Mirror `cmd_stack.py:94-99` and pass the stored values through. `applied_at` still defaults to now — upgrade **is** a re-install, and edit-protection compares doc mtimes against it.

## Deliberately not changed

The five migrate-levels writers (`cmd_upgrade.py:238, 245, 291, 300, 320`) still write defaults. That path is gated to markers older than `0.7.0` (`cmd_upgrade.py:229`), but these three slots did not exist until `0.10` — there is provably nothing there to preserve, so threading `stored` through would be dead code.

## Tests

Two new tests in `TestCmdUpgrade`, written failing first:

- `test_upgrade_preserves_calibration_stack_and_assumptions` — the regression. Failed with `assert None == {'id': 'python-fastapi', ...}` before the fix.
- `test_upgrade_still_bumps_applied_at` — guards against over-correcting. Preserving calibration must not turn into preserving `applied_at`, which would leave edit-protection comparing against a stale install time. This one passed before the fix and must keep passing.

Full suite: **1007 passed, 1 skipped.**

## Verified end to end

Real `apply` → stamp a completed calibration → `upgrade`, against a live target:

| Marker field | Before fix | After fix |
|---|---|---|
| `stack.id` | `None` | `python-fastapi` |
| `assumptions` | `0` entries | `1`, `review_required: False` |
| `calibration.decisions` | `0` | `2` |
| `skill_context.yaml` `stack.id` | `null` | `python-fastapi` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)