### PR TITLE
feat(govkit): install codex governance as a managed block in AGENTS.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   governance install is skipped (with a warning) so you never get duplicate
   governance. Codex (`AGENTS.md`, which has no native rules directory) is
   unchanged for now.
+  instruction file is retired automatically when it is byte-identical to govkit's
+  governance; if you edited it, it is kept and governance install is skipped
+  (with a warning) so you never get duplicate governance. Codex (`AGENTS.md`,
+  which has no native rules directory) is unchanged for now.
 - `govkit doctor`'s rule-glob check (D001) now scans the rules directory
   recursively, so rules in subdirectories — including govkit's own
   `.claude/rules/govkit/` — are validated instead of silently skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - `govkit doctor`'s rule-glob check (D001) now scans the rules directory
   recursively, so rules in subdirectories — including govkit's own
   `.claude/rules/govkit/` — are validated instead of silently skipped.
+- **Codex `AGENTS.md` is no longer overwritten wholesale.** Codex has no
+  auto-loaded rules directory, so its governance must share `AGENTS.md` with the
+  team — govkit now installs it as a managed block fenced by
+  `<!-- BEGIN GOVKIT GOVERNANCE -->` / `<!-- END GOVKIT GOVERNANCE -->`, and
+  preserves whatever the team wrote outside it. On `upgrade`, an existing
+  pre-block govkit `AGENTS.md` is replaced by the block when it is provably
+  govkit's own (byte-identical or untouched since `applied_at`); a team's file
+  keeps its content with the block appended below. Nested per-layer `AGENTS.md`
+  files are unchanged for now.
 
 ### Changed — internal
 

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -26,7 +26,7 @@
     "type": {
       "data": {
         "files": [
-          { "src": "agents-md/data.md", "dest": "AGENTS.md" },
+          { "src": "agents-md/data.md", "dest": "AGENTS.md", "managed_block": true },
           { "src": "rules/data/staging.md", "dest": "models/staging/AGENTS.md" },
           { "src": "rules/data/intermediate.md", "dest": "models/intermediate/AGENTS.md" },
           { "src": "rules/data/marts.md", "dest": "models/marts/AGENTS.md" },
@@ -42,7 +42,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "agents-md/l4-data.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l4-data.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/generic/test-first.md", "dest": ".agents/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/spec-planning/" },
@@ -57,7 +57,7 @@
       },
       "api": {
         "files": [
-          { "src": "agents-md/backend-api.md", "dest": "AGENTS.md" },
+          { "src": "agents-md/backend-api.md", "dest": "AGENTS.md", "managed_block": true },
           { "src": "rules/backend/api.md", "dest": "api/AGENTS.md" },
           { "src": "rules/backend/services.md", "dest": "services/AGENTS.md" },
           { "src": "rules/backend/ports.md", "dest": "ports/AGENTS.md" },
@@ -73,7 +73,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "agents-md/l4-backend-api.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l4-backend-api.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/generic/test-first.md", "dest": ".agents/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/spec-planning/" },
@@ -94,7 +94,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "agents-md/l5-backend-api.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l5-backend-api.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/backend/api.md", "dest": "api/AGENTS.md" },
             { "src": "rules/backend/services.md", "dest": "services/AGENTS.md" },
             { "src": "rules/backend/ports.md", "dest": "ports/AGENTS.md" },
@@ -129,7 +129,7 @@
       },
       "cli": {
         "files": [
-          { "src": "agents-md/backend-cli.md", "dest": "AGENTS.md" },
+          { "src": "agents-md/backend-cli.md", "dest": "AGENTS.md", "managed_block": true },
           { "src": "rules/cli/cli.md", "dest": "cli/AGENTS.md" },
           { "src": "rules/backend/services.md", "dest": "services/AGENTS.md" },
           { "src": "rules/backend/ports.md", "dest": "ports/AGENTS.md" },
@@ -145,7 +145,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "agents-md/l4-backend-cli.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l4-backend-cli.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/generic/test-first.md", "dest": ".agents/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/spec-planning/" },
@@ -165,7 +165,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "agents-md/l5-backend-cli.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l5-backend-cli.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/cli/cli.md", "dest": "cli/AGENTS.md" },
             { "src": "rules/backend/services.md", "dest": "services/AGENTS.md" },
             { "src": "rules/backend/ports.md", "dest": "ports/AGENTS.md" },
@@ -199,7 +199,7 @@
       },
       "ui-react": {
         "files": [
-          { "src": "agents-md/ui-react.md", "dest": "AGENTS.md" },
+          { "src": "agents-md/ui-react.md", "dest": "AGENTS.md", "managed_block": true },
           { "src": "agents-md/src-ui-react.md", "dest": "src/AGENTS.md" },
           { "src": "rules/ui-react/components.md", "dest": "src/features/components/AGENTS.md" },
           { "src": "rules/ui-react/viewmodel.md", "dest": "src/features/hooks/AGENTS.md" },
@@ -218,7 +218,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "agents-md/l4-ui-react.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l4-ui-react.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/generic/test-first.md", "dest": ".agents/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/ui-spec-planning/" },
@@ -237,7 +237,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "agents-md/l5-ui-react.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l5-ui-react.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "agents-md/src-ui-react.md", "dest": "src/AGENTS.md" },
             { "src": "rules/ui-react/components.md", "dest": "src/features/components/AGENTS.md" },
             { "src": "rules/ui-react/viewmodel.md", "dest": "src/features/hooks/AGENTS.md" },
@@ -267,7 +267,7 @@
       },
       "ui-angular": {
         "files": [
-          { "src": "agents-md/ui-angular.md", "dest": "AGENTS.md" },
+          { "src": "agents-md/ui-angular.md", "dest": "AGENTS.md", "managed_block": true },
           { "src": "agents-md/src-ui-angular.md", "dest": "src/AGENTS.md" },
           { "src": "rules/ui-angular/components.md", "dest": "src/features/components/AGENTS.md" },
           { "src": "rules/ui-angular/viewmodel.md", "dest": "src/features/hooks/AGENTS.md" },
@@ -286,7 +286,7 @@
         "level_4": {
           "mode": "merge",
           "files": [
-            { "src": "agents-md/l4-ui-angular.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l4-ui-angular.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "rules/generic/test-first.md", "dest": ".agents/rules/test-first.md" },
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/ui-spec-planning/" },
@@ -305,7 +305,7 @@
         "level_5": {
           "mode": "replace",
           "files": [
-            { "src": "agents-md/l5-ui-angular.md", "dest": "AGENTS.md" },
+            { "src": "agents-md/l5-ui-angular.md", "dest": "AGENTS.md", "managed_block": true },
             { "src": "agents-md/src-ui-angular.md", "dest": "src/AGENTS.md" },
             { "src": "rules/ui-angular/components.md", "dest": "src/features/components/AGENTS.md" },
             { "src": "rules/ui-angular/viewmodel.md", "dest": "src/features/hooks/AGENTS.md" },

--- a/cli/cmd_apply.py
+++ b/cli/cmd_apply.py
@@ -14,10 +14,10 @@ from typing import TYPE_CHECKING
 
 from . import paths, version
 from .compat import validate_level_type
-from .fs import copy_entry
 from .install_common import (
     copy_governed_or_shared,
     exclude_for_level,
+    install_agent_file,
     post_install_finalize,
 )
 from .manifest import load_manifest, resolve_options, resolve_variant_files
@@ -112,7 +112,7 @@ def _apply_variant_install(
 
     print("Agent files:")
     for entry in files:
-        copy_entry(agent_dir / entry["src"], target / entry["dest"])
+        install_agent_file(agent_dir, entry, target, prior_applied_at)
 
     l5_exclude = exclude_for_level(level)
     print("\nGoverned contracts (skip if present):")
@@ -143,7 +143,7 @@ def _apply_legacy_install(
     print(f"\nApplying govkit agent '{args.agent}' to {target}\n")
     print("Agent files:")
     for entry in manifest["files"]:
-        copy_entry(agent_dir / entry["src"], target / entry["dest"])
+        install_agent_file(agent_dir, entry, target, prior_applied_at)
 
     print("\nShared governance:")
     copy_governed_or_shared(

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -17,10 +17,10 @@ import sys
 from pathlib import Path
 
 from . import paths, version
-from .fs import copy_entry
 from .install_common import (
     copy_governed_or_shared,
     exclude_for_level,
+    install_agent_file,
     post_install_finalize,
     reconcile_legacy_instruction_files,
 )
@@ -122,9 +122,7 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
 
     print("Agent files (refreshed):")
     for entry in files:
-        src = agent_dir / entry["src"]
-        dest = target / entry["dest"]
-        copy_entry(src, dest)
+        install_agent_file(agent_dir, entry, target, prior_applied_at)
 
     # PR 6c: keep L5-only docs out of L3/L4 upgrades too.
     l5_exclude = exclude_for_level(stored_level)

--- a/cli/headers.py
+++ b/cli/headers.py
@@ -21,10 +21,49 @@ renders invisibly in tooling that respects markdown comments.
 
 from pathlib import Path
 
-
 _HEADER_START = "<!-- govkit:editable"
 _HEADER_END = "-->"
 _DEFAULT_SEE = "GOVKIT_SETUP_REVIEW.md"
+
+# Managed-block markers (A6, codex). An agent whose only instruction mechanism
+# is a shared file — codex's AGENTS.md — cannot have its governance moved to a
+# separate namespace. Instead govkit fences its governance between these markers
+# so a team's own content in the same file is preserved across upgrades.
+GOVKIT_BLOCK_BEGIN = "<!-- BEGIN GOVKIT GOVERNANCE -->"
+GOVKIT_BLOCK_END = "<!-- END GOVKIT GOVERNANCE -->"
+_BLOCK_NOTE = (
+    "<!-- Managed by govkit — content in this block is overwritten on "
+    "`govkit upgrade`. Put your own instructions outside it. -->"
+)
+
+
+def upsert_govkit_block(
+    existing: str | None, body: str, replace_unblocked: bool = False,
+) -> str:
+    """Return file content carrying govkit's governance in a managed block.
+
+    - `existing is None` (no file yet) ⇒ just the block.
+    - `existing` already contains a govkit block ⇒ the block's body is replaced
+      in place; everything before and after it is preserved byte-for-byte.
+    - `existing` has no block and `replace_unblocked` ⇒ the whole file is
+      replaced by the block. Used when the existing file is govkit's own
+      pre-block full-overwrite copy (nothing of the team's to keep).
+    - `existing` has no block and not `replace_unblocked` ⇒ the block is
+      appended below the team's content, which is preserved.
+    """
+    block = f"{GOVKIT_BLOCK_BEGIN}\n{_BLOCK_NOTE}\n{body.rstrip(chr(10))}\n{GOVKIT_BLOCK_END}\n"
+    if existing is None or replace_unblocked and GOVKIT_BLOCK_BEGIN not in existing:
+        return block
+
+    b_idx = existing.find(GOVKIT_BLOCK_BEGIN)
+    e_idx = existing.find(GOVKIT_BLOCK_END)
+    if b_idx != -1 and e_idx != -1 and e_idx > b_idx:
+        before = existing[:b_idx]
+        after = existing[e_idx + len(GOVKIT_BLOCK_END):]
+        return before + block.rstrip("\n") + after
+
+    # Team file with no block: keep it, append govkit's block below.
+    return existing.rstrip("\n") + "\n\n" + block
 
 
 def format_editable_header(

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from . import paths
 from .fs import copy_entry
+from .headers import GOVKIT_BLOCK_BEGIN, upsert_govkit_block
 from .marker import read_govkit_marker
 
 if TYPE_CHECKING:
@@ -64,6 +65,47 @@ def _unmodified_since(path: Path, applied_at: str | None) -> bool:
         return mtime_dt <= applied_dt
     except TypeError:
         return False
+
+
+def write_managed_agent_block(dest: Path, body: str, applied_at: str | None = None) -> None:
+    """Install govkit's governance into `dest` as a managed block.
+
+    For an agent (codex) whose only mechanism is a shared AGENTS.md, govkit
+    cannot move its governance elsewhere, so it fences it between markers and
+    preserves the team's own content in the same file. When the file already
+    exists without a block, it is replaced wholesale only if it is provably
+    govkit's own pre-block copy (byte-identical to the governance body, or
+    untouched since the marker's `applied_at`); otherwise it is treated as the
+    team's and the block is appended below their content.
+    """
+    existing: str | None = None
+    if dest.exists():
+        try:
+            existing = dest.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            existing = None
+    replace_unblocked = False
+    if existing is not None and GOVKIT_BLOCK_BEGIN not in existing:
+        replace_unblocked = existing == body or _unmodified_since(dest, applied_at)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(
+        upsert_govkit_block(existing, body, replace_unblocked=replace_unblocked),
+        encoding="utf-8",
+    )
+    print(f"  wrote   {dest}  (govkit governance block)")
+
+
+def install_agent_file(
+    agent_dir: Path, entry: dict, target: Path, applied_at: str | None = None,
+) -> None:
+    """Install one agent-file manifest entry: a managed block when the entry
+    opts in (`managed_block`), otherwise a plain overwrite copy."""
+    src = agent_dir / entry["src"]
+    dest = target / entry["dest"]
+    if entry.get("managed_block"):
+        write_managed_agent_block(dest, src.read_text(encoding="utf-8"), applied_at)
+    else:
+        copy_entry(src, dest)
 
 
 def reconcile_legacy_instruction_files(

--- a/governance/schemas/agent-manifest.schema.json
+++ b/governance/schemas/agent-manifest.schema.json
@@ -73,6 +73,10 @@
         "dest": {
           "type": "string",
           "description": "Destination path relative to the target project root"
+        },
+        "managed_block": {
+          "type": "boolean",
+          "description": "When true, govkit installs this file's content as a managed block fenced by BEGIN/END GOVKIT markers instead of overwriting the whole file, preserving a team's own content in the same file. Used for agents (codex) whose only instruction mechanism is a shared AGENTS.md."
         }
       }
     },

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -607,6 +607,43 @@ class TestMonorepoFixture:
                 assert "apps" not in f.file or "web" in f.file
 
 
+class TestCodexAgentsMdManagedBlock:
+    """Codex has no auto-loaded rules dir, so govkit's governance must live in
+    AGENTS.md. govkit fences it in a managed block so a team's own AGENTS.md
+    content survives apply/upgrade."""
+
+    def _apply(self, target: Path) -> None:
+        from cli.cmd_apply import cmd_apply
+
+        cmd_apply(argparse.Namespace(
+            agent="codex", target=str(target),
+            level="4", type="api", ci="github", stack=None,
+            force=False, detect=False,
+        ))
+
+    def test_fresh_install_writes_the_block(self, tmp_path):
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        self._apply(target)
+        content = (target / "AGENTS.md").read_text(encoding="utf-8")
+        assert "BEGIN GOVKIT GOVERNANCE" in content
+        assert "END GOVKIT GOVERNANCE" in content
+
+    def test_team_agents_md_content_is_preserved(self, tmp_path):
+        target = _copy_fixture("python-fastapi-github", tmp_path)
+        (target / "AGENTS.md").write_text(
+            "# ACME agent rules\nAlways use pnpm.\n", encoding="utf-8",
+        )
+        self._apply(target)
+
+        content = (target / "AGENTS.md").read_text(encoding="utf-8")
+        assert "# ACME agent rules" in content
+        assert "Always use pnpm." in content
+        assert "BEGIN GOVKIT GOVERNANCE" in content
+        # Exactly one managed block, and the team's content leads.
+        assert content.count("BEGIN GOVKIT GOVERNANCE") == 1
+        assert content.index("ACME") < content.index("BEGIN GOVKIT GOVERNANCE")
+
+
 class TestGovernanceLivesInRulesNamespace:
     """govkit's agent instructions install into its own auto-loaded rules
     namespace, not the team's top-level CLAUDE.md. This is what lets a team's

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2440,6 +2440,63 @@ def _make_governance_repo(tmp_path: Path, agent: str = "test-agent") -> tuple[Pa
     return tmp_path, body
 
 
+class TestWriteManagedAgentBlock:
+    """A6: the codex AGENTS.md writer must replace govkit's own pre-block file
+    wholesale, but preserve a team's content by appending the block below it."""
+
+    def test_govkit_byte_identical_file_is_replaced_not_appended(self, tmp_path):
+        from cli.install_common import write_managed_agent_block
+
+        body = "# govkit governance\nRules.\n"
+        dest = tmp_path / "AGENTS.md"
+        dest.write_text(body, encoding="utf-8")  # govkit's old full-overwrite copy
+
+        write_managed_agent_block(dest, body)
+
+        out = dest.read_text(encoding="utf-8")
+        assert out.count("BEGIN GOVKIT GOVERNANCE") == 1
+        # The body appears once (inside the block) — the old unblocked copy was
+        # replaced, not left above a duplicate in the block.
+        assert out.count("Rules.") == 1
+
+    def test_untouched_since_applied_at_is_replaced(self, tmp_path):
+        import os
+        from datetime import datetime, timezone
+
+        from cli.install_common import write_managed_agent_block
+
+        dest = tmp_path / "AGENTS.md"
+        dest.write_text("# OLD govkit v0.10 governance\n", encoding="utf-8")
+        stamp = datetime(2025, 12, 1, tzinfo=timezone.utc).timestamp()
+        os.utime(dest, (stamp, stamp))
+        applied_at = datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat()
+
+        write_managed_agent_block(dest, "# NEW governance\n", applied_at)
+
+        out = dest.read_text(encoding="utf-8")
+        assert "OLD govkit v0.10" not in out
+        assert "NEW governance" in out
+
+    def test_team_file_is_preserved_and_block_appended(self, tmp_path):
+        import os
+        from datetime import datetime, timezone
+
+        from cli.install_common import write_managed_agent_block
+
+        dest = tmp_path / "AGENTS.md"
+        dest.write_text("# ACME rules\nUse pnpm.\n", encoding="utf-8")
+        stamp = datetime(2026, 6, 1, tzinfo=timezone.utc).timestamp()  # after applied_at
+        os.utime(dest, (stamp, stamp))
+        applied_at = datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat()
+
+        write_managed_agent_block(dest, "# govkit governance\n", applied_at)
+
+        out = dest.read_text(encoding="utf-8")
+        assert "# ACME rules" in out
+        assert "Use pnpm." in out
+        assert out.index("ACME") < out.index("BEGIN GOVKIT GOVERNANCE")
+
+
 class TestUpgradeMigratesLegacyInstructionFile:
     """A6: an existing install carries govkit's old top-level CLAUDE.md. Once
     governance moves into the rules namespace, upgrade must retire the orphan —

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -5,7 +5,6 @@ installed editable doc gets a top header that records its baseline so doctor
 can detect staleness and edit-protection can preserve team changes.
 """
 
-import pytest
 
 
 class TestFormatEditableHeader:
@@ -153,7 +152,7 @@ class TestPrependHeaderToFile:
     def test_does_not_duplicate_existing_header(self, tmp_path):
         """If the file already starts with an editable header, prepending must
         not stack a second one."""
-        from cli.headers import prepend_header_to_file, format_editable_header
+        from cli.headers import format_editable_header, prepend_header_to_file
 
         existing = format_editable_header(baseline="govkit@0.10.0")
         doc = tmp_path / "TECH_STACK.md"
@@ -189,3 +188,58 @@ class TestPrependHeaderToFile:
         # Should not raise.
         prepend_header_to_file(missing, baseline="govkit@0.10.0")
         assert not missing.exists()
+
+
+class TestUpsertGovkitBlock:
+    """Codex has no auto-loaded rules dir, so govkit's governance must live in
+    AGENTS.md. The managed block lets govkit own its governance in-file while
+    preserving whatever the team wrote around it."""
+
+    def _markers(self):
+        from cli.headers import GOVKIT_BLOCK_BEGIN, GOVKIT_BLOCK_END
+        return GOVKIT_BLOCK_BEGIN, GOVKIT_BLOCK_END
+
+    def test_new_file_is_just_the_block(self):
+        from cli.headers import upsert_govkit_block
+        begin, end = self._markers()
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        assert out.startswith(begin)
+        assert end in out
+        assert "GOVERNANCE BODY" in out
+
+    def test_team_file_without_block_keeps_team_content(self):
+        from cli.headers import upsert_govkit_block
+        begin, end = self._markers()
+
+        team = "# ACME AGENTS.md\nUse pnpm.\n"
+        out = upsert_govkit_block(team, "GOVERNANCE BODY")
+        assert "# ACME AGENTS.md" in out
+        assert "Use pnpm." in out
+        assert begin in out and end in out
+        # Team content comes first; govkit's block is appended below it.
+        assert out.index("ACME") < out.index(begin)
+
+    def test_existing_block_is_replaced_in_place(self):
+        from cli.headers import upsert_govkit_block
+        begin, end = self._markers()
+
+        before = f"# team top\n\n{begin}\nOLD GOVERNANCE\n{end}\n\n# team bottom\n"
+        out = upsert_govkit_block(before, "NEW GOVERNANCE")
+        assert "NEW GOVERNANCE" in out
+        assert "OLD GOVERNANCE" not in out
+        assert "# team top" in out
+        assert "# team bottom" in out
+        # Exactly one block after replacement.
+        assert out.count(begin) == 1
+        assert out.count(end) == 1
+
+    def test_replace_unblocked_replaces_whole_file(self):
+        """An existing govkit full-overwrite AGENTS.md (no block) is govkit's
+        own — replace it wholesale with the block, not append to it."""
+        from cli.headers import upsert_govkit_block
+
+        old_full = "# old govkit governance, no markers\n"
+        out = upsert_govkit_block(old_full, "NEW GOVERNANCE", replace_unblocked=True)
+        assert "old govkit governance" not in out
+        assert "NEW GOVERNANCE" in out


### PR DESCRIPTION
Stacked on #51 (retarget to `main` once #51 merges).

## Why

#51 stopped govkit overwriting the team's instruction file for claude-code and copilot by moving governance into each agent's native auto-loaded rules directory. **Codex has no such directory** — its only instruction mechanism is `AGENTS.md` — so that approach can't apply, and govkit was still overwriting `AGENTS.md` wholesale, destroying any content a team kept there.

## What

Install codex's root governance as a **managed block** instead, fenced by `<!-- BEGIN GOVKIT GOVERNANCE -->` / `<!-- END GOVKIT GOVERNANCE -->`:

| Existing `AGENTS.md` | Result |
|---|---|
| none | write the block |
| has a govkit block | replace the block body in place, preserve everything around it |
| no block, provably govkit's own (byte-identical, or untouched since `applied_at`) | replace wholesale — a pre-block install migrates with no duplicate |
| no block, the team's | keep it; append the block below |

`upsert_govkit_block` (pure string surgery, `headers.py`) + `write_managed_agent_block` / `install_agent_file` (`install_common.py`, file I/O + govkit-vs-team detection, reusing #51's `applied_at` signal). Both `apply` and `upgrade` route their agent-files loop through `install_agent_file`, which honors a schema-validated per-entry `managed_block` flag; only codex's 14 root `AGENTS.md` entries set it.

## Scope

**Root `AGENTS.md` only.** The 19 nested per-layer `AGENTS.md` files are codex's rules equivalent and are deferred alongside the rule/skill name-collision namespacing — consistent with how claude-code's flat rules are deferred in #51.

## Tests

TDD; verified end-to-end (fresh install, team-content preserved with block appended, pre-block upgrade replaced without duplication). New: `TestUpsertGovkitBlock`, `TestWriteManagedAgentBlock`, `TestCodexAgentsMdManagedBlock`. **Full suite: 1023 passed, 1 skipped, 3 xfailed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)