### PR TITLE
refactor(govkit): single owner for stack marker records (dedup two write paths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed — internal
 
+- The two stack marker records (the `stack.id` assumption and the `stack`
+  metadata block) are now built only by `stack_select.build_stack_assumption`
+  / `build_stack_meta`; `govkit stack apply` consumes them instead of
+  inlining copies, so the two write paths cannot drift apart. See
+  `plans/STACK_RECORD_DEDUP_PLAN.md`.
 - The three one-time migration warnings in `cli/marker.py` (version, shape,
   directory) now share a single `_OneTimeWarning` value object instead of
   three copies of the flag/env-check/reset machinery. Messages, suppression

--- a/cli/cmd_stack.py
+++ b/cli/cmd_stack.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 
 import argparse
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 
 from .marker import read_govkit_marker, write_govkit_marker
 from .overlay import apply_overlay, list_overlays, load_overlay
 from .setup_review import print_review_checklist, write_setup_review
 from .skill_context import write_skill_context
-from .stack_select import STACK_ID_ASSUMPTION
+from .stack_select import STACK_ID_ASSUMPTION, build_stack_assumption, build_stack_meta
 
 
 def cmd_stack_list(_args: argparse.Namespace) -> None:
@@ -83,26 +82,14 @@ def cmd_stack_apply(args: argparse.Namespace) -> None:
     print(f"  {overlay.display_name}\n")
     apply_overlay(overlay, target, applied_at=prior_applied_at, force=args.force)
 
-    stack_meta = {
-        "id": overlay.id,
-        "version": overlay.version,
-        "display_name": overlay.display_name,
-        "applied_at": datetime.now(timezone.utc).isoformat(),
-    }
-    # Replace any prior stack.id assumption; keep the rest.
+    stack_meta = build_stack_meta(overlay)
+    # Replace any prior stack.id assumption; keep the rest. The stack id is
+    # an explicit CLI argument here, so source/confidence mirror the --stack
+    # flag path in apply.
     assumptions = [a for a in prior_assumptions if a.get("id") != STACK_ID_ASSUMPTION]
-    assumptions.append({
-        "id": STACK_ID_ASSUMPTION,
-        "value": overlay.id,
-        "source": "flag",
-        "confidence": "high",
-        "evidence": [],
-        "files_affected": [d["dest"] for d in overlay.docs],
-        "review_required": False,
-        "warning_message": None,
-        "calibrated_at": None,
-        "calibrated_against_overlay_version": None,
-    })
+    assumptions.append(
+        build_stack_assumption(overlay, source="flag", confidence="high", evidence=[])
+    )
 
     write_govkit_marker(
         target, agent, level, options,

--- a/cli/stack_select.py
+++ b/cli/stack_select.py
@@ -141,10 +141,15 @@ def print_detection_summary(
     _print_chosen_stack_line(inferred_stack, inferred_confidence, chosen_stack, stack_source)
 
 
-def _build_stack_assumption(
+def build_stack_assumption(
     overlay, source: str, confidence: str, evidence: list[str],
 ) -> dict:
-    """Construct the `stack.id` assumption block to write into the marker."""
+    """Construct the `stack.id` assumption block to write into the marker.
+
+    Single point of definition for the record shape — `govkit apply --stack`
+    (via apply_stack_overlay) and `govkit stack apply` (cmd_stack) both
+    consume it so the two write paths cannot drift apart.
+    """
     return {
         "id": STACK_ID_ASSUMPTION,
         "value": overlay.id,
@@ -159,6 +164,20 @@ def _build_stack_assumption(
         ) if source == "default" else None,
         "calibrated_at": None,
         "calibrated_against_overlay_version": None,
+    }
+
+
+def build_stack_meta(overlay) -> dict:
+    """Construct the marker's `stack` metadata block, stamped now.
+
+    Shared by apply_stack_overlay and cmd_stack for the same
+    single-point-of-definition reason as build_stack_assumption.
+    """
+    return {
+        "id": overlay.id,
+        "version": overlay.version,
+        "display_name": overlay.display_name,
+        "applied_at": datetime.now(timezone.utc).isoformat(),
     }
 
 
@@ -202,13 +221,8 @@ def apply_stack_overlay(
     print(f"\nStack overlay: {overlay.id} ({overlay.display_name})")
     apply_overlay(overlay, target, applied_at=prior_applied_at, force=force)
 
-    stack_meta = {
-        "id": overlay.id,
-        "version": overlay.version,
-        "display_name": overlay.display_name,
-        "applied_at": datetime.now(timezone.utc).isoformat(),
-    }
-    stack_assumption = _build_stack_assumption(overlay, source, confidence, evidence)
+    stack_meta = build_stack_meta(overlay)
+    stack_assumption = build_stack_assumption(overlay, source, confidence, evidence)
     # Persist the chosen stack in marker.options so future commands
     # (upgrade, stack apply, doctor) know what was selected.
     return stack_meta, stack_assumption, {**options, "stack": overlay.id}, profile

--- a/tests/test_stack_select.py
+++ b/tests/test_stack_select.py
@@ -96,3 +96,53 @@ class TestResolveStackChoiceTypeCompatibility:
         )
         assert chosen == "dotnet-aspnet"
         assert source == "detected"
+
+
+class TestStackMarkerRecordBuilders:
+    """build_stack_assumption / build_stack_meta are the single point of
+    construction for the two stack records written into the marker — both
+    `govkit apply --stack` and `govkit stack apply` must consume them so the
+    record shapes cannot drift apart."""
+
+    def _overlay(self):
+        from cli.overlay import load_overlay
+
+        overlay = load_overlay("python-fastapi")
+        assert overlay is not None
+        return overlay
+
+    def test_assumption_from_flag_source(self):
+        from cli.stack_select import build_stack_assumption
+
+        overlay = self._overlay()
+        a = build_stack_assumption(overlay, source="flag", confidence="high", evidence=[])
+        assert a["id"] == "stack.id"
+        assert a["value"] == "python-fastapi"
+        assert a["source"] == "flag"
+        assert a["confidence"] == "high"
+        assert a["evidence"] == []
+        assert a["files_affected"] == [d["dest"] for d in overlay.docs]
+        assert a["review_required"] is False
+        assert a["warning_message"] is None
+        assert a["calibrated_at"] is None
+        assert a["calibrated_against_overlay_version"] is None
+
+    def test_assumption_from_default_source_requires_review(self):
+        from cli.stack_select import build_stack_assumption
+
+        a = build_stack_assumption(self._overlay(), source="default", confidence="low", evidence=[])
+        assert a["review_required"] is True
+        assert "python-fastapi" in a["warning_message"]
+
+    def test_stack_meta_shape(self):
+        from datetime import datetime
+
+        from cli.stack_select import build_stack_meta
+
+        overlay = self._overlay()
+        meta = build_stack_meta(overlay)
+        assert set(meta) == {"id", "version", "display_name", "applied_at"}
+        assert meta["id"] == overlay.id
+        assert meta["version"] == overlay.version
+        assert meta["display_name"] == overlay.display_name
+        datetime.fromisoformat(meta["applied_at"])  # parseable timestamp


### PR DESCRIPTION
## What

The two stack marker records — the `stack.id` assumption and the `stack` metadata block — were built by inlined copies in more than one place, so the write paths could drift apart. This promotes them to shared builders and makes `govkit stack apply` consume those instead of its own copies.

- `stack_select.build_stack_assumption` / `build_stack_meta` become the single owners of record construction.
- `govkit stack apply` calls the shared builders instead of inlining its own versions, so both write paths stay in lock-step.

See `plans/STACK_RECORD_DEDUP_PLAN.md`.

## Changes

- `cli/stack_select.py` — promote the shared record builders.
- `cli/cmd_stack.py` — `stack apply` consumes the shared builders (drops inlined copies).
- `tests/test_stack_select.py` — coverage for the shared builders.
- `CHANGELOG.md` — record the dedup.

## Notes

- Refactor only — no behavior change intended; the two write paths now produce identical records by construction.
- Rebased onto current `main`; merges cleanly.
- `pytest tests/test_stack_select.py tests/test_govkit.py` → 297 passed; ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)