### PR TITLE
feat(govkit): govern via the native rules namespace, not the team's CLAUDE.md

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,7 @@ jobs:
               --stack python-dbt
           test -f "$tmp/.govkit/marker.json"
           test -f "$tmp/.govkit/skill_context.yaml"
-          test -f "$tmp/CLAUDE.md"                                  # claude-md/data.md
+          test -f "$tmp/.claude/rules/govkit/governance.md"        # claude-md/data.md
           test -f "$tmp/.claude/rules/staging.md"                   # rules/data/
           test -f "$tmp/docs/data/architecture/BOUNDARIES.md"       # baseline contracts
           test -f "$tmp/docs/data/architecture/TECH_STACK.md"       # python-dbt overlay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   (`stack.id: null`). `apply`, `stack apply`, and `calibrate` already carried
   these through; `upgrade` was the lone writer that did not. `applied_at` still
   advances on upgrade — that is a re-install, and edit-protection depends on it.
+### Changed
+
+- **govkit no longer overwrites your `CLAUDE.md` or `.github/copilot-instructions.md`.**
+  Both agents natively auto-load a separate instructions directory, so govkit's
+  governance now installs there — `.claude/rules/govkit/governance.md` for
+  claude-code (plus a `src/**`-scoped `governance-src.md` for UI types) and
+  `.github/instructions/govkit/governance.instructions.md` (`applyTo: "**"`) for
+  copilot — and govkit writes no top-level instruction file at all. A team that
+  wrote its own `CLAUDE.md` keeps it untouched while govkit's governance still
+  loads every session. On `upgrade`, an existing install's old govkit-authored
+  instruction file is retired automatically when it is byte-identical to govkit's
+  governance; if you edited it, it is kept and governance install is skipped
+  (with a warning) so you never get duplicate governance. Codex (`AGENTS.md`,
+  which has no native rules directory) is unchanged for now.
+- `govkit doctor`'s rule-glob check (D001) now scans the rules directory
+  recursively, so rules in subdirectories — including govkit's own
+  `.claude/rules/govkit/` — are validated instead of silently skipped.
 
 ### Changed — internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   copilot — and govkit writes no top-level instruction file at all. A team that
   wrote its own `CLAUDE.md` keeps it untouched while govkit's governance still
   loads every session. On `upgrade`, an existing install's old govkit-authored
-  instruction file is retired automatically when it is byte-identical to govkit's
-  governance; if you edited it, it is kept and governance install is skipped
-  (with a warning) so you never get duplicate governance. Codex (`AGENTS.md`,
-  which has no native rules directory) is unchanged for now.
+  instruction file is retired automatically when it is govkit's own — either
+  byte-identical to the current governance or untouched since the last apply
+  (so older-version files clean up too); if you edited it, it is kept and
+  governance install is skipped (with a warning) so you never get duplicate
+  governance. Codex (`AGENTS.md`, which has no native rules directory) is
+  unchanged for now.
 - `govkit doctor`'s rule-glob check (D001) now scans the rules directory
   recursively, so rules in subdirectories — including govkit's own
   `.claude/rules/govkit/` — are validated instead of silently skipped.

--- a/agents/claude-code/claude-md/data.md
+++ b/agents/claude-code/claude-md/data.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — Data Project Governance
+# Governed AI Delivery — Data Project Governance
 
 This repository ships data pipelines + models. Claude must follow the
 contracts in `docs/data/architecture/` when writing or modifying anything

--- a/agents/claude-code/claude-md/l4-data.md
+++ b/agents/claude-code/claude-md/l4-data.md
@@ -1,7 +1,7 @@
-# CLAUDE.md — Data Project Governance (L4 — Spec-Driven Add-On)
+# Governed AI Delivery — Data Project Governance (L4 — Spec-Driven Add-On)
 
 This repository is at **Level 4 — Spec-Driven Add-On**. Every feature ships
-with the L3 baseline contracts (see the L3 CLAUDE.md content above) PLUS a
+with the L3 baseline contracts (see the L3 governance content above) PLUS a
 spec-driven feature package.
 
 ---

--- a/agents/claude-code/claude-md/l4-ui-angular.md
+++ b/agents/claude-code/claude-md/l4-ui-angular.md
@@ -41,21 +41,21 @@ Read before generating any code:
 - All server data via TanStack Query inject functions
 - All client state via Signal store injection
 - Use `@if`, `@for`, `@switch` control flow (Angular 17+)
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Query Functions (`src/features/<feature>/hooks/`)
 - All server state via TanStack Angular Query (`injectQuery`, `injectMutation`)
 - Transform API responses in `select` — never in templates or components
 - Query keys defined as typed constants in `query-keys.ts` per feature
 - Mutations must invalidate relevant query keys on success
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Signal Store (`src/features/<feature>/store/`)
 - Angular Signals for UI-only state — modals, active tab, pagination, selections
 - Never store server data — use TanStack Query cache
 - Expose read-only signals via `.asReadonly()`
 - Never call API services directly from a store
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### Model — API (`src/features/<feature>/api/`)
 - Plain async functions using the shared `ApiService`

--- a/agents/claude-code/claude-md/l4-ui-react.md
+++ b/agents/claude-code/claude-md/l4-ui-react.md
@@ -39,19 +39,19 @@ Read before generating any code:
 - No business logic or data transformation
 - Receive data and callbacks via props or hooks only
 - All data via React Query hooks or Zustand selectors
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Hooks (`src/features/<feature>/hooks/`)
 - All server state via React Query (`useQuery`, `useMutation`)
 - One hook file per logical data concern
 - Transform API responses here — never in components
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Store (`src/features/<feature>/store/`)
 - Zustand for client-only UI state (modals, selections, pagination)
 - Never store server data in Zustand — that belongs in React Query cache
 - Feature-scoped stores only — no global catch-all store
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### Model — API (`src/features/<feature>/api/`)
 - Plain async functions — no React, no hooks

--- a/agents/claude-code/claude-md/l5-ui-angular.md
+++ b/agents/claude-code/claude-md/l5-ui-angular.md
@@ -87,7 +87,7 @@ Implementation must not begin unless all five artifacts exist.
 
 ## Layer Rules
 
-Layer-specific rules are consolidated in `src/CLAUDE.md`. Claude Code loads it automatically when working anywhere under `src/`. Categories covered:
+Layer-specific rules are consolidated in `.claude/rules/govkit/governance-src.md`. Claude Code loads it automatically when working anywhere under `src/`. Categories covered:
 
 - Component rules — `**/components/**`
 - ViewModel rules (hooks + store) — `**/hooks/**`, `**/store/**`

--- a/agents/claude-code/claude-md/l5-ui-react.md
+++ b/agents/claude-code/claude-md/l5-ui-react.md
@@ -87,7 +87,7 @@ Implementation must not begin unless all five artifacts exist.
 
 ## Layer Rules
 
-Layer-specific rules are consolidated in `src/CLAUDE.md`. Claude Code loads it automatically when working anywhere under `src/`. Categories covered:
+Layer-specific rules are consolidated in `.claude/rules/govkit/governance-src.md`. Claude Code loads it automatically when working anywhere under `src/`. Categories covered:
 
 - Component rules — `**/components/**`
 - ViewModel rules (hooks + store) — `**/hooks/**`, `**/store/**`

--- a/agents/claude-code/claude-md/src-ui-angular.md
+++ b/agents/claude-code/claude-md/src-ui-angular.md
@@ -1,6 +1,10 @@
+---
+paths:
+  - "src/**"
+---
 # UI Layer Rules — Angular (src/)
 
-This file consolidates the Angular UI layer rules. Claude Code loads it automatically when working anywhere under `src/`. Rules below apply on top of the root `CLAUDE.md`.
+This file consolidates the Angular UI layer rules. Claude Code loads it automatically when editing files under `src/`. Rules below apply on top of the root govkit governance (`.claude/rules/govkit/governance.md`).
 
 Source-of-truth contracts live in `docs/ui/architecture/` and `docs/ui/architecture/angular/` — this file is the inline-loadable summary.
 

--- a/agents/claude-code/claude-md/src-ui-react.md
+++ b/agents/claude-code/claude-md/src-ui-react.md
@@ -1,6 +1,10 @@
+---
+paths:
+  - "src/**"
+---
 # UI Layer Rules — React (src/)
 
-This file consolidates the React UI layer rules. Claude Code loads it automatically when working anywhere under `src/`. Rules below apply on top of the root `CLAUDE.md`.
+This file consolidates the React UI layer rules. Claude Code loads it automatically when editing files under `src/`. Rules below apply on top of the root govkit governance (`.claude/rules/govkit/governance.md`).
 
 Source-of-truth contracts live in `docs/ui/architecture/` and `docs/ui/architecture/react/` — this file is the inline-loadable summary.
 

--- a/agents/claude-code/claude-md/ui-angular.md
+++ b/agents/claude-code/claude-md/ui-angular.md
@@ -51,7 +51,7 @@ Read before generating any code:
 - All server data via TanStack Query inject functions
 - All client state via Signal store injection
 - Use `@if`, `@for`, `@switch` control flow (Angular 17+)
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Query Functions (`src/features/<slice>/hooks/`)
 
@@ -59,7 +59,7 @@ Read before generating any code:
 - Transform API responses in `select` — never in templates or components
 - Query keys defined as typed constants in `query-keys.ts` per slice
 - Mutations must invalidate relevant query keys on success
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Signal Store (`src/features/<slice>/store/`)
 
@@ -68,19 +68,19 @@ Read before generating any code:
 - Never store server data — use TanStack Query cache
 - Expose read-only signals via `.asReadonly()`
 - Never call API services directly from a store
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### Model — API (`src/features/<slice>/api/`)
 
 - Plain functions wrapping `HttpClient`
 - One file per backend resource
 - Use shared base from `src/shared/api/`
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### Accessibility
 
 - Every interactive component must meet WCAG 2.1 AA
-- See `src/CLAUDE.md` and
+- See `.claude/rules/govkit/governance-src.md` and
   `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 
 ---

--- a/agents/claude-code/claude-md/ui-react.md
+++ b/agents/claude-code/claude-md/ui-react.md
@@ -49,33 +49,33 @@ Read before generating any code:
 - No business logic or data transformation
 - Receive data and callbacks via props or hooks only
 - All data via React Query hooks or Zustand selectors
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Hooks (`src/features/<slice>/hooks/`)
 
 - All server state via React Query (`useQuery`, `useMutation`)
 - One hook file per logical data concern
 - Transform API responses here — never in components
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### ViewModel — Store (`src/features/<slice>/store/`)
 
 - Zustand for client-only UI state (modals, selections, pagination)
 - Never store server data in Zustand — that belongs in React Query cache
 - Slice-scoped stores only — no global catch-all store
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### Model — API (`src/features/<slice>/api/`)
 
 - Plain async functions — no React, no hooks
 - One file per backend resource
 - Use shared base client from `src/shared/api/`
-- See `src/CLAUDE.md`
+- See `.claude/rules/govkit/governance-src.md`
 
 ### Accessibility
 
 - Every interactive component must meet WCAG 2.1 AA
-- See `src/CLAUDE.md` and
+- See `.claude/rules/govkit/governance-src.md` and
   `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 
 ---

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -26,7 +26,7 @@
     "type": {
       "api": {
         "files": [
-          { "src": "claude-md/backend-api.md", "dest": "CLAUDE.md" },
+          { "src": "claude-md/backend-api.md", "dest": ".claude/rules/govkit/governance.md" },
           { "src": "rules/backend/api.md", "dest": ".claude/rules/api.md" },
           { "src": "rules/backend/services.md", "dest": ".claude/rules/services.md" },
           { "src": "rules/backend/ports.md", "dest": ".claude/rules/ports.md" },
@@ -42,7 +42,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "claude-md/l4-backend-api.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l4-backend-api.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/spec-planning/" },
@@ -63,7 +63,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "claude-md/l5-backend-api.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l5-backend-api.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/backend/api.md", "dest": ".claude/rules/api.md" },
             { "src": "rules/backend/services.md", "dest": ".claude/rules/services.md" },
             { "src": "rules/backend/ports.md", "dest": ".claude/rules/ports.md" },
@@ -98,7 +98,7 @@
       },
       "cli": {
         "files": [
-          { "src": "claude-md/backend-cli.md", "dest": "CLAUDE.md" },
+          { "src": "claude-md/backend-cli.md", "dest": ".claude/rules/govkit/governance.md" },
           { "src": "rules/cli/cli.md", "dest": ".claude/rules/cli.md" },
           { "src": "rules/backend/services.md", "dest": ".claude/rules/services.md" },
           { "src": "rules/backend/ports.md", "dest": ".claude/rules/ports.md" },
@@ -114,7 +114,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "claude-md/l4-backend-cli.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l4-backend-cli.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/spec-planning/" },
@@ -134,7 +134,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "claude-md/l5-backend-cli.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l5-backend-cli.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/cli/cli.md", "dest": ".claude/rules/cli.md" },
             { "src": "rules/backend/services.md", "dest": ".claude/rules/services.md" },
             { "src": "rules/backend/ports.md", "dest": ".claude/rules/ports.md" },
@@ -168,8 +168,8 @@
       },
       "ui-react": {
         "files": [
-          { "src": "claude-md/ui-react.md", "dest": "CLAUDE.md" },
-          { "src": "claude-md/src-ui-react.md", "dest": "src/CLAUDE.md" },
+          { "src": "claude-md/ui-react.md", "dest": ".claude/rules/govkit/governance.md" },
+          { "src": "claude-md/src-ui-react.md", "dest": ".claude/rules/govkit/governance-src.md" },
           { "src": "rules/generic/repo-scope-ui.md", "dest": ".claude/rules/repo-scope.md" },
           { "src": "skills/ui/adr-author/", "dest": ".claude/skills/ui-adr-author/" }
         ],
@@ -183,7 +183,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "claude-md/l4-ui-react.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l4-ui-react.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/ui-spec-planning/" },
@@ -202,8 +202,8 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "claude-md/l5-ui-react.md", "dest": "CLAUDE.md" },
-            { "src": "claude-md/src-ui-react.md", "dest": "src/CLAUDE.md" },
+            { "src": "claude-md/l5-ui-react.md", "dest": ".claude/rules/govkit/governance.md" },
+            { "src": "claude-md/src-ui-react.md", "dest": ".claude/rules/govkit/governance-src.md" },
             { "src": "rules/generic/repo-scope-ui.md", "dest": ".claude/rules/repo-scope.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
@@ -228,8 +228,8 @@
       },
       "ui-angular": {
         "files": [
-          { "src": "claude-md/ui-angular.md", "dest": "CLAUDE.md" },
-          { "src": "claude-md/src-ui-angular.md", "dest": "src/CLAUDE.md" },
+          { "src": "claude-md/ui-angular.md", "dest": ".claude/rules/govkit/governance.md" },
+          { "src": "claude-md/src-ui-angular.md", "dest": ".claude/rules/govkit/governance-src.md" },
           { "src": "rules/generic/repo-scope-ui.md", "dest": ".claude/rules/repo-scope.md" },
           { "src": "skills/ui/adr-author/", "dest": ".claude/skills/ui-adr-author/" }
         ],
@@ -243,7 +243,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "claude-md/l4-ui-angular.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l4-ui-angular.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/ui-spec-planning/" },
@@ -262,8 +262,8 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "claude-md/l5-ui-angular.md", "dest": "CLAUDE.md" },
-            { "src": "claude-md/src-ui-angular.md", "dest": "src/CLAUDE.md" },
+            { "src": "claude-md/l5-ui-angular.md", "dest": ".claude/rules/govkit/governance.md" },
+            { "src": "claude-md/src-ui-angular.md", "dest": ".claude/rules/govkit/governance-src.md" },
             { "src": "rules/generic/repo-scope-ui.md", "dest": ".claude/rules/repo-scope.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
@@ -288,7 +288,7 @@
       },
       "data": {
         "files": [
-          { "src": "claude-md/data.md", "dest": "CLAUDE.md" },
+          { "src": "claude-md/data.md", "dest": ".claude/rules/govkit/governance.md" },
           { "src": "rules/data/staging.md", "dest": ".claude/rules/staging.md" },
           { "src": "rules/data/intermediate.md", "dest": ".claude/rules/intermediate.md" },
           { "src": "rules/data/marts.md", "dest": ".claude/rules/marts.md" },
@@ -304,7 +304,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "claude-md/l4-data.md", "dest": "CLAUDE.md" },
+            { "src": "claude-md/l4-data.md", "dest": ".claude/rules/govkit/governance.md" },
             { "src": "rules/generic/test-first.md", "dest": ".claude/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/spec-planning/" },

--- a/agents/copilot/copilot-instructions/backend-api.md
+++ b/agents/copilot/copilot-instructions/backend-api.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Foundations (Level 3)
 
 These instructions govern how GitHub Copilot plans, reasons, and generates

--- a/agents/copilot/copilot-instructions/backend-cli.md
+++ b/agents/copilot/copilot-instructions/backend-cli.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Foundations (Level 3)
 
 These instructions govern how GitHub Copilot plans, reasons, and generates

--- a/agents/copilot/copilot-instructions/data.md
+++ b/agents/copilot/copilot-instructions/data.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Foundations (Level 3) — Data
 
 These instructions govern how GitHub Copilot plans, reasons, and generates

--- a/agents/copilot/copilot-instructions/l4-backend-api.md
+++ b/agents/copilot/copilot-instructions/l4-backend-api.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this repository.

--- a/agents/copilot/copilot-instructions/l4-backend-cli.md
+++ b/agents/copilot/copilot-instructions/l4-backend-cli.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this repository.

--- a/agents/copilot/copilot-instructions/l4-data.md
+++ b/agents/copilot/copilot-instructions/l4-data.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Data (Level 4)
 
 These instructions govern how GitHub Copilot plans, reasons, and generates

--- a/agents/copilot/copilot-instructions/l4-ui-angular.md
+++ b/agents/copilot/copilot-instructions/l4-ui-angular.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Angular UI
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this Angular UI repository.

--- a/agents/copilot/copilot-instructions/l4-ui-react.md
+++ b/agents/copilot/copilot-instructions/l4-ui-react.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — React UI
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this React UI repository.

--- a/agents/copilot/copilot-instructions/l5-backend-api.md
+++ b/agents/copilot/copilot-instructions/l5-backend-api.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Level 5 GenAI Operations
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this repository.

--- a/agents/copilot/copilot-instructions/l5-backend-cli.md
+++ b/agents/copilot/copilot-instructions/l5-backend-cli.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Level 5 GenAI Operations (CLI)
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this repository.

--- a/agents/copilot/copilot-instructions/l5-ui-angular.md
+++ b/agents/copilot/copilot-instructions/l5-ui-angular.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Level 5 GenAI Operations (Angular UI)
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this Angular UI repository at Level 5.

--- a/agents/copilot/copilot-instructions/l5-ui-react.md
+++ b/agents/copilot/copilot-instructions/l5-ui-react.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Level 5 GenAI Operations (React UI)
 
 These instructions govern how GitHub Copilot plans, reasons, and generates code in this React UI repository at Level 5.

--- a/agents/copilot/copilot-instructions/ui-angular.md
+++ b/agents/copilot/copilot-instructions/ui-angular.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Foundations (Level 3) — Angular UI
 
 These instructions govern how GitHub Copilot plans, reasons, and generates

--- a/agents/copilot/copilot-instructions/ui-react.md
+++ b/agents/copilot/copilot-instructions/ui-react.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # GitHub Copilot Instructions — Foundations (Level 3) — React UI
 
 These instructions govern how GitHub Copilot plans, reasons, and generates

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -26,7 +26,7 @@
     "type": {
       "data": {
         "files": [
-          { "src": "copilot-instructions/data.md", "dest": ".github/copilot-instructions.md" },
+          { "src": "copilot-instructions/data.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
           { "src": "instructions/data/staging.instructions.md", "dest": ".github/instructions/staging.instructions.md" },
           { "src": "instructions/data/intermediate.instructions.md", "dest": ".github/instructions/intermediate.instructions.md" },
           { "src": "instructions/data/marts.instructions.md", "dest": ".github/instructions/marts.instructions.md" },
@@ -42,7 +42,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "copilot-instructions/l4-data.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l4-data.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/generic/test-first.instructions.md", "dest": ".github/instructions/test-first.instructions.md" },
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".github/skills/spec-planning/" },
@@ -57,7 +57,7 @@
       },
       "api": {
         "files": [
-          { "src": "copilot-instructions/backend-api.md", "dest": ".github/copilot-instructions.md" },
+          { "src": "copilot-instructions/backend-api.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
           { "src": "instructions/backend/api.instructions.md", "dest": ".github/instructions/api.instructions.md" },
           { "src": "instructions/backend/services.instructions.md", "dest": ".github/instructions/services.instructions.md" },
           { "src": "instructions/backend/ports.instructions.md", "dest": ".github/instructions/ports.instructions.md" },
@@ -73,7 +73,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "copilot-instructions/l4-backend-api.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l4-backend-api.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/generic/test-first.instructions.md", "dest": ".github/instructions/test-first.instructions.md" },
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".github/skills/spec-planning/" },
@@ -94,7 +94,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "copilot-instructions/l5-backend-api.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l5-backend-api.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/backend/", "dest": ".github/instructions/" },
             { "src": "instructions/backend/llm-gateway.instructions.md", "dest": ".github/instructions/llm-gateway.instructions.md" },
             { "src": "instructions/backend/guardrails.instructions.md", "dest": ".github/instructions/guardrails.instructions.md" },
@@ -122,7 +122,7 @@
       },
       "cli": {
         "files": [
-          { "src": "copilot-instructions/backend-cli.md", "dest": ".github/copilot-instructions.md" },
+          { "src": "copilot-instructions/backend-cli.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
           { "src": "instructions/cli/cli.instructions.md", "dest": ".github/instructions/cli.instructions.md" },
           { "src": "instructions/backend/services.instructions.md", "dest": ".github/instructions/services.instructions.md" },
           { "src": "instructions/backend/ports.instructions.md", "dest": ".github/instructions/ports.instructions.md" },
@@ -138,7 +138,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "copilot-instructions/l4-backend-cli.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l4-backend-cli.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/generic/test-first.instructions.md", "dest": ".github/instructions/test-first.instructions.md" },
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".github/skills/spec-planning/" },
@@ -158,7 +158,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "copilot-instructions/l5-backend-cli.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l5-backend-cli.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/cli/", "dest": ".github/instructions/" },
             { "src": "instructions/backend/llm-gateway.instructions.md", "dest": ".github/instructions/llm-gateway.instructions.md" },
             { "src": "instructions/backend/guardrails.instructions.md", "dest": ".github/instructions/guardrails.instructions.md" },
@@ -185,7 +185,7 @@
       },
       "ui-react": {
         "files": [
-          { "src": "copilot-instructions/ui-react.md", "dest": ".github/copilot-instructions.md" },
+          { "src": "copilot-instructions/ui-react.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
           { "src": "instructions/ui-react/components.instructions.md", "dest": ".github/instructions/components.instructions.md" },
           { "src": "instructions/ui-react/viewmodel.instructions.md", "dest": ".github/instructions/viewmodel.instructions.md" },
           { "src": "instructions/ui-react/api.instructions.md", "dest": ".github/instructions/ui-api.instructions.md" },
@@ -203,7 +203,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "copilot-instructions/l4-ui-react.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l4-ui-react.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/generic/test-first.instructions.md", "dest": ".github/instructions/test-first.instructions.md" },
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/ui-spec-planning/" },
@@ -222,7 +222,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "copilot-instructions/l5-ui-react.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l5-ui-react.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/ui-react/components.instructions.md", "dest": ".github/instructions/components.instructions.md" },
             { "src": "instructions/ui-react/viewmodel.instructions.md", "dest": ".github/instructions/viewmodel.instructions.md" },
             { "src": "instructions/ui-react/api.instructions.md", "dest": ".github/instructions/ui-api.instructions.md" },
@@ -251,7 +251,7 @@
       },
       "ui-angular": {
         "files": [
-          { "src": "copilot-instructions/ui-angular.md", "dest": ".github/copilot-instructions.md" },
+          { "src": "copilot-instructions/ui-angular.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
           { "src": "instructions/ui-angular/components.instructions.md", "dest": ".github/instructions/components.instructions.md" },
           { "src": "instructions/ui-angular/viewmodel.instructions.md", "dest": ".github/instructions/viewmodel.instructions.md" },
           { "src": "instructions/ui-angular/api.instructions.md", "dest": ".github/instructions/ui-api.instructions.md" },
@@ -269,7 +269,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "copilot-instructions/l4-ui-angular.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l4-ui-angular.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/generic/test-first.instructions.md", "dest": ".github/instructions/test-first.instructions.md" },
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/spec-compliance.instructions.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/ui-spec-planning/" },
@@ -288,7 +288,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "copilot-instructions/l5-ui-angular.md", "dest": ".github/copilot-instructions.md" },
+            { "src": "copilot-instructions/l5-ui-angular.md", "dest": ".github/instructions/govkit/governance.instructions.md" },
             { "src": "instructions/ui-angular/components.instructions.md", "dest": ".github/instructions/components.instructions.md" },
             { "src": "instructions/ui-angular/viewmodel.instructions.md", "dest": ".github/instructions/viewmodel.instructions.md" },
             { "src": "instructions/ui-angular/api.instructions.md", "dest": ".github/instructions/ui-api.instructions.md" },

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -118,7 +118,7 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
 
     # A6: retire any pre-namespace top-level instruction file (CLAUDE.md etc.)
     # before installing governance into the rules namespace.
-    files = reconcile_legacy_instruction_files(target, agent_dir, files)
+    files = reconcile_legacy_instruction_files(target, agent_dir, files, prior_applied_at)
 
     print("Agent files (refreshed):")
     for entry in files:

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -18,7 +18,12 @@ from pathlib import Path
 
 from . import paths, version
 from .fs import copy_entry
-from .install_common import copy_governed_or_shared, exclude_for_level, post_install_finalize
+from .install_common import (
+    copy_governed_or_shared,
+    exclude_for_level,
+    post_install_finalize,
+    reconcile_legacy_instruction_files,
+)
 from .manifest import load_manifest, resolve_variant_files
 from .marker import _compare_version, read_govkit_marker, write_govkit_marker
 
@@ -110,6 +115,10 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
     # headers.
     prior_applied_at = stored.get("applied_at")
     baseline = f"govkit@{version.GOVKIT_VERSION}"
+
+    # A6: retire any pre-namespace top-level instruction file (CLAUDE.md etc.)
+    # before installing governance into the rules namespace.
+    files = reconcile_legacy_instruction_files(target, agent_dir, files)
 
     print("Agent files (refreshed):")
     for entry in files:

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -83,9 +83,11 @@ def _parse_frontmatter(text: str) -> dict | None:
 
 
 def _iter_rule_files(target: Path, rules_dir: Path) -> list[Path]:
-    """Find every rule file at target/<rules_dir>.
+    """Find every rule file at or below target/<rules_dir>.
 
-    `*.instructions.md` (copilot) is a subset of `*.md`, so glob both then
+    The scan is recursive: govkit owns a `govkit/` subtree under the rules dir,
+    and teams may nest their own rules, so a top-level glob would silently skip
+    both. `*.instructions.md` (copilot) is a subset of `*.md`, so glob both then
     dedupe — keeps the helper agent-agnostic.
     """
     full = target / rules_dir
@@ -93,7 +95,7 @@ def _iter_rule_files(target: Path, rules_dir: Path) -> list[Path]:
         return []
     seen: set[Path] = set()
     out: list[Path] = []
-    for p in sorted(full.glob("*.md")) + sorted(full.glob("*.instructions.md")):
+    for p in sorted(full.rglob("*.md")) + sorted(full.rglob("*.instructions.md")):
         if p in seen:
             continue
         seen.add(p)

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -44,6 +44,12 @@ def _unmodified_since(path: Path, applied_at: str | None) -> bool:
     (or before) that timestamp is govkit's own untouched copy — regardless of
     which govkit version's text it carries. Returns False when `applied_at` is
     missing/unparseable, so an unknown history never authorizes a delete.
+
+    A timezone-naive `applied_at` (no offset on disk — markers aren't schema-
+    validated) is likewise treated as unknown history: it cannot be compared
+    to the timezone-aware UTC mtime without raising TypeError, so it returns
+    False rather than crash the caller. The comparison is also wrapped as a
+    final safety net.
     """
     if not applied_at:
         return False
@@ -51,8 +57,13 @@ def _unmodified_since(path: Path, applied_at: str | None) -> bool:
         applied_dt = datetime.fromisoformat(applied_at)
     except (ValueError, TypeError):
         return False
+    if applied_dt.tzinfo is None:
+        return False
     mtime_dt = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
-    return mtime_dt <= applied_dt
+    try:
+        return mtime_dt <= applied_dt
+    except TypeError:
+        return False
 
 
 def reconcile_legacy_instruction_files(
@@ -90,7 +101,21 @@ def reconcile_legacy_instruction_files(
             legacy_body = None
         is_govkit_orphan = legacy_body == govkit_body or _unmodified_since(legacy, applied_at)
         if is_govkit_orphan:
-            legacy.unlink()
+            try:
+                legacy.unlink()
+            except OSError as exc:
+                # Deletion can fail (permissions, a Windows sharing violation, a
+                # read-only mount). Don't crash the upgrade — and don't install
+                # the namespaced governance while the legacy copy is still on
+                # disk, or the agent would load governance twice.
+                print(
+                    f"  warning: could not remove legacy {legacy_rel} ({exc}); "
+                    f"skipping {entry['dest']} to avoid loading governance twice. "
+                    f"Remove {legacy_rel} manually and re-run upgrade to adopt the "
+                    "managed governance.",
+                    file=sys.stderr,
+                )
+                continue
             print(f"  migrated {legacy_rel} -> {entry['dest']}  (removed govkit-authored orphan)")
             keep.append(entry)
         else:

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -14,6 +14,7 @@ them inward without duplicating logic or reaching back into cli/govkit.py.
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -36,18 +37,38 @@ _LEGACY_INSTRUCTION_DEST = {
 }
 
 
+def _unmodified_since(path: Path, applied_at: str | None) -> bool:
+    """True when `path` has not been modified since the marker's `applied_at`.
+
+    govkit wrote the legacy instruction file at apply time, so a file still at
+    (or before) that timestamp is govkit's own untouched copy — regardless of
+    which govkit version's text it carries. Returns False when `applied_at` is
+    missing/unparseable, so an unknown history never authorizes a delete.
+    """
+    if not applied_at:
+        return False
+    try:
+        applied_dt = datetime.fromisoformat(applied_at)
+    except (ValueError, TypeError):
+        return False
+    mtime_dt = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    return mtime_dt <= applied_dt
+
+
 def reconcile_legacy_instruction_files(
-    target: Path, agent_dir: Path, files: list,
+    target: Path, agent_dir: Path, files: list, applied_at: str | None = None,
 ) -> list:
     """Retire a pre-namespace govkit instruction file before writing governance.
 
     For each governance entry, if the legacy top-level file it superseded is
-    present:
-      - byte-identical to govkit's governance body ⇒ it is govkit's own
-        untouched orphan; delete it and let governance install.
-      - otherwise ⇒ treat it as the team's file: keep it, and drop the
-        governance entry so upgrade does not install duplicate governance
-        alongside it. A warning tells the team how to adopt the managed layout.
+    present, it is treated as govkit's own untouched orphan — and removed — when
+    EITHER:
+      - it is byte-identical to govkit's current governance body, or
+      - it has not been modified since the marker's `applied_at` (so it is
+        govkit's file from an earlier version, untouched by the team).
+    Otherwise it is treated as the team's file: kept, and the governance entry
+    is dropped so upgrade does not install duplicate governance alongside it. A
+    warning tells the team how to adopt the managed layout.
 
     Returns the files list to actually write. Upgrade-only: on a fresh apply a
     top-level CLAUDE.md is the team's, and governance is expected to coexist.
@@ -67,7 +88,8 @@ def reconcile_legacy_instruction_files(
             legacy_body = legacy.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             legacy_body = None
-        if legacy_body == govkit_body:
+        is_govkit_orphan = legacy_body == govkit_body or _unmodified_since(legacy, applied_at)
+        if is_govkit_orphan:
             legacy.unlink()
             print(f"  migrated {legacy_rel} -> {entry['dest']}  (removed govkit-authored orphan)")
             keep.append(entry)

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -13,6 +13,7 @@ them inward without duplicating logic or reaching back into cli/govkit.py.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,63 @@ from .marker import read_govkit_marker
 
 if TYPE_CHECKING:
     from .detect import RepoProfile
+
+
+# A6: govkit used to install its agent instructions at these top-level paths.
+# They now live in the auto-loaded rules namespace, so on upgrade an existing
+# install carries an orphaned copy. This maps each new governance dest back to
+# the legacy path it superseded, so upgrade can retire the orphan.
+_LEGACY_INSTRUCTION_DEST = {
+    ".claude/rules/govkit/governance.md": "CLAUDE.md",
+    ".claude/rules/govkit/governance-src.md": "src/CLAUDE.md",
+    ".github/instructions/govkit/governance.instructions.md": ".github/copilot-instructions.md",
+}
+
+
+def reconcile_legacy_instruction_files(
+    target: Path, agent_dir: Path, files: list,
+) -> list:
+    """Retire a pre-namespace govkit instruction file before writing governance.
+
+    For each governance entry, if the legacy top-level file it superseded is
+    present:
+      - byte-identical to govkit's governance body ⇒ it is govkit's own
+        untouched orphan; delete it and let governance install.
+      - otherwise ⇒ treat it as the team's file: keep it, and drop the
+        governance entry so upgrade does not install duplicate governance
+        alongside it. A warning tells the team how to adopt the managed layout.
+
+    Returns the files list to actually write. Upgrade-only: on a fresh apply a
+    top-level CLAUDE.md is the team's, and governance is expected to coexist.
+    """
+    keep = []
+    for entry in files:
+        legacy_rel = _LEGACY_INSTRUCTION_DEST.get(entry["dest"])
+        if legacy_rel is None:
+            keep.append(entry)
+            continue
+        legacy = target / legacy_rel
+        if not legacy.exists():
+            keep.append(entry)
+            continue
+        govkit_body = (agent_dir / entry["src"]).read_text(encoding="utf-8")
+        try:
+            legacy_body = legacy.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            legacy_body = None
+        if legacy_body == govkit_body:
+            legacy.unlink()
+            print(f"  migrated {legacy_rel} -> {entry['dest']}  (removed govkit-authored orphan)")
+            keep.append(entry)
+        else:
+            print(
+                f"  warning: {legacy_rel} exists and is not govkit's governance; "
+                f"leaving it and skipping {entry['dest']} to avoid duplicate governance. "
+                f"If it is no longer needed, delete {legacy_rel} and re-run upgrade to "
+                "adopt the managed governance.",
+                file=sys.stderr,
+            )
+    return keep
 
 
 # PR 6c: L5-only architecture docs. These live in docs/backend/architecture/

--- a/cli/setup_review.py
+++ b/cli/setup_review.py
@@ -22,16 +22,6 @@ def _layout_for(agent: str) -> AgentLayout:
     return AGENT_LAYOUTS.get(agent, AGENT_LAYOUTS["claude-code"])
 
 
-def _rules_display(layout: AgentLayout) -> tuple[str, str]:
-    """Human-readable (rules_dir, rules_glob) for the review file and banner.
-
-    Agents without a glob-scoped rules dir (codex) get descriptive text — a
-    presentation concern, so it lives here rather than in the layout table."""
-    if layout.rules_dir is None:
-        return "(nested AGENTS.md per layer)", layout.instruction_file
-    return f"{layout.rules_dir}/", layout.rules_glob
-
-
 def _architecture_root(type_value: str) -> str:
     """Map project type to its docs architecture root."""
     if type_value in ("ui-react", "ui-angular"):
@@ -83,7 +73,6 @@ def _format_review_checklist(agent: str, type_value: str) -> str:
     agent/type; the items themselves are stable for PR 1."""
     arch = _architecture_root(type_value)
     layout = _layout_for(agent)
-    rules_dir, rules_glob = _rules_display(layout)
     items = [
         (f"{arch}/TECH_STACK.md",
          "Confirm the language, framework, persistence, messaging, observability, "
@@ -96,12 +85,17 @@ def _format_review_checklist(agent: str, type_value: str) -> str:
         (f"{arch}/TESTING.md",
          "Confirm the unit/BDD framework, mocking library, and any framework-as-L4-gate "
          "decisions (set BDD to 'none' if your team does not practise BDD)."),
-        (layout.instruction_file,
-         "Top-level agent guidance. Confirm references to architecture docs are accurate."),
-        (rules_dir,
-         f"Agent rules ({rules_glob}). Confirm globs/applyTo patterns match your "
-         "folder layout — rules that don't match anything provide no guidance."),
     ]
+    # Agents with a native rules dir (claude-code, copilot) get govkit's
+    # governance in that auto-loaded namespace — govkit owns and refreshes it,
+    # so it is NOT a team-editable review item. Teams steer it through the
+    # architecture docs above and `govkit calibrate`. Codex has no rules dir, so
+    # its governance lives in AGENTS.md, which the team still reviews.
+    if layout.rules_dir is None:
+        items.append((
+            layout.instruction_file,
+            "Top-level agent guidance. Confirm references to architecture docs are accurate.",
+        ))
     lines = ["Please read these files before relying on the installed governance:\n"]
     for i, (path, note) in enumerate(items, start=1):
         lines.append(f"{i}. **{path}**\n   {note}")
@@ -193,10 +187,13 @@ this file — author your notes in ADRs or a separate doc instead.
 
 ## Next steps
 
-- After reviewing, edit any docs above to match your repo. GovKit detects your
+- After reviewing, edit the docs above to match your repo. GovKit detects your
   edits (via the `govkit:editable` header + file mtime vs. the marker's
   `applied_at`) and refuses to overwrite them on `govkit upgrade` or
   `govkit stack apply`. Use `--force` to override.
+- GovKit's own agent guidance is refreshed on every upgrade and is not meant to
+  be hand-edited — steer it through the architecture docs above and
+  `govkit calibrate`, not by editing the installed governance files.
 - `govkit doctor` validates fit and surfaces mismatches; run it in CI.
 - `govkit calibrate` walks the review checklist with the team and records
   each decision in `.govkit/marker.json`.
@@ -216,7 +213,6 @@ def print_review_checklist(target: Path, marker: dict) -> None:
     type_value = marker.get("options", {}).get("type", "api")
     arch = _architecture_root(type_value)
     layout = _layout_for(agent)
-    rules_dir, _ = _rules_display(layout)
     needs_review_count = sum(
         1 for a in (marker.get("assumptions") or []) if a.get("review_required")
     )
@@ -229,13 +225,16 @@ def print_review_checklist(target: Path, marker: dict) -> None:
         bar,
         "  See GOVKIT_SETUP_REVIEW.md (just written) for the full checklist.",
         "",
-        "  Top items to confirm:",
+        "  Confirm these match your repo (GovKit governs against them):",
         f"    1. {arch}/TECH_STACK.md      — language / framework / libraries",
         f"    2. {arch}/BOUNDARIES.md      — architecture style + folder mappings",
         f"    3. {arch}/TESTING.md         — test framework + BDD policy",
-        f"    4. {layout.instruction_file:32s} — top-level agent guidance",
-        f"    5. {rules_dir:32s} — rule globs / applyTo patterns",
     ]
+    # Codex has no auto-loaded rules dir, so its governance lives in AGENTS.md,
+    # which the team reviews. claude-code/copilot governance is govkit-owned in
+    # the rules namespace and isn't a team-review item.
+    if layout.rules_dir is None:
+        lines.append(f"    4. {layout.instruction_file:32s} — top-level agent guidance")
     if needs_review_count:
         lines.append("")
         lines.append(

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -203,6 +202,48 @@ class TestMonorepoDiscovery:
         assert d001s[0].severity == "error"
         assert "ports" in d001s[0].message
         assert d001s[0].file and "ports.md" in d001s[0].file
+
+    def test_d001_checks_rules_in_govkit_subdirectory(self, tmp_path):
+        """Rules live in `.claude/rules/govkit/` once govkit owns its own
+        namespace; doctor must descend into subdirectories, not just glob the
+        top level, or it silently stops validating govkit's own rule globs."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, agent="claude-code")
+        govkit_rules = tmp_path / ".claude" / "rules" / "govkit"
+        govkit_rules.mkdir(parents=True)
+        (govkit_rules / "ports.md").write_text(
+            '---\npaths:\n  - "**/ports/**"\n---\n# Ports\n', encoding="utf-8",
+        )
+        # No ports/ folder anywhere in target — the glob resolves to nothing.
+
+        findings = run_doctor(tmp_path)
+        d001s = [f for f in findings if f.id == "D001"]
+        assert len(d001s) == 1
+        assert d001s[0].file and "ports.md" in d001s[0].file
+
+    def test_d001_still_checks_flat_team_rules_alongside_subdir(self, tmp_path):
+        """The recursive scan is additive: a team's own flat rule is still
+        validated, not shadowed by the govkit/ subtree."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, agent="claude-code")
+        rules_dir = tmp_path / ".claude" / "rules"
+        (rules_dir / "govkit").mkdir(parents=True)
+        # govkit's rule resolves (folder exists); the team's flat rule does not.
+        (rules_dir / "govkit" / "api.md").write_text(
+            '---\npaths:\n  - "**/api/**"\n---\n# Api\n', encoding="utf-8",
+        )
+        (rules_dir / "team-thing.md").write_text(
+            '---\npaths:\n  - "**/nonexistent-team-folder/**"\n---\n# Team\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "src" / "api").mkdir(parents=True)
+
+        findings = run_doctor(tmp_path)
+        d001s = [f for f in findings if f.id == "D001"]
+        assert len(d001s) == 1
+        assert d001s[0].file and "team-thing.md" in d001s[0].file
 
     def test_d001_handles_copilot_applyto_format(self, tmp_path):
         """Copilot rules carry `applyTo: "<glob>"` (string), not the
@@ -430,8 +471,8 @@ class TestMonorepoDiscovery:
     def test_d006_fires_when_installed_doc_baseline_is_older(self, tmp_path):
         """Installed TECH_STACK.md carries baseline=python-fastapi@0.9.0 but
         the bundled overlay is at 0.10.0 — user should refresh."""
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path, stack={
             "id": "python-fastapi", "version": "0.10.0",
@@ -450,8 +491,8 @@ class TestMonorepoDiscovery:
         assert "0.10.0" in d006s[0].message
 
     def test_d006_does_not_fire_when_baseline_matches_current_overlay(self, tmp_path):
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path, stack={
             "id": "python-fastapi", "version": "0.10.0",
@@ -483,8 +524,8 @@ class TestMonorepoDiscovery:
     # -----------------------------------------------------------------------
 
     def test_d007_fires_at_l4_when_tech_stack_mentions_litellm(self, tmp_path):
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path, level="4")
         tech_stack = tmp_path / "docs" / "backend" / "architecture" / "TECH_STACK.md"
@@ -504,8 +545,8 @@ class TestMonorepoDiscovery:
         assert "LiteLLM" in d007s[0].message or "L5" in d007s[0].message
 
     def test_d007_does_not_fire_at_l5(self, tmp_path):
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path, level="5")
         tech_stack = tmp_path / "docs" / "backend" / "architecture" / "TECH_STACK.md"
@@ -520,8 +561,8 @@ class TestMonorepoDiscovery:
         assert not any(f.id == "D007" for f in findings)
 
     def test_d007_does_not_fire_when_no_llm_keywords(self, tmp_path):
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path, level="4")
         tech_stack = tmp_path / "docs" / "backend" / "architecture" / "TECH_STACK.md"
@@ -573,8 +614,8 @@ class TestMonorepoDiscovery:
     # -----------------------------------------------------------------------
 
     def test_d009_fires_when_testing_md_names_framework_not_in_deps(self, tmp_path):
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path)
         testing = tmp_path / "docs" / "backend" / "architecture" / "TESTING.md"
@@ -593,8 +634,8 @@ class TestMonorepoDiscovery:
         assert "pytest" in d009s[0].message
 
     def test_d009_does_not_fire_when_framework_in_deps(self, tmp_path):
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path)
         testing = tmp_path / "docs" / "backend" / "architecture" / "TESTING.md"
@@ -618,8 +659,8 @@ class TestMonorepoDiscovery:
 
     def test_d009_silent_when_no_dep_manifest(self, tmp_path):
         """Without any dep manifest to cross-check, D009 has nothing to compare against."""
-        from cli.headers import format_editable_header
         from cli.doctor import run_doctor
+        from cli.headers import format_editable_header
 
         _write_marker(tmp_path)
         testing = tmp_path / "docs" / "backend" / "architecture" / "TESTING.md"
@@ -664,6 +705,7 @@ class TestMonorepoDiscovery:
     def test_d010_does_not_fire_for_recent_assumption(self, tmp_path):
         """A review_required assumption applied recently isn't yet stale."""
         from datetime import datetime, timezone
+
         from cli.doctor import run_doctor
 
         recent = datetime.now(timezone.utc).isoformat()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -605,3 +605,65 @@ class TestMonorepoFixture:
         for f in web_findings:
             if f.file:
                 assert "apps" not in f.file or "web" in f.file
+
+
+@pytest.mark.xfail(
+    reason="Namespacing govkit rules/skills under govkit/ is deferred (plan inc 2); "
+    "today a team rule whose name collides with govkit's is still overwritten. "
+    "These pin the target contract.",
+    strict=True,
+)
+class TestTeamOwnedContentSurvivesApply:
+    """A team that authored their own agent files before adopting govkit must
+    not lose them on `govkit apply`. govkit owns a `govkit/` subtree under the
+    native rules dir and a `govkit-` skill prefix, so its files never share a
+    path with a team's own same-named rule or skill.
+    """
+
+    def _apply(self, target: Path, agent: str) -> None:
+        from cli.cmd_apply import cmd_apply
+
+        cmd_apply(argparse.Namespace(
+            agent=agent, target=str(target),
+            level="4", type="api", ci="github", stack=None,
+            force=False, detect=False,
+        ))
+
+    def test_team_rule_with_govkit_name_survives(self, tmp_path):
+        """A team's own .claude/rules/api.md is not clobbered by govkit's api rule."""
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        team_rule = target / ".claude" / "rules" / "api.md"
+        team_rule.parent.mkdir(parents=True, exist_ok=True)
+        team_rule.write_text("# TEAM api rule — do not lose\n", encoding="utf-8")
+
+        self._apply(target, "claude-code")
+
+        assert team_rule.read_text(encoding="utf-8") == "# TEAM api rule — do not lose\n"
+        # govkit's own copy lands in its namespace, still installed.
+        assert (target / ".claude" / "rules" / "govkit" / "api.md").is_file()
+
+    def test_team_skill_with_govkit_name_survives(self, tmp_path):
+        """A team's own .claude/skills/spec-planning/ is not clobbered."""
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        team_skill = target / ".claude" / "skills" / "spec-planning" / "SKILL.md"
+        team_skill.parent.mkdir(parents=True, exist_ok=True)
+        team_skill.write_text("# TEAM spec-planning\n", encoding="utf-8")
+
+        self._apply(target, "claude-code")
+
+        assert team_skill.read_text(encoding="utf-8") == "# TEAM spec-planning\n"
+        assert (target / ".claude" / "skills" / "govkit-spec-planning" / "SKILL.md").is_file()
+
+    def test_copilot_team_instruction_with_govkit_name_survives(self, tmp_path):
+        """A team's own .github/instructions/api.instructions.md is not clobbered."""
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        team_rule = target / ".github" / "instructions" / "api.instructions.md"
+        team_rule.parent.mkdir(parents=True, exist_ok=True)
+        team_rule.write_text("# TEAM copilot api\n", encoding="utf-8")
+
+        self._apply(target, "copilot")
+
+        assert team_rule.read_text(encoding="utf-8") == "# TEAM copilot api\n"
+        assert (
+            target / ".github" / "instructions" / "govkit" / "api.instructions.md"
+        ).is_file()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -607,6 +607,50 @@ class TestMonorepoFixture:
                 assert "apps" not in f.file or "web" in f.file
 
 
+class TestGovernanceLivesInRulesNamespace:
+    """govkit's agent instructions install into its own auto-loaded rules
+    namespace, not the team's top-level CLAUDE.md. This is what lets a team's
+    hand-written CLAUDE.md survive `govkit apply` untouched while govkit's
+    governance still loads every session.
+    """
+
+    def _apply(self, target: Path, agent: str) -> None:
+        from cli.cmd_apply import cmd_apply
+
+        cmd_apply(argparse.Namespace(
+            agent=agent, target=str(target),
+            level="4", type="api", ci="github", stack=None,
+            force=False, detect=False,
+        ))
+
+    def test_governance_installs_into_rules_namespace(self, tmp_path):
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        self._apply(target, "claude-code")
+
+        governance = target / ".claude" / "rules" / "govkit" / "governance.md"
+        assert governance.is_file()
+        # It carries the real governance body, not a stub.
+        assert "source of truth" in governance.read_text(encoding="utf-8").lower()
+
+    def test_apply_does_not_write_a_claude_md(self, tmp_path):
+        """No-stub: govkit never creates CLAUDE.md, so a team is free to own it."""
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        assert not (target / "CLAUDE.md").exists()
+        self._apply(target, "claude-code")
+        assert not (target / "CLAUDE.md").exists()
+
+    def test_team_claude_md_untouched(self, tmp_path):
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        (target / "CLAUDE.md").write_text("# ACME house rules\nUse pnpm.\n", encoding="utf-8")
+
+        self._apply(target, "claude-code")
+
+        assert (target / "CLAUDE.md").read_text(encoding="utf-8") == (
+            "# ACME house rules\nUse pnpm.\n"
+        )
+        assert (target / ".claude" / "rules" / "govkit" / "governance.md").is_file()
+
+
 @pytest.mark.xfail(
     reason="Namespacing govkit rules/skills under govkit/ is deferred (plan inc 2); "
     "today a team rule whose name collides with govkit's is still overwritten. "

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2445,7 +2445,10 @@ class TestUpgradeMigratesLegacyInstructionFile:
     governance moves into the rules namespace, upgrade must retire the orphan —
     but only when it is provably govkit's own untouched file, never a team's."""
 
-    def _target(self, tmp_path: Path, claude_md: str | None) -> Path:
+    def _target(
+        self, tmp_path: Path, claude_md: str | None,
+        applied_at: str = "2026-01-01T00:00:00+00:00",
+    ) -> Path:
         target = tmp_path / "project"
         target.mkdir()
         if claude_md is not None:
@@ -2453,7 +2456,7 @@ class TestUpgradeMigratesLegacyInstructionFile:
         marker = {
             "version": "0.1.0", "level": "4", "agent": "test-agent",
             "options": {"type": "api", "ci": "github"},
-            "applied_at": "2026-01-01T00:00:00+00:00",
+            "applied_at": applied_at,
         }
         (target / ".govkit").mkdir()
         (target / ".govkit" / "marker.json").write_text(json.dumps(marker), encoding="utf-8")
@@ -2519,6 +2522,56 @@ class TestUpgradeMigratesLegacyInstructionFile:
 
         assert (target / ".claude" / "rules" / "govkit" / "governance.md").is_file()
         assert not (target / "CLAUDE.md").exists()
+
+    def test_naive_applied_at_does_not_crash_or_delete(self, tmp_path, monkeypatch, capsys):
+        """A marker whose applied_at parses timezone-naive (no offset on disk —
+        markers aren't schema-validated) must not crash upgrade when compared to
+        the timezone-aware mtime. Unknown history → the legacy file is kept, never
+        deleted on the strength of a naive timestamp."""
+        import os
+        from datetime import datetime, timezone
+
+        target = self._target(
+            tmp_path,
+            claude_md="# OLD govkit governance (v0.10)\n",
+            applied_at="2026-01-01T00:00:00",  # naive: no UTC offset
+        )
+        # mtime BEFORE the naive applied_at: a buggy naive comparison would treat
+        # this as "unmodified since apply" and delete it. The fix returns False.
+        stamp = datetime(2025, 12, 1, tzinfo=timezone.utc).timestamp()
+        os.utime(target / "CLAUDE.md", (stamp, stamp))
+
+        self._run(tmp_path, target, monkeypatch)  # must not raise TypeError
+
+        assert (target / "CLAUDE.md").exists()
+        assert not (target / ".claude" / "rules" / "govkit" / "governance.md").exists()
+
+    def test_unlink_failure_warns_and_continues(self, tmp_path, monkeypatch, capsys):
+        """If removing the govkit-authored orphan fails (permissions, a Windows
+        sharing violation, a read-only mount), upgrade must not crash: it warns
+        and skips installing the namespaced governance so the agent never loads
+        governance twice."""
+        _, body = _make_governance_repo(tmp_path)
+        # Byte-identical to govkit's governance → provably govkit's orphan, so
+        # reconcile attempts to unlink it.
+        target = self._target(tmp_path, claude_md=body)
+
+        real_unlink = Path.unlink
+
+        def failing_unlink(self, *args, **kwargs):
+            if self.name == "CLAUDE.md":
+                raise OSError("simulated sharing violation")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        self._run(tmp_path, target, monkeypatch)  # must not raise OSError
+
+        assert (target / "CLAUDE.md").exists()  # left in place
+        assert not (target / ".claude" / "rules" / "govkit" / "governance.md").exists()
+        err = capsys.readouterr().err
+        assert "CLAUDE.md" in err
+        assert "could not remove" in err
 
 
 class TestCmdUpgradeEditProtection:

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2406,6 +2406,96 @@ class TestCmdUpgrade:
         assert not (target / "ci" / "github" / "repo-scope-check.yml").exists()
 
 
+def _make_governance_repo(tmp_path: Path, agent: str = "test-agent") -> tuple[Path, str]:
+    """A repo whose manifest installs governance into the rules namespace
+    (post-migration layout), returning (repo, governance_body)."""
+    agents = tmp_path / "agents" / agent
+    (agents / "claude-md").mkdir(parents=True, exist_ok=True)
+    body = "# Governed AI Delivery\nRepository artifacts are the source of truth.\n"
+    (agents / "claude-md" / "governance.md").write_text(body, encoding="utf-8")
+    manifest = {
+        "agent": agent,
+        "description": "governance-namespace test agent",
+        "options": {
+            "level": {"prompt": "Level?", "choices": ["3", "4", "5"], "default": "4"},
+            "type": {"prompt": "Type?", "choices": ["api"], "default": "api"},
+            "ci": {"prompt": "CI?", "choices": ["github"], "default": "github"},
+        },
+        "variants": {
+            "type": {
+                "api": {
+                    "files": [
+                        {"src": "claude-md/governance.md",
+                         "dest": ".claude/rules/govkit/governance.md"},
+                    ],
+                    "shared": [],
+                    "governed": [],
+                }
+            },
+            "ci": {"github": {"files": [], "shared": [], "governed": []}},
+        },
+        "base_files": [],
+    }
+    (agents / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp_path, body
+
+
+class TestUpgradeMigratesLegacyInstructionFile:
+    """A6: an existing install carries govkit's old top-level CLAUDE.md. Once
+    governance moves into the rules namespace, upgrade must retire the orphan —
+    but only when it is provably govkit's own untouched file, never a team's."""
+
+    def _target(self, tmp_path: Path, claude_md: str | None) -> Path:
+        target = tmp_path / "project"
+        target.mkdir()
+        if claude_md is not None:
+            (target / "CLAUDE.md").write_text(claude_md, encoding="utf-8")
+        marker = {
+            "version": "0.1.0", "level": "4", "agent": "test-agent",
+            "options": {"type": "api", "ci": "github"},
+            "applied_at": "2026-01-01T00:00:00+00:00",
+        }
+        (target / ".govkit").mkdir()
+        (target / ".govkit" / "marker.json").write_text(json.dumps(marker), encoding="utf-8")
+        return target
+
+    def _run(self, tmp_path, target, monkeypatch):
+        repo, _ = _make_governance_repo(tmp_path)
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.2.0")
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+    def test_removes_govkit_authored_claude_md(self, tmp_path, monkeypatch):
+        """CLAUDE.md byte-identical to govkit's governance is govkit's own
+        orphan → removed; governance.md is installed in its place."""
+        _, body = _make_governance_repo(tmp_path)
+        target = self._target(tmp_path, claude_md=body)
+        self._run(tmp_path, target, monkeypatch)
+
+        assert not (target / "CLAUDE.md").exists()
+        assert (target / ".claude" / "rules" / "govkit" / "governance.md").is_file()
+
+    def test_keeps_edited_claude_md_and_skips_governance(self, tmp_path, monkeypatch, capsys):
+        """A CLAUDE.md that differs from govkit's governance is treated as the
+        team's: kept, governance.md NOT installed (no duplicate), warning shown."""
+        target = self._target(tmp_path, claude_md="# ACME house rules\nUse pnpm.\n")
+        self._run(tmp_path, target, monkeypatch)
+
+        assert (target / "CLAUDE.md").read_text(encoding="utf-8") == "# ACME house rules\nUse pnpm.\n"
+        assert not (target / ".claude" / "rules" / "govkit" / "governance.md").exists()
+        err = capsys.readouterr().err
+        assert "CLAUDE.md" in err
+
+    def test_no_legacy_file_installs_governance_normally(self, tmp_path, monkeypatch):
+        """A migrated (or fresh) install with no CLAUDE.md just gets governance.md."""
+        target = self._target(tmp_path, claude_md=None)
+        self._run(tmp_path, target, monkeypatch)
+
+        assert (target / ".claude" / "rules" / "govkit" / "governance.md").is_file()
+        assert not (target / "CLAUDE.md").exists()
+
+
 class TestCmdUpgradeEditProtection:
     """PR 1 / A2: cmd_upgrade refuses to overwrite user-edited governed
     docs unless --force is supplied. Files without a govkit:editable header

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2476,10 +2476,35 @@ class TestUpgradeMigratesLegacyInstructionFile:
         assert not (target / "CLAUDE.md").exists()
         assert (target / ".claude" / "rules" / "govkit" / "governance.md").is_file()
 
+    def test_removes_cross_version_untouched_claude_md(self, tmp_path, monkeypatch):
+        """An older-version govkit CLAUDE.md won't byte-match today's governance,
+        but if it is untouched since the last apply (mtime <= applied_at) it is
+        still govkit's orphan → removed, and current governance installed."""
+        import os
+        from datetime import datetime, timezone
+
+        target = self._target(tmp_path, claude_md="# OLD govkit governance (v0.10)\n")
+        # Untouched since apply: mtime a month before the marker's applied_at.
+        stamp = datetime(2025, 12, 1, tzinfo=timezone.utc).timestamp()
+        os.utime(target / "CLAUDE.md", (stamp, stamp))
+
+        self._run(tmp_path, target, monkeypatch)
+
+        assert not (target / "CLAUDE.md").exists()
+        assert (target / ".claude" / "rules" / "govkit" / "governance.md").is_file()
+
     def test_keeps_edited_claude_md_and_skips_governance(self, tmp_path, monkeypatch, capsys):
-        """A CLAUDE.md that differs from govkit's governance is treated as the
-        team's: kept, governance.md NOT installed (no duplicate), warning shown."""
+        """A CLAUDE.md that differs from govkit's governance AND was touched since
+        the last apply is the team's: kept, governance.md NOT installed (no
+        duplicate), warning shown."""
+        import os
+        from datetime import datetime, timezone
+
         target = self._target(tmp_path, claude_md="# ACME house rules\nUse pnpm.\n")
+        # Edited after apply: mtime well after the marker's applied_at.
+        stamp = datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp()
+        os.utime(target / "CLAUDE.md", (stamp, stamp))
+
         self._run(tmp_path, target, monkeypatch)
 
         assert (target / "CLAUDE.md").read_text(encoding="utf-8") == "# ACME house rules\nUse pnpm.\n"

--- a/tests/test_setup_review.py
+++ b/tests/test_setup_review.py
@@ -51,7 +51,9 @@ class TestWriteSetupReview:
         assert "TECH_STACK.md" in content
         assert "BOUNDARIES.md" in content
         assert "TESTING.md" in content
-        assert "CLAUDE.md" in content
+        # claude-code governance is govkit-owned in the rules namespace, not a
+        # team-editable review item — the checklist must not list CLAUDE.md.
+        assert "CLAUDE.md" not in content
 
     def test_review_paths_match_ui_type(self, tmp_path):
         """UI installs should reference docs/ui/architecture/, not docs/backend/."""
@@ -63,16 +65,16 @@ class TestWriteSetupReview:
         assert "docs/ui/architecture" in content
 
     def test_review_paths_match_copilot_agent(self, tmp_path):
-        """Copilot installs reference .github/instructions/ for agent rules,
-        not .claude/rules/."""
+        """Copilot governance lives in the govkit-owned .github/instructions/govkit/
+        namespace, so the review lists the team-editable architecture docs and
+        does NOT present copilot-instructions.md as something to hand-edit."""
         from cli.setup_review import write_setup_review
 
         write_setup_review(tmp_path, self._marker(agent="copilot"))
         content = (tmp_path / "GOVKIT_SETUP_REVIEW.md").read_text(encoding="utf-8")
 
-        assert ".github/instructions" in content
-        # The agent-instruction file for copilot:
-        assert "copilot-instructions.md" in content
+        assert "TECH_STACK.md" in content
+        assert "copilot-instructions.md" not in content
 
     def test_review_paths_match_codex_agent(self, tmp_path):
         from cli.setup_review import write_setup_review


### PR DESCRIPTION
## What this fixes

`govkit apply` overwrote `CLAUDE.md` / `.github/copilot-instructions.md` on every run, silently destroying whatever a team had written there — with no prompt, no backup, and `--force` didn't even gate it. This is the single sharpest adoption hazard: it punishes exactly the teams who cared enough to write agent instructions before adopting govkit.

## The insight

Both agents natively auto-load a **separate** instructions directory — `.claude/rules/` and `.github/instructions/` — and govkit already writes those in the correct native format. So govkit never needed the team's top-level file to carry its governance.

## The change

govkit's agent instructions move into its own auto-loaded namespace, and govkit writes **no** top-level instruction file at all:

| Agent | Governance now installs at |
|---|---|
| claude-code | `.claude/rules/govkit/governance.md` (+ `src/**`-scoped `governance-src.md` for UI) |
| copilot | `.github/instructions/govkit/governance.instructions.md` (`applyTo: "**"`) |

A team's hand-written `CLAUDE.md` / `copilot-instructions.md` is now **untouched** by apply, while govkit's governance still loads every session from the namespace it owns and refreshes.

### Upgrade migration for existing installs

An existing install carries govkit's old top-level file. On `upgrade`, `reconcile_legacy_instruction_files` retires it **only when it is provably govkit's own**:
- byte-identical to the current governance body, **or**
- untouched since the marker's `applied_at` (so older-version files clean up too).

Otherwise the file is treated as the team's: kept, governance install skipped (no duplicate), with a warning explaining how to adopt the managed layout. Detection is conservative in every failure direction — a missing/unparseable `applied_at`, or an mtime after `applied_at` (a real edit, or a clone that reset mtimes), never authorizes a delete.

### `setup_review` promise made honest

The old review checklist told teams to edit `CLAUDE.md` / rules and promised "we won't overwrite your edits" — which was false for exactly those files. The checklist now lists only the genuinely edit-protected architecture docs for agents with a native rules dir, so the promise is true. Codex keeps its `AGENTS.md` review item.

### doctor D001 recursion (prereq)

`doctor`'s rule-glob check scanned only the top level, so it would silently stop validating rules once they live in `.claude/rules/govkit/`. It now scans recursively — govkit's namespaced rules and a team's own flat rules are both checked.

## Scope / not in this PR

- **Codex** (`AGENTS.md`, no native rules dir) is **unchanged** — it needs a managed-block approach, tracked as a follow-up. No regression.
- **Rule/skill name-collision namespacing** is deferred, pinned by three strict-`xfail` tests (`TestTeamOwnedContentSurvivesApply`) that flip red the moment it lands.

## Tests

TDD throughout; verified end-to-end against live targets (fresh install, team-file-present, cross-version upgrade orphan, edited-file kept). New: `TestGovernanceLivesInRulesNamespace`, `TestUpgradeMigratesLegacyInstructionFile`, doctor recursion tests. **Full suite: 1014 passed, 1 skipped, 3 xfailed.**

> Note: independent of #50 (the calibration-wipe fix), which can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)