### PR TITLE
feat: add skill-oriented agent architecture extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Added the bundled `skill-oriented-agent-architecture` extension. It translates
+  approved SOAA v0.2 decisions into five progressively loaded contract sets for
+  core semantics, selection and authority, context and resilience, assurance,
+  and lifecycle interoperability. The package is provider-neutral, supersedes
+  the generic `AGENT_ARCHITECTURE.md` when installed, and includes focused
+  validation and installation tests.
+
 ### Fixed
 
 - `govkit upgrade` no longer erases the team's calibration. It wrote the marker

--- a/README.md
+++ b/README.md
@@ -510,7 +510,7 @@ See [`cli/stacks/README.md`](cli/stacks/README.md) for the complete guide, inclu
 
 ## Extensions
 
-Govkit ships **optional extension packs** that layer additional architecture contracts on top of the core kit — currently `agentic-skills` and `vision-inference`. Add one with `govkit extension add`, or drop the folder in by hand; either way the folder under `extensions/<id>/` in your project *is* the install.
+Govkit ships **optional extension packs** that layer additional architecture contracts on top of the core kit — currently `agentic-skills`, `skill-oriented-agent-architecture`, and `vision-inference`. Add one with `govkit extension add`, or drop the folder in by hand; either way the folder under `extensions/<id>/` in your project *is* the install.
 
 ### How to add an extension
 
@@ -519,6 +519,7 @@ The quickest path is the bundled-pack command:
 ```bash
 govkit extension list                              # see what's bundled
 govkit extension add vision-inference --target .   # copy it into extensions/vision-inference/
+govkit extension add skill-oriented-agent-architecture --target .
 ```
 
 `add` copies the pack into your project's `extensions/<id>/` and validates it in place. It **warns but proceeds** if the pack's `supported_levels` / `supported_project_types` don't match your `.govkit` marker, or if a core contract it `extends` isn't installed yet (e.g. a generative pack's L5 contracts in a non-L5 project). Pass `--force` to overwrite an existing folder.
@@ -549,7 +550,7 @@ govkit extension add vision-inference --target .   # copy it into extensions/vis
 
 When `extensions/` is absent, govkit behaves exactly as it does without extensions — they are entirely optional.
 
-See `extensions/agentic-skills/` and `extensions/vision-inference/` in this repository for complete reference examples.
+See `extensions/skill-oriented-agent-architecture/` and `extensions/vision-inference/` in this repository for complete reference examples. The older `agentic-skills/` package remains available for its product-specific skill-family and phase model. Do not install it beside `skill-oriented-agent-architecture`.
 
 ### Authoring an extension
 

--- a/extensions/skill-oriented-agent-architecture/README.md
+++ b/extensions/skill-oriented-agent-architecture/README.md
@@ -27,6 +27,12 @@ Install this extension for an API or CLI application with one or more of these c
 
 This extension governs the application being built. It is distinct from the Agent Skills packages used by Codex, Claude Code, or Copilot to guide software delivery.
 
+## Agent Skills compatibility
+
+The SOAA package profile preserves a standard root `SKILL.md` and places governance metadata in an additional `soaa/` directory permitted by the Agent Skills format. A generic Agent Skills client may ignore the SOAA files and process the standard skill, but it must not claim SOAA conformance. A SOAA-aware runtime validates both the Agent Skills format and the SOAA profile before admission.
+
+See [`SKILL_CONTRACT.md`](docs/backend/architecture/SKILL_CONTRACT.md) for the normative flat metadata keys, two-stage validation rule, and `allowed-tools` authority boundary.
+
 ## Install
 
 ```bash

--- a/extensions/skill-oriented-agent-architecture/README.md
+++ b/extensions/skill-oriented-agent-architecture/README.md
@@ -1,0 +1,96 @@
+# Skill-Oriented Agent Architecture Extension
+
+## Purpose
+
+The `skill-oriented-agent-architecture` extension guides coding agents building applications in which an accountable agent run selects and applies governed procedural skills.
+
+It implements a GovKit guidance profile derived from the approved Skill-Oriented Agent Architecture v0.2 specification dated 2026-07-18.
+
+The central boundary is:
+
+> A skill supplies procedure. Trusted runtime components retain authority, state, side-effect control, evaluation, and completion.
+
+## Intended use
+
+Install this extension for an API or CLI application with one or more of these characteristics:
+
+- Adaptive agent execution
+- Dynamic or fixed skill binding
+- Tool or executable-asset invocation
+- Human approval before consequential action
+- Multi-skill composition
+- Agent delegation or task handoff
+- Governed context or memory
+- Agent and skill evaluation
+- Skill release lifecycle management
+- MCP or A2A interoperability
+
+This extension governs the application being built. It is distinct from the Agent Skills packages used by Codex, Claude Code, or Copilot to guide software delivery.
+
+## Install
+
+```bash
+govkit extension add skill-oriented-agent-architecture --target .
+```
+
+The extension targets GovKit Level 5 backend API and CLI projects. Its manifest supersedes the generic core `AGENT_ARCHITECTURE.md` contract for the consuming project. Record the supersession in an ADR during architecture preflight.
+
+## Contract loading
+
+Load `soaa_core` for every feature in scope. Load the remaining sets only when the feature touches their concerns.
+
+| Contract set | Load when the feature touches |
+|---|---|
+| `soaa_core` | Agents, skills, task ownership, runtime state, orchestration |
+| `soaa_selection_authority` | Catalogs, selection, activation, policy, permissions, approvals |
+| `soaa_context_resilience` | Context, memory, resources, retries, recovery, budgets, telemetry |
+| `soaa_assurance` | Evaluation, evidence, verification, completion, conformance |
+| `soaa_ecosystem` | Releases, package integrity, versioning, MCP, A2A, portability |
+
+This structure preserves progressive disclosure. A coding agent should not load every contract for every feature.
+
+## Architecture documents
+
+The extension ships these guidance contracts under `docs/backend/architecture/`:
+
+- `SKILL_ORIENTED_AGENT_ARCHITECTURE.md`
+- `SKILL_CONTRACT.md`
+- `RUNTIME_STATE_AND_EXECUTION_CONTRACT.md`
+- `SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md`
+- `AUTHORITY_AND_APPROVAL_CONTRACT.md`
+- `CONTEXT_MEMORY_AND_RESOURCE_CONTRACT.md`
+- `RESILIENCE_AND_RECOVERY_CONTRACT.md`
+- `EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md`
+- `SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md`
+
+Each document identifies its approved SOAA decision scope and invariant range.
+
+## Relationship to LLM application governance
+
+SOAA does not prescribe an LLM provider, model family, gateway product, evaluation product, observability product, or guardrail product.
+
+The present GovKit Level 5 baseline supplies:
+
+- `LLM_GATEWAY_CONTRACT.md`
+- `EVALUATION_LLM_CONTRACT.md`
+- `OBSERVABILITY_LLM_CONTRACT.md`
+- `GUARDRAILS_CONTRACT.md`
+
+Those concerns apply to LLM applications without skills and belong in a separate `llm-application` extension. Until GovKit extracts that package, this extension declares relationships to the Level 5 core contracts without duplicating them.
+
+## Source authority and limits
+
+This package is an implementation-guidance profile. It does not by itself establish SOAA conformance.
+
+SOAA v0.2 conformance requires the approved normative modules, all 206 invariant-to-assertion identities, released schemas, fixtures, adapters, oracles, and a valid evidence package. The current SOAA source set records the conformance suite and reference runtime as future implementation work.
+
+Where this guidance conflicts with a higher SOAA authority, use this precedence:
+
+1. Approved invariant
+2. Approved decision record
+3. Applied midpoint amendment
+4. SOAA v0.2 root cross-module rule
+5. Most specific approved module contract
+6. This GovKit guidance profile
+
+An unresolved conflict blocks implementation and enters architecture review.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/AUTHORITY_AND_APPROVAL_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/AUTHORITY_AND_APPROVAL_CONTRACT.md
@@ -1,0 +1,201 @@
+# Authority and Approval Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decisions | SOAA-007, SOAA-008 |
+| Primary invariants | SOAA-INV-025 through SOAA-INV-031 |
+| Source module | SOAA Packet 2 |
+
+## Purpose
+
+This contract keeps procedural guidance separate from runtime authority. A skill declares access needs and ceilings. Trusted policy components derive and enforce the authority available for the current task and operation.
+
+## Authority rule
+
+A skill never grants authority.
+
+```text
+BaseAuthority(context) =
+    PrincipalGrants
+    INTERSECT AgentBoundary
+    INTERSECT TaskBoundary
+    INTERSECT PolicyBoundary
+    INTERSECT RuntimeBoundary
+
+EffectiveAuthority(skill, context) =
+    BaseAuthority
+    INTERSECT ToolBoundary
+    INTERSECT RequestedSkillScope
+    MINUS ExplicitDenies
+```
+
+Activation is permitted only when:
+
+```text
+RequiredAccess(skill) SUBSET_OF EffectiveAuthority(skill, context)
+```
+
+Explicit denies take precedence over grants, prompts, descriptions, model output, user requests, and approval text.
+
+## Capability tuple
+
+Represent authority as typed capabilities with at least:
+
+- Action
+- Resource or target scope
+- Data classification
+- Tenant or organizational scope
+- Environment
+- Purpose
+- Side-effect class
+- Constraints
+- Expiry
+- Grant and deny references
+
+String tool names alone are insufficient authority records.
+
+## Fresh operation authorization
+
+Activation-time authority is a ceiling, not a reusable permit.
+
+The Policy and Authority Controller must authorize every external operation immediately before execution. Reauthorization is required after any material change to:
+
+- Principal or runtime owner
+- Owner epoch or task revision
+- Policy or grant set
+- Approval scope or expiry
+- Skill release or lifecycle state
+- Tool interface or target
+- Context, environment, or data classification
+- Budget or risk state
+
+Revocation blocks the next operation and any resume, retry, recovery, or asset execution covered by the revoked scope.
+
+## Approval contract
+
+Approval is:
+
+- Scoped to an exact action or capability
+- Bound to a task, principal, and decision authority
+- Purpose-bound
+- Time-bounded
+- Condition-bound
+- Revocable
+- Evidence-linked
+
+An ApprovalRecord must contain:
+
+- Request and decision identities
+- Requested action or capability
+- Task and skill context
+- Current authority gap
+- Proposed scope and conditions
+- Required decision authority
+- Approver identity and role
+- Decision, rationale summary, and timestamp
+- Expiry and revocation state
+- Evidence references
+
+Approval changes authority context. It does not change package integrity, accountable principal, or task ownership by itself.
+
+## Approval outcomes
+
+Supported outcomes are:
+
+- Approved
+- Denied
+- Changes required
+- Expired
+- Revoked
+- Canceled
+
+After approval, all hard controls and current inputs must be re-evaluated. An approval never converts an incompatible, untrusted, stale, or revoked skill into an eligible release.
+
+## Human roles
+
+Keep these roles distinct:
+
+| Role | Responsibility |
+|---|---|
+| Reviewer | Assesses evidence or content |
+| Approver | Commits a scoped consequential decision |
+| Human execution owner | Owns active task execution after authorized takeover |
+| Accountable principal | Retains accountability for intent and consequences |
+
+A reviewer does not gain approval authority. Approval does not transfer execution ownership. Human takeover requires a separate atomic owner transition.
+
+## Instruction precedence
+
+Apply this order:
+
+1. System and platform safety policy
+2. Organization and application policy
+3. Accepted task contract and principal intent
+4. Approved workflow and architecture constraints
+5. Active skill instructions
+6. Current user interaction inside task scope
+7. Tool, resource, memory, protocol, and retrieved content
+
+Lower-precedence content cannot override a higher layer. Same-level conflict blocks the affected action until resolved.
+
+Data-to-instruction promotion requires an explicit trusted transformation and policy decision. Content never promotes itself.
+
+## Tool and side-effect boundary
+
+Every tool contract must declare:
+
+- Interface and version
+- Input and output schemas
+- Side-effect class
+- Required capability tuple
+- Idempotency behavior
+- Failure and status behavior
+- Cancellation support
+- Reconciliation and compensation behavior
+- Evidence requirements
+
+Agents propose operations. The Policy and Authority Controller authorizes. The Tool Gateway or Skill Asset Runner executes. The State Repository and Evidence Recorder preserve the outcome.
+
+Credentials remain inside trusted adapters. A model, prompt, skill, MCP server description, or A2A Agent Card never receives or implies a credential grant.
+
+## Prohibited patterns
+
+- Permission declarations inside prompt text
+- Using `allowed-tools` as an authorization decision
+- Reusing stale activation authority for a later operation
+- Approval after the side effect
+- Broad approval for hidden batches
+- Approval by an unauthorized identity
+- Treating chat acknowledgment, elicitation, or authentication as approval
+- A skill requesting more access than its declared ceiling
+- Policy downgrade during fallback
+
+## Required evidence
+
+Record:
+
+- Inputs to authority calculation
+- Effective capability set and explicit denies
+- Approval request and decision
+- Fresh operation authorization
+- Tool or asset identity
+- Side-effect class and target
+- Idempotency key
+- Result certainty
+- Revocation and reauthorization events
+
+## Verification
+
+Tests must prove:
+
+- Skill metadata contains no self-issued grant.
+- Effective authority equals the intersection and deny calculation.
+- Every missing required capability blocks activation.
+- Approval leaves package identity unchanged.
+- Revocation blocks the next covered operation.
+- Injection content cannot change precedence or authority.
+- Unauthorized reviewers cannot approve.
+- A valid credential does not count as approval.
+- Fallback never broadens authority.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/CONTEXT_MEMORY_AND_RESOURCE_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/CONTEXT_MEMORY_AND_RESOURCE_CONTRACT.md
@@ -1,0 +1,236 @@
+# Context, Memory, and Resource Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decision | SOAA-014 |
+| Primary invariants | SOAA-INV-068 through SOAA-INV-088 |
+| Source module | SOAA Packet 4 |
+
+## Purpose
+
+This contract treats context as an immutable, authorized projection of durable sources. Long context is not authoritative memory. Retrieval rank is not truth, permission, or instruction precedence.
+
+## Context source classes
+
+Every context item must retain a source class:
+
+- System or platform policy
+- Organization or application policy
+- Accepted task contract
+- Workflow or architecture constraint
+- Active skill instruction
+- Current task interaction
+- Tool observation
+- Resource
+- Memory
+- Remote protocol content
+- Derived summary
+
+Trust metadata describes origin, integrity, validation, scope, and freshness. It never declares universal truth.
+
+## Immutable ContextSnapshot
+
+Every model invocation binds one immutable ContextSnapshot containing:
+
+- Snapshot identity and digest
+- Task identity and revision
+- Owner identity and epoch
+- Authority-context identity
+- Active skill releases and activation identities
+- Composition-plan version
+- Policy and instruction-profile versions
+- Resource and memory references
+- Source classes and precedence
+- Token, data, privacy, and cost budgets
+- Data classifications and tenant scope
+- Creation time and expiry
+
+A change to any controlling identity makes the snapshot stale. Stale snapshots reject model invocation and operation proposals.
+
+## Assembly pipeline
+
+The Context Controller must:
+
+1. Load the accepted task and control references.
+2. Apply authorization and tenant filters.
+3. Reserve protected budget for policy, task, authority, and output schema.
+4. Retrieve only relevant discovery metadata.
+5. Load active skill instructions after activation commit.
+6. Retrieve supporting resources or assets on demand.
+7. Apply classification, redaction, minimization, and precedence labels.
+8. Validate budget and integrity.
+9. Commit the immutable snapshot.
+
+Context assembly performs no external mutation and grants no authority.
+
+## Progressive disclosure
+
+Skill content loads in three stages:
+
+1. Discovery metadata
+2. Activated procedural instructions
+3. Supporting references and assets on demand
+
+Full instructions remain unavailable before activation. Executable assets never run during disclosure.
+
+## Context budgets
+
+Budgets must cover:
+
+- Total tokens or bytes
+- Protected control allocation
+- Skill instructions
+- Resources and memory
+- Tool observations
+- Output reservation
+- Sensitive-data allowance
+
+Minimization must prefer:
+
+- Structured records over broad dumps
+- Relevant excerpts over full documents
+- References over duplicated content
+- Current authoritative state over conversational summaries
+- Explicit omission over silent truncation
+
+Position inside a long prompt must not determine enforcement. Critical controls require deterministic enforcement outside context.
+
+## Compaction
+
+Compaction creates a derived summary. It must preserve:
+
+- Task and owner identities
+- Current task revision and state
+- Active skill releases
+- Authority, approval, and policy references
+- Plan and dependency state
+- Outstanding operations and uncertainty
+- Budget state
+- Completion criteria and evidence obligations
+- Source lineage
+- Material omissions and information loss
+- Compaction method, validator, and digest
+
+Original records and evidence remain unchanged.
+
+Rehydration reloads authoritative sources, verifies the compacted summary, and creates a new ContextSnapshot. Summary text alone never reconstructs authoritative state.
+
+## Resource contract
+
+Every ResourceDescriptor must state:
+
+- Source and owner
+- Trust and validation status
+- Scope and authorized audience
+- Data classification
+- Freshness and expiry
+- Integrity identity
+- Transformation lineage
+- Instruction classification
+- Limitations
+
+Resource content remains data. A document, website, MCP resource, A2A artifact, tool output, or retrieved prompt fragment cannot grant permission or override instructions.
+
+## Memory types
+
+Supported memory types include:
+
+- Working
+- Episodic
+- Semantic
+- Procedural reference
+- Preference
+- Operational
+
+Every MemoryRecord must contain:
+
+- Type and scope
+- Source and provenance
+- Trust and validation state
+- Tenant and task boundaries
+- Data classification
+- Authorized readers and writers
+- Purpose and retention
+- Supersession relation
+- Integrity identity
+- Created, refreshed, and expiry times
+
+## Memory read and write
+
+The Memory Gateway owns controlled reads and writes.
+
+Memory reads require:
+
+- Current task purpose
+- Authorized scope
+- Type compatibility
+- Freshness
+- Tenant isolation
+- Data minimization
+
+Memory writes require:
+
+- Typed record
+- Provenance
+- Validation
+- Classification
+- Retention
+- Authorized writer
+- Promotion state
+
+Model output proposes a memory write. It never commits one directly.
+
+Memory must not mutate:
+
+- Task or ownership
+- Skill release or activation
+- Workflow or policy
+- Authority or approval
+- Evidence records
+
+## Poisoning and isolation controls
+
+The runtime must protect against:
+
+- Cross-tenant retrieval
+- Prompt injection in resources or memory
+- Model-generated self-promotion
+- Untrusted content marked as policy
+- Stale or superseded memory
+- Hidden executable content
+- Summary corruption
+- Excessive retention
+
+Quarantined or unvalidated content receives no instruction role and no write access.
+
+## Required evidence
+
+Record:
+
+- Snapshot identity and source inventory
+- Authorization and filtering decisions
+- Disclosure stage
+- Classification and redaction actions
+- Budget allocation and omissions
+- Resource and memory provenance
+- Compaction lineage and loss disclosure
+- Staleness rejection
+- Memory write proposal and commit decision
+
+## Verification
+
+Tests must prove:
+
+- Any controlling revision invalidates the snapshot.
+- Restart succeeds without provider transcript state.
+- Injection cannot elevate resource or memory content.
+- Retrieval rank changes do not change authority or precedence.
+- Full skill instructions remain hidden before activation.
+- Context limits preserve protected control fields.
+- Repeated compaction leaves original sources intact.
+- Corrupted summaries recover from authoritative sources.
+- Cross-tenant and over-broad memory reads fail.
+- Direct model memory writes create no record.
+- Memory cannot mutate task, policy, authority, skill, or evidence aggregates.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md
@@ -1,0 +1,250 @@
+# Evaluation, Evidence, and Completion Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decisions | SOAA-016 and SOAA-017 |
+| Primary invariants | SOAA-INV-103 through SOAA-INV-146 |
+| Source module | SOAA Packet 5 |
+
+## Purpose
+
+This contract separates evaluation, evidence, gate decisions, task completion, and conformance. Agent confidence, skill success, fluent explanation, and absence of visible error are never sufficient completion evidence.
+
+## Separate concepts
+
+| Concept | Meaning | Authoritative owner |
+|---|---|---|
+| Evaluation | Measurement of a target against explicit criteria | Evaluation Controller |
+| Evidence | Immutable source-linked observation record | Evidence Recorder |
+| Gate decision | Deterministic application of policy to evaluated claims | Evaluation Controller |
+| Completion | Task lifecycle transition after gate pass | Task Controller |
+| Conformance | Requirement adherence for a named profile | Conformance assessor and report authority |
+
+## Evaluation modes
+
+Use the modes relevant to the governing decision:
+
+- Design evaluation
+- Skill admission
+- Capability evaluation
+- Regression evaluation
+- Runtime gate
+- Completion evaluation
+- Production shadow evaluation
+- Incident evaluation
+- Conformance evaluation
+
+Evaluation definitions are versioned governed artifacts. Threshold, rubric, grader, dataset, aggregation, independence, or blocking-rule changes create new versions.
+
+## Evaluation definition
+
+An EvaluationDefinition must identify:
+
+- Purpose and mode
+- Target and risk classes
+- Dimensions and suites
+- Graders, metrics, thresholds, and aggregation
+- Blocking criteria
+- Independence requirements
+- Human-review triggers
+- Evidence and environment profiles
+- Budget and data classification
+- Owner, approver, validity, integrity, and limitations
+
+Blocking criteria remain separate from aggregate scores. Efficiency or stylistic quality never offsets a blocking correctness, safety, security, authority, or evidence failure.
+
+## Evaluation cases and datasets
+
+Cases must include applicable:
+
+- Positive behavior
+- Negative behavior
+- Null selection
+- Denial
+- Escalation
+- Failure and recovery
+- Adversarial behavior
+
+Every case must define allowed and prohibited inputs, expected and prohibited outcomes, mandatory path controls, grader bindings, risk tags, origin, data classification, solvability, ambiguity, contamination controls, integrity, and limitations.
+
+Keep authoring, calibration, regression, held-out, adversarial, and incident partitions distinct. Hidden expected results remain unavailable to the evaluated target.
+
+## Oracle preference
+
+Use the strongest suitable oracle:
+
+1. Authoritative state or externally observed effect
+2. Deterministic schema, contract, policy, functional, property, or trace verifier
+3. Controlled simulation or fault evaluator
+4. Calibrated statistical measurement
+5. Calibrated model judge for semantic or subjective criteria
+6. Qualified human review for judgment, novelty, conflict, or consequence
+
+Evaluate outcomes when several adaptive paths are valid. Evaluate paths only for mandatory controls. Hidden reasoning and stylistic similarity are prohibited correctness requirements.
+
+## Model-judge boundary
+
+A model judge may assess subjective quality, semantic coverage, groundedness, open-ended comparisons, and advisory instruction review.
+
+A model judge is prohibited as the sole blocking oracle for:
+
+- Identity, authority, approval, permission, or ownership
+- Policy enforcement
+- External side effects
+- Evidence integrity
+- Budget accounting
+- Idempotency, fencing, transaction, or state-version correctness
+- Security-critical code or executable assets
+- Irreversible action completion
+- SOAA conformance
+
+Blocking use requires focused rubrics, structured output, calibration, bias and adversarial testing, validity limits, independence disclosure, an inconclusive result, and periodic human sampling.
+
+## Human review and approval
+
+Review and approval are separate:
+
+- Domain, security, evidence, or conformance reviewers assess claims.
+- An authorized approver commits a consequential authority or release decision.
+
+Human review is required for profile-defined high-impact, irreversible, materially uncertain, novel, disputed, security-sensitive, appealable, or legally required decisions.
+
+Reviewer identity, competency, independence, conflicts, evidence, counterevidence, rubric, outcome, rationale, limits, and time must enter a HumanReviewRecord.
+
+## Evaluator independence
+
+Declare independence across:
+
+- Producer identity
+- Model family
+- Context
+- Data and oracle
+- Execution environment
+- Organization
+- Authority
+- Conflict of interest
+
+A producer self-check is advisory. The task owner never commits its own final gate.
+
+## Non-deterministic evaluation
+
+For stochastic behavior, declare:
+
+- Trial count and sampling
+- Seed and model configuration
+- Reliability measure
+- Confidence or credible interval method
+- Minimum acceptable lower bound
+- Tail and critical-failure treatment
+- Multiple-comparison treatment
+- Stopping rule
+
+Use a reliability measure aligned with production behavior. A one-attempt production path must not claim reliability through a many-attempt best-of result.
+
+## Completion evidence profiles
+
+| Profile | Minimum evidence | Intended use |
+|---|---|---|
+| `EP0_OBSERVED` | Trace, outcome statement, sources, budget result, limitations | Advisory analysis |
+| `EP1_VERIFIED` | EP0 plus an objective verifier for each required criterion and policy evidence | Routine reversible execution |
+| `EP2_INDEPENDENT` | EP1 plus independent evaluation, negative checks, side-effect certainty, evidence review | Consequential execution |
+| `EP3_HUMAN_GATED` | EP2 plus qualified human review and separate approval where required | Irreversible, high-impact, disputed, or policy-designated execution |
+
+Task acceptance binds a profile before execution. Increased risk may preserve or strengthen the profile, never weaken it silently.
+
+## Completion gate
+
+Every completion follows:
+
+```text
+Observation
+  -> EvidenceRecord
+  -> EvidenceClaim
+  -> GateDecision
+  -> Task transition
+```
+
+Completion requires:
+
+- Disposition for every acceptance criterion
+- Required outcome verification
+- Required mandatory-path verification
+- Side-effect reconciliation
+- Evidence sufficiency
+- Blocking counterevidence resolution
+- Evaluation Controller gate pass
+- Task Controller transition from `VERIFYING` to `COMPLETED`
+
+Failed or inconclusive gates route to revision, re-evaluation, review, suspension, cancellation, or failure under policy.
+
+## Evidence rules
+
+Evidence must be:
+
+- Immutable and append-only
+- Content-addressed
+- Source, method, environment, time, and target linked
+- Scoped to exact versions and operating conditions
+- Data-minimized and access-controlled
+- Retained under governing policy
+- Linked to counterevidence
+- Independent of private model reasoning
+
+Evidence from a different skill, model, tool, policy, runtime, configuration, or environment requires explicit compatibility evidence.
+
+Missing, stale, integrity-failed, conflicting, mis-scoped, or insufficient evidence blocks the claim.
+
+## Gate semantics
+
+Gate logic is deterministic even when one input comes from a model or human.
+
+Supported outcomes are:
+
+- `PASS`
+- `FAIL`
+- `INCONCLUSIVE`
+- `ERROR`
+
+One blocking failure makes the gate fail. `ERROR`, missing execution, stale evidence, or unmet independence never becomes pass through aggregation.
+
+Weighted scoring applies only to non-blocking criteria with explicit weights and thresholds.
+
+## Conformance boundary
+
+SOAA conformance measures adherence to every applicable required invariant in a named profile. It does not certify general safety, business fitness, quality superiority, or absence of defects.
+
+A claim must name:
+
+- Exact target and version
+- Profile and version
+- Suite and adapter versions
+- Environment and dependency versions
+- Assessment mode
+- Evidence package
+- Validity period
+- Limitations
+
+Required assertion results have no waiver inside a claimed profile.
+
+This GovKit extension is guidance. It does not supply the complete 206-assertion executable suite and must not be presented as a conformance certificate.
+
+## Required verification
+
+Tests must cover:
+
+- Definition and target identity
+- Dataset separation and contamination
+- Positive, negative, null, denial, escalation, and failure cases
+- Blocking criteria and aggregation
+- Model-judge calibration and attack resistance
+- Reviewer and approver authority separation
+- Evaluator independence
+- Stochastic reliability and uncertainty
+- Exact evidence scope, integrity, freshness, and counterevidence
+- False completion narratives
+- Side-effect certainty
+- Gate outcomes and task transitions
+
+Every production failure must enter a reviewed regression case with data minimization and provenance.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/RESILIENCE_AND_RECOVERY_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/RESILIENCE_AND_RECOVERY_CONTRACT.md
@@ -1,0 +1,244 @@
+# Resilience and Recovery Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decision | SOAA-015 |
+| Primary invariants | SOAA-INV-089 through SOAA-INV-102 |
+| Source module | SOAA Packet 4 |
+
+## Purpose
+
+This contract makes retry, timeout, cancellation, reconciliation, compensation, restart, budget enforcement, and recovery trusted runtime responsibilities.
+
+## Failure taxonomy
+
+Every failure must receive one explicit class:
+
+| Class | Meaning | Required route |
+|---|---|---|
+| Deterministic rejection | Contract, policy, state, or compatibility denial | Stop or request correction |
+| Transient known-safe failure | No effect occurred and bounded retry is safe | Retry under one owner |
+| Unknown-effect failure | Side-effect status is uncertain | Reconcile before retry |
+| Permanent execution failure | Current conditions cannot satisfy the operation | Fail, compensate, or escalate |
+| Security failure | Injection, compromise, exfiltration, or authority abuse signal | Contain, revoke, suspend, investigate |
+| Evidence failure | Required evidence is missing, stale, conflicting, or invalid | Block the gate and escalate |
+
+The model may propose a classification. A trusted controller commits it.
+
+## Retry contract
+
+Every retry chain must define:
+
+- One retry owner
+- Finite maximum attempts
+- Deadline
+- Backoff and jitter
+- Retryable failure set
+- Idempotency rule
+- Effective total across nested libraries
+- Cost, token, operation, and time budget
+- Stop and escalation route
+
+Unknown-effect operations are prohibited from retry until reconciliation establishes a safe status.
+
+Retry creates a new attempt identity while preserving the original operation identity and evidence.
+
+## Timeout contract
+
+A timeout must distinguish:
+
+- Model wait timeout
+- Tool execution timeout
+- Remote delegation timeout
+- Human input or approval expiry
+- Overall task deadline
+
+A mutating operation timeout enters unknown-effect reconciliation unless authoritative status proves no effect.
+
+Timeout never implies cancellation at the target and never implies operation failure without evidence.
+
+## Cancellation and quiescence
+
+Cancellation propagates to:
+
+- Active skill activations
+- Tool and asset operations
+- Workflow nodes
+- Child tasks
+- Delegations and handoffs
+- Model invocations
+- Pending evaluations
+
+Terminal cancellation commits only after work reaches quiescence or every uncertain operation is fenced and routed to reconciliation.
+
+Partial completion records:
+
+- Completed work
+- Incomplete work
+- Side effects
+- Uncertainty
+- Outstanding obligations
+- Compensation eligibility
+- Evidence
+
+## Operation ledger
+
+Every external or executable operation requires a durable ledger entry before invocation.
+
+The ledger tracks:
+
+- Operation and attempt identities
+- Idempotency key
+- Input digest
+- Target and interface version
+- Authority decision
+- Invocation time
+- Known status
+- Result certainty
+- External correlation
+- Cancellation status
+- Reconciliation state
+- Compensation link
+- Evidence
+
+## Reconciliation
+
+Reconciliation obtains authoritative operation status after timeout, disconnect, crash, or ambiguous response.
+
+It must:
+
+1. Fence duplicate mutation.
+2. Query authoritative target state where available.
+3. Compare target state with expected effect.
+4. Classify success, no effect, partial effect, conflicting effect, or still unknown.
+5. Commit evidence.
+6. Route retry, compensation, manual review, suspension, or terminal result.
+
+No uncertainty record may age past policy without a routed outcome.
+
+## Compensation
+
+Compensation is a new separately authorized operation. It:
+
+- Receives its own operation identity.
+- Recalculates authority.
+- Preserves the original effect and evidence.
+- Defines its own failure and reconciliation path.
+- Never rewrites history as though the first operation did not occur.
+
+## Checkpoint and resume
+
+Checkpoint only durable observable state:
+
+- Task, owner, and revisions
+- Active plans and activations
+- Authority and approvals
+- Context references
+- Operations and uncertainty
+- Delegations
+- Evaluation state
+- Budgets
+- Evidence cursor
+
+Resume must revalidate:
+
+- Owner and owner epoch
+- Task revision
+- Policy and authority
+- Approval validity
+- Skill release and revocation
+- Dependency lock
+- Context and memory sources
+- Operation status
+- Remaining budget
+- Evaluation definitions
+- Runtime and environment compatibility
+
+Changed conditions block unsafe resume.
+
+## Execution budget
+
+Every accepted task has a finite BudgetEnvelope covering:
+
+- Deadline and elapsed time
+- Model tokens and invocations
+- Tool and asset operations
+- Retry attempts
+- Monetary cost
+- Context size
+- Child tasks and delegation depth
+- External data volume
+- Evaluation work
+
+Child reservations must not exceed unreserved parent balance.
+
+Hard-limit exhaustion stops covered work and routes to:
+
+- Completion with sufficient evidence
+- Partial result
+- Suspension
+- Failure
+- Escalation for a new authorized budget
+
+Silent continuation and silent success are prohibited.
+
+## Operational telemetry
+
+Trace one execution chain across:
+
+- Principal and task
+- Owner epoch
+- Agent run
+- Skill selection and activation
+- Context snapshot
+- Model request
+- Tool or asset operation
+- Delegation or handoff
+- Evaluation and gate
+- State transition
+- Evidence record
+
+Required metrics include:
+
+- Task and activation outcomes
+- Selection null, denial, and escalation rates
+- Retry and unknown-effect rates
+- Reconciliation age
+- Cancellation time to quiescence
+- Budget use and exhaustion
+- Evaluation failure and inconclusive rates
+- Recovery and resume outcomes
+
+Telemetry becomes evidence only when it meets evidence integrity, completeness, scope, access, and retention rules.
+
+## Prohibited patterns
+
+- Infinite or hidden retry
+- Independent nested retry budgets
+- Retry after unknown effect without reconciliation
+- Timeout treated as confirmed failure
+- Cancellation reported before quiescence
+- Compensation hidden as rollback
+- Resume from conversational summary alone
+- Budget stored only in prompt instructions
+- Recovery directed by a revoked skill release
+- Logs treated as authoritative state without a reconstruction contract
+
+## Verification
+
+Tests must prove:
+
+- Every injected failure receives one complete class.
+- Nested retries obey one total limit and one owner.
+- Unknown-effect replay creates no duplicate side effect.
+- Timeout on mutation enters reconciliation.
+- Cancellation accounts for every child and operation.
+- Uncertainty routes before policy expiry.
+- Session loss resumes from durable state.
+- Changed owner, authority, release, policy, or environment blocks resume.
+- Compensation has separate identity, authority, and evidence.
+- Concurrent child reservations never over-allocate parent budget.
+- Hard exhaustion produces no silent continuation.
+- Telemetry preserves correlation without leaking prohibited data.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/RUNTIME_STATE_AND_EXECUTION_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/RUNTIME_STATE_AND_EXECUTION_CONTRACT.md
@@ -1,0 +1,273 @@
+# Runtime State and Execution Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decisions | SOAA-005, SOAA-010 through SOAA-013 |
+| Primary invariants | SOAA-INV-001 through SOAA-INV-005 and SOAA-INV-038 through SOAA-INV-067 |
+| Source modules | SOAA Packets 1 and 3 |
+
+## Purpose
+
+This contract governs accepted tasks, runtime ownership, skill activations, composition, external operations, delegation, handoff, and authoritative state.
+
+## Task offer and acceptance
+
+A requested task begins as a TaskOfferRecord. It has no runtime owner.
+
+The offer must state:
+
+- Accountable principal
+- Intent and bounded outcome
+- Proposed scope
+- Acceptance criteria
+- Consequence and data classifications
+- Requested authority
+- Requested deadline and budget
+- Evidence obligations
+
+Acceptance atomically creates a TaskRecord and assigns its first runtime owner. Rejection preserves the offer and reason without creating active task state.
+
+## One-owner rule
+
+Every active TaskRecord has exactly one runtime owner:
+
+- `AGENT_RUN`
+- `HUMAN`
+
+Skills, models, tools, resources, workflows, policies, evaluators, AgentDefinitions, and protocol endpoints never own tasks.
+
+Every ownership change increments `owner_epoch`. A mutating command must match:
+
+- Task identity
+- Task aggregate version
+- Current owner identity
+- Current owner epoch
+- Current authority context
+
+Former-owner commands are fenced after transfer.
+
+## Task lifecycle
+
+Supported states are:
+
+```text
+READY
+RUNNING
+WAITING_INPUT
+WAITING_APPROVAL
+WAITING_DEPENDENCY
+HANDOFF_PENDING
+HUMAN_CONTROLLED
+SUSPENDED
+VERIFYING
+COMPLETED
+FAILED
+CANCELED
+```
+
+Only the Task Controller commits task transitions.
+
+Required rules:
+
+- Accepted work enters `READY` with one owner.
+- Adaptive cycles occur inside `RUNNING`.
+- External waits have durable dependency, input, or approval records.
+- Human takeover requires quiescence and an atomic owner commit.
+- Every completion claim enters `VERIFYING`.
+- Only an Evaluation Controller pass permits `COMPLETED`.
+- Terminal tasks reject mutation.
+- Reopened work receives a new linked task identity.
+
+## Task revision
+
+A material change to goal, constraints, completion criteria, stop conditions, authority, or evidence creates a new immutable task revision.
+
+Active plans, activations, delegations, context snapshots, approvals, and evaluations must revalidate against the new revision. Historical evidence remains linked to the revision in force at decision time.
+
+## Authoritative aggregate ownership
+
+| Aggregate | Authoritative writer |
+|---|---|
+| TaskOfferRecord and TaskRecord | Task Controller |
+| AgentRunRecord | Task Controller and Agent Decision Runtime through trusted ports |
+| SelectionRecord and SkillActivationRecord | Capability Controller |
+| CompositionPlan and workflow instance | Workflow and Composition Controller |
+| AuthorityContext and ApprovalRecord | Policy and Authority Controller |
+| OperationRecord | Tool Gateway or Skill Asset Runner |
+| DelegationRecord and handoff transaction | Delegation and Handoff Controller |
+| ContextSnapshot | Context Controller |
+| MemoryRecord | Memory Gateway |
+| EvaluationRun and GateDecision | Evaluation Controller |
+| SkillRelease and installation state | Skill Registry and Capability Controller |
+| EvidenceRecord | Evidence Recorder |
+
+A controller must not mutate another controller's aggregate directly. Cross-aggregate coordination uses committed commands and events with idempotent consumers.
+
+## Skill-activation lifecycle
+
+A SkillActivation binds one exact admitted release to one task and agent run.
+
+Supported states are:
+
+```text
+SELECTED
+APPROVAL_PENDING
+ACTIVATING
+ACTIVE
+SUSPENDED
+TERMINATING
+SUCCEEDED
+FAILED
+STOPPED
+ESCALATED
+DENIED
+STALE
+ACTIVATION_FAILED
+```
+
+Only the Capability Controller commits activation transitions.
+
+Task and activation state remain independent:
+
+- Skill success does not complete the task.
+- Skill failure does not automatically fail the task.
+- Skill escalation does not transfer ownership.
+- Task cancellation drives every active activation toward termination.
+
+## Adaptive decision loop
+
+Every decision cycle records:
+
+1. Observation received
+2. Immutable context snapshot
+3. Model request identity
+4. Proposed next action
+5. Trusted controller decision
+6. Activation, operation, delegation, wait, or evaluation outcome
+7. Budget update
+8. Observation cursor
+
+Private model reasoning is never required for restart, audit, evidence, or correctness.
+
+## Composition
+
+A multi-skill run requires a versioned CompositionPlan defining:
+
+- Exact skill nodes and bindings
+- Dependencies and data flow
+- Authority and budget allocation
+- Conflict and exclusion rules
+- Shared state and concurrency control
+- Cancellation propagation
+- Join and aggregation semantics
+- Failure routes
+- Safe amendment points
+
+Adaptive parallel branches become child tasks with distinct owners. Shared-state mutation requires a lease, fencing token, transaction, partition, or validated merge rule.
+
+Plan amendments create new versions. A running node keeps the plan version under which it started unless a declared safe-point migration commits.
+
+## Operation boundary
+
+Every mutating external operation receives a durable OperationRecord before invocation.
+
+Required fields include:
+
+- Operation identity and idempotency key
+- Task, owner epoch, activation, and plan identities
+- Tool or asset interface and version
+- Input digest
+- Authority decision
+- Side-effect class
+- Attempt state
+- Result certainty
+- Reconciliation and compensation links
+- Evidence reference
+
+Unknown effect is a distinct result. It is never treated as assumed success or assumed failure.
+
+## Subtask delegation
+
+Subtask acceptance:
+
+- Creates a distinct child TaskRecord.
+- Assigns the receiver as child owner.
+- Preserves parent ownership.
+- Preserves the accountable principal.
+- Derives child authority independently inside the parent boundary.
+- Creates parent-child and remote-correlation evidence.
+
+The parent may wait, continue independent work, or cancel under declared policy.
+
+## Whole-task handoff
+
+Handoff uses prepare and commit phases:
+
+1. Receiver admission
+2. Acceptance intent
+3. Sender quiescence
+4. Atomic owner commit
+5. Owner-epoch increment
+6. Receiver acknowledgment
+7. Former-owner fencing
+
+Failure before commit leaves sender ownership unchanged. Ambiguous commit blocks unfenced mutation and enters reconciliation.
+
+Network location does not determine semantics. Every delegation envelope declares `SUBTASK` or `HANDOFF`.
+
+## State and evidence commit
+
+Every accepted consequential transition must commit its authoritative state and evidence:
+
+- In one transaction, or
+- Through one authoritative durable envelope with deterministic recovery
+
+A log line written before a failed state commit is not authoritative evidence of the transition.
+
+## Restart rule
+
+Restart reconstructs work from:
+
+- Task and owner records
+- Agent-run record
+- Activation records
+- Composition plan
+- Authority and approval records
+- Context snapshot references
+- Operation and delegation records
+- Evaluation and gate records
+- Budget envelope
+- Evidence stream
+
+Provider conversation state or private model reasoning must not be required.
+
+## Prohibited patterns
+
+- Accepted tasks without one owner
+- Direct model writes to authoritative aggregates
+- Task state stored only inside a prompt or conversation
+- Skill state and task state collapsed into one status
+- External side effects without a prior OperationRecord
+- Hidden recursive activation
+- Parallel adaptive branches sharing one owner
+- Handoff without quiescence and fencing
+- Task completion without `VERIFYING`
+- Historical evidence overwritten after retry or recovery
+
+## Verification
+
+Tests must prove:
+
+- Zero-owner and multi-owner states are rejected.
+- Stale aggregate versions and owner epochs reject writes.
+- Terminal aggregates reject mutation.
+- State and evidence commit atomically or recover together.
+- Skill and task lifecycles remain distinct.
+- Only one concurrent adaptive proposal commits.
+- Every side effect has a pre-invocation operation identity.
+- Mutating command replay is idempotent.
+- Subtask and handoff preserve their different ownership semantics.
+- Handoff fault injection preserves or fences ownership at every boundary.
+- Restart reconstructs active work without a provider transcript.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_CONTRACT.md
@@ -7,6 +7,7 @@
 | Primary decisions | SOAA-002, SOAA-004, SOAA-019 |
 | Primary invariants | SOAA-INV-006 through SOAA-INV-020 and SOAA-INV-175 through SOAA-INV-182 |
 | Source modules | SOAA Packets 1 and 6 |
+| External format | [Agent Skills specification](https://agentskills.io/specification), accessed 2026-07-20 |
 
 ## Purpose
 
@@ -57,7 +58,7 @@ Executable assets remain inert until:
 
 One package may contain instructions, references, schemas, and executable assets. Packaging does not erase the responsibility boundary.
 
-## Agent Skills package profile
+## SOAA profile for Agent Skills packages
 
 A SOAA-aligned Agent Skills package uses two layers:
 
@@ -76,16 +77,61 @@ skill-name/
 └── LICENSE.txt
 ```
 
-`SKILL.md` preserves standard discovery metadata and procedural instructions. `soaa/manifest.yaml` holds the governance contract.
+`SKILL.md` preserves Agent Skills discovery metadata and procedural instructions. `soaa/manifest.yaml` holds the SOAA governance contract. The Agent Skills format permits additional files and directories, so `soaa/` and `evals/` extend the package without replacing or modifying the standard format.
 
-The `SKILL.md` metadata must link:
+The standard constraints for `SKILL.md` remain binding, including the parent-directory name match and the required `name` and `description` fields. SOAA metadata uses the standard `metadata` field, whose entries are string keys mapped to string values.
 
-- SOAA profile identifier
-- Relative manifest path
-- Manifest digest
-- Exact skill release identity
+```yaml
+---
+name: skill-name
+description: Performs the governed skill-name procedure. Use for tasks that require this procedure.
+license: LICENSE.txt
+metadata:
+  soaa-profile: "soaa-agent-skills/0.2"
+  soaa-manifest: "soaa/manifest.yaml"
+  soaa-manifest-digest: "sha256:<64-lowercase-hex>"
+  soaa-release-id: "<immutable-release-id>"
+---
+```
 
-The standard `allowed-tools` field is a requested ceiling. It never grants runtime access.
+The four SOAA metadata keys are normative:
+
+| Key | Required value |
+|---|---|
+| `soaa-profile` | Exact SOAA Agent Skills profile identifier and version |
+| `soaa-manifest` | Skill-root-relative path to `soaa/manifest.yaml` with no parent traversal |
+| `soaa-manifest-digest` | Digest of the exact manifest bytes using the declared algorithm |
+| `soaa-release-id` | Immutable release identity matching the manifest |
+
+All four values must be non-empty strings. Nested SOAA metadata is invalid because Agent Skills metadata values are strings, not mappings. The manifest digest and release identity must match before admission.
+
+### Generic-client behavior
+
+A generic Agent Skills client may ignore the `soaa/` directory and unrecognized `soaa-*` metadata. It may still process the package as Agent Skills-format conformant when `SKILL.md` passes standard validation. It must not claim SOAA package-profile or runtime conformance.
+
+A SOAA-aware client must recognize the four metadata keys, validate the referenced manifest and package integrity, and enforce SOAA admission and activation rules before using governed capabilities.
+
+### `allowed-tools` profile rule
+
+The Agent Skills `allowed-tools` field remains an optional, space-separated string. Within SOAA it declares a requested maximum tool set, not an authority grant. A SOAA runtime calculates:
+
+```text
+effective_tools = allowed_tools
+                  intersect runtime_policy
+                  intersect task_authority
+                  intersect approval_scope
+```
+
+An absent `allowed-tools` field never authorizes a tool. Runtime policy, task authority, approvals, and the admitted SOAA manifest remain controlling.
+
+### Two-stage validation
+
+Package admission requires both validation stages:
+
+1. Agent Skills format validation using `skills-ref validate <skill-root>` or an equivalent conforming validator. This validates `SKILL.md` frontmatter, naming, and standard field constraints.
+2. SOAA profile validation. This validates the manifest schema and digest, release identity, declared files, package digest, compatibility, provenance, evidence profile, executable-asset declarations, and mirrored-field consistency.
+
+Passing stage 1 supports an Agent Skills-format conformance claim. Passing both stages supports a SOAA package-profile conformance claim. Neither result alone establishes runtime, activation, evaluation, or task-completion conformance.
 
 ## Source-of-truth split
 

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_CONTRACT.md
@@ -1,0 +1,189 @@
+# Skill Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decisions | SOAA-002, SOAA-004, SOAA-019 |
+| Primary invariants | SOAA-INV-006 through SOAA-INV-020 and SOAA-INV-175 through SOAA-INV-182 |
+| Source modules | SOAA Packets 1 and 6 |
+
+## Purpose
+
+This contract defines a skill as a versioned procedural capability. A skill supplies reusable method and contract metadata to a bound agent run. It does not become an agent, workflow, permission grant, or state owner.
+
+## Canonical semantic model
+
+```text
+Skill = (I, C, P, T, R, D, G, E)
+```
+
+| Element | Required meaning |
+|---|---|
+| `I` | Identity, version, provenance, and integrity |
+| `C` | Applicability, exclusions, and preconditions |
+| `P` | Procedure, heuristics, references, and examples |
+| `T` | Success, failure, stop, and escalation conditions |
+| `R` | Inputs, outputs, artifacts, and errors |
+| `D` | Skill, tool, resource, runtime, and environment dependencies |
+| `G` | Required authority, ceilings, approvals, and prohibited access |
+| `E` | Evaluation, evidence, and conformance obligations |
+
+Every production skill must declare all eight areas. An empty area remains explicit.
+
+## Passive package rule
+
+Discovery, retrieval, parsing, validation, installation, and activation must not execute package code or cause an external side effect.
+
+Executable assets remain inert until:
+
+1. The exact release passes admission.
+2. Activation commits.
+3. The agent run proposes a typed invocation.
+4. The runtime recalculates authority.
+5. The Skill Asset Runner authorizes and isolates execution.
+6. The operation and outcome enter durable records.
+
+## Primitive boundaries
+
+| If the component primarily... | Classify it as... |
+|---|---|
+| Owns an adaptive goal and next-action loop | Agent run |
+| Supplies reusable contextual procedure | Skill |
+| Performs one typed bounded operation | Tool |
+| Supplies facts or reference content | Resource |
+| Enforces mandatory order or gates | Workflow |
+| Measures a target against criteria | Evaluator |
+
+One package may contain instructions, references, schemas, and executable assets. Packaging does not erase the responsibility boundary.
+
+## Agent Skills package profile
+
+A SOAA-aligned Agent Skills package uses two layers:
+
+```text
+skill-name/
+├── SKILL.md
+├── soaa/
+│   ├── manifest.yaml
+│   ├── evidence-profile.yaml
+│   ├── compatibility.yaml
+│   └── provenance.json
+├── scripts/
+├── references/
+├── assets/
+├── evals/
+└── LICENSE.txt
+```
+
+`SKILL.md` preserves standard discovery metadata and procedural instructions. `soaa/manifest.yaml` holds the governance contract.
+
+The `SKILL.md` metadata must link:
+
+- SOAA profile identifier
+- Relative manifest path
+- Manifest digest
+- Exact skill release identity
+
+The standard `allowed-tools` field is a requested ceiling. It never grants runtime access.
+
+## Source-of-truth split
+
+| Concern | Authority |
+|---|---|
+| Standard name, description, license, compatibility, allowed-tools | `SKILL.md` frontmatter |
+| Procedure | `SKILL.md` body and integrity-bound references |
+| Identity, applicability, interface, authority needs, termination, dependencies, evaluation, evidence, provenance | `soaa/manifest.yaml` |
+| Exact executable behavior | Integrity-bound asset plus runner contract |
+| Current grant | Policy and Authority Controller |
+| Current release state | Skill Registry |
+
+Mirrored fields must match after normalization. A conflict fails package validation.
+
+## Required manifest areas
+
+The SOAA manifest must define:
+
+- Profile and schema version
+- Lineage ID, release ID, declared version, digest, and owner
+- Triggers, exclusions, and preconditions
+- Typed inputs, outputs, artifacts, and errors
+- Required, optional, and prohibited access
+- Approval points
+- Success, failure, stop, and escalation conditions
+- Skill, tool, resource, runtime, model, protocol, and environment dependencies
+- Admission and regression evaluation suites
+- Completion evidence profile
+- Compatibility and provenance references
+- Data classification and execution-isolation needs
+
+Unknown critical fields fail validation. Unknown noncritical fields remain preserved and reported.
+
+## Required release identity
+
+```text
+(skill_lineage_id, declared_version, package_digest, soaa_profile_version)
+```
+
+The runtime resolves version ranges before admission, then binds one exact digest and one resolved dependency lock during activation.
+
+## Procedure and code boundary
+
+Skill instructions may:
+
+- Describe a method
+- Offer heuristics and examples
+- Identify information to inspect
+- Propose tool or resource use
+- State stop and escalation conditions
+- Define expected artifacts and evidence
+
+Skill instructions must not:
+
+- Mutate authoritative state
+- Issue credentials or permissions
+- Bypass approval
+- Execute package assets during loading
+- Hide required dependencies
+- Reclassify lower-precedence content as policy
+- Declare the parent task complete
+- Modify the released package in place
+
+Permission checks, state transitions, transactions, idempotency, integration boundaries, budget enforcement, completion gates, revocation, and recovery belong in application code.
+
+## Termination boundary
+
+Skill termination and task completion are separate.
+
+- Skill success reports a skill-level outcome.
+- Skill failure reports a skill-level failure.
+- Skill stop ends the activation under a declared condition.
+- Skill escalation requests a different authority or controller.
+- None of these outcomes changes task ownership.
+- None completes the task without the task-level completion gate.
+
+## Required evidence
+
+Every activation must preserve:
+
+- Skill lineage, declared version, digest, and profile version
+- Selection source and admission result
+- Bound task and agent run
+- Authority envelope and approval references
+- Instruction and context snapshot identities
+- Dependency lock
+- Asset invocations
+- Termination outcome
+- Evaluation and evidence profile
+
+## Verification
+
+Tests must prove:
+
+- Loading produces no execution side effect.
+- The schema contains no owner or grant field.
+- Activation leaves task ownership and existing grants unchanged.
+- Exact assets execute only through the runner.
+- Package traversal, undeclared assets, digest mismatch, and conflicting mirrored fields fail admission.
+- Skill success alone never commits task completion.
+- `allowed-tools` never expands effective authority.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md
@@ -1,0 +1,278 @@
+# Skill Lifecycle and Interoperability Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decisions | SOAA-018 through SOAA-020 |
+| Primary invariants | SOAA-INV-147 through SOAA-INV-206 |
+| Source module | SOAA Packet 6 |
+
+## Purpose
+
+This contract governs immutable skill releases, promotion, deprecation, retirement, revocation, compatibility, supply-chain integrity, Agent Skills packaging, MCP and A2A mappings, and portability.
+
+## Separate identities
+
+Keep these identities distinct:
+
+- Skill definition or lineage
+- Immutable skill release
+- Environment-specific installation
+- Task-specific activation
+
+No mutable `latest` directory or version label identifies exact executable behavior.
+
+## Release lifecycle
+
+Supported release states are:
+
+```text
+CANDIDATE
+ADMITTED
+REJECTED
+DEPRECATED
+RETIRED
+REVOKED
+```
+
+Legal transitions:
+
+- `CANDIDATE -> ADMITTED` after admission and release gates pass
+- `CANDIDATE -> REJECTED` after failure or withdrawal
+- `ADMITTED -> DEPRECATED` with an approved migration plan
+- `ADMITTED -> REVOKED` after a revocation directive
+- `DEPRECATED -> RETIRED` after the support deadline
+- `DEPRECATED -> REVOKED` after a revocation directive
+- `RETIRED -> REVOKED` after a later compromise finding
+
+Only admitted releases enter new selection or activation.
+
+## Release identity and immutability
+
+```text
+(skill_lineage_id, declared_version, package_digest, soaa_profile_version)
+```
+
+- Declared versions use Semantic Versioning syntax.
+- Exact bytes define the package digest.
+- Published release bytes are immutable.
+- Changed executable assets always create a new digest and impacted-area regression run.
+- A version class is a governed claim supported by change-impact evidence.
+- Activation binds the exact digest after range resolution.
+
+## Compatibility and dependency lock
+
+Compatibility must address:
+
+- SOAA and Agent Skills profile
+- Runtime capabilities
+- Model profile
+- Tool and resource interfaces
+- Skill dependencies
+- MCP, A2A, and extension versions
+- Platform and language runtime
+- Policy schemas
+- Data contracts
+- Supported degradation modes
+
+Resolve floating ranges before admission and activation. Bind one deterministic dependency lock containing exact skill releases, tool interfaces, resource contracts, protocol versions, runtime version, model profile, policy digest, and evaluation reference.
+
+Missing required compatibility rejects binding or enters one predeclared safe degraded mode.
+
+Silent fallback is prohibited when it drops a control, changes authority or ownership, weakens completion evidence, changes side-effect class, loses required data, or uses an untested profile.
+
+## Change impact, migration, and rollback
+
+Every release change must record:
+
+- Predecessor and proposed release identities
+- Changed files and semantics
+- Version class
+- Affected dependencies, authority, data, evaluations, and protocols
+- Migration and rollback support
+- Reviewer, approval, and evidence
+
+A live activation migrates only at a declared safe point with:
+
+- Exact source and target releases
+- State-transform contract
+- Fresh authority and compatibility checks
+- New context and instruction snapshot
+- Target admission status
+- Migration evaluation
+- Atomic binding change and evidence
+- Recovery route
+
+Rollback binds another exact admitted release. It never rewrites history or reuses a prior digest with different bytes.
+
+## Revocation
+
+Revocation blocks:
+
+- New selection
+- New activation
+- Resume
+- Retry
+- Recovery directed by the revoked release
+- Asset execution
+- Covered operation authorization
+
+Active work follows one committed policy:
+
+- Cancel now
+- Suspend and quarantine
+- Stop before next operation
+- Compensation only
+
+In-flight mutation is canceled where safe or fenced and reconciled. Outputs after the compromise boundary remain quarantined until cleared.
+
+Cached descriptors must include lifecycle epoch, fetch time, expiry, and integrity. Operation beyond the allowed revocation-staleness limit fails closed.
+
+## Learning and drift
+
+Execution evidence, incidents, feedback, or model proposals enter a governed draft process. Released packages are never mutated in place.
+
+Revalidation triggers include changes to:
+
+- Model or configuration
+- Runtime or orchestration
+- System or developer instructions
+- Policy
+- Tool schema, behavior, endpoint, or permission
+- Resource contract or trust
+- Dependent skill
+- Protocol or adapter
+- Operating system or language runtime
+- Threat intelligence or legal constraint
+- Observed task distribution or outcome quality
+
+Revalidation results in pass, constrained operation, deprecation, disablement, revocation, or suspension for insufficient evidence.
+
+## Agent Skills mapping
+
+The SOAA package profile uses:
+
+- `SKILL.md` for standard discovery and procedure
+- `soaa/manifest.yaml` for governance semantics
+- Namespaced metadata for profile, manifest path, manifest digest, and release identity
+
+`allowed-tools` is a requested ceiling, not a grant.
+
+Package integrity covers instructions, manifest, profile files, scripts, assets, references, evaluations, schemas, migrations, license, and provenance. Parent traversal, symbolic-link escape, undeclared executable assets, and digest mismatch fail admission.
+
+## MCP mapping
+
+SOAA v0.2 maps MCP specification revision `2025-11-25`.
+
+| MCP primitive | SOAA interpretation |
+|---|---|
+| Resource | Resource candidate through Resource Gateway |
+| Resource template | Parameterized resource descriptor |
+| Prompt | Prompt-template resource under precedence rules |
+| Tool | Descriptor and operation through Tool Gateway |
+| Roots | Context-boundary advertisement, never a grant |
+| Sampling | Model request through Model Gateway |
+| Elicitation | Structured human-input request, never approval by itself |
+| Protocol task | Remote operation handle, never local TaskRecord by default |
+| Logging and progress | Untrusted observation events until validated |
+
+MCP names, descriptions, annotations, prompts, and server instructions are external claims. Wire compatibility never grants SOAA authority.
+
+## A2A mapping
+
+SOAA v0.2 maps A2A protocol version `1.0`.
+
+| A2A primitive | SOAA interpretation |
+|---|---|
+| Agent Card | Remote agent descriptor |
+| AgentSkill | Advertised remote capability, not internal SkillDefinition |
+| Message | Task offer or task-interaction input |
+| Task | Remote protocol lifecycle object, not local TaskRecord by default |
+| Artifact | Untrusted data until validated |
+| Authentication-required state | Authentication need, not approval |
+
+Remote completion remains a proposal until local verification.
+
+SOAA remote delegation declares `SUBTASK` or `HANDOFF`. Whole-task handoff requires prepare, quiescence, atomic owner commit, fencing, reconciliation, and evidence across failure boundaries.
+
+## Protocol version policy
+
+Every protocol adapter pins:
+
+- Protocol version
+- Negotiated extensions
+- Semantic mapping profile
+- Adapter version
+- Compatibility evidence
+- Downgrade policy
+
+A protocol upgrade or downgrade triggers change-impact and behavior-preservation evaluation. Missing semantics reject the connection or route one predeclared degraded mode.
+
+## Portability claims
+
+Keep separate:
+
+- Package portability
+- Runtime semantic portability
+- Protocol interoperability
+
+A runtime portability claim requires at least two independently implemented runtime profiles and evidence preserving:
+
+- Outcomes
+- Authority
+- Side effects
+- Ownership
+- Interfaces
+- Failure behavior
+- Completion
+- Evidence
+
+Syntax conversion or package loading alone does not prove behavioral equivalence.
+
+## Supply-chain controls
+
+Review:
+
+- Names and discovery metadata
+- Natural-language procedure
+- Executable assets
+- References and templates
+- Tool and resource declarations
+- Evaluation definitions and graders
+- Dependencies and build process
+- Provenance, signatures, package inventory, and license
+
+Digest validity, signer trust, provenance acceptance, and release admission remain separate decisions.
+
+## Prohibited patterns
+
+- Mutable released packages
+- Activation by version label without digest
+- Silent compatible-range fallback
+- New operations after revocation
+- Offline use past lifecycle staleness limits
+- MCP or A2A descriptors treated as grants
+- Remote completion accepted as local completion
+- A2A AgentSkill treated as internal procedural skill without mapping
+- Authentication or elicitation treated as approval
+- Protocol downgrade without semantic checks
+- Portability claimed from file-format compatibility alone
+
+## Verification
+
+Tests must prove:
+
+- Lifecycle transitions reject every illegal edge.
+- Exact release bytes remain immutable.
+- Candidate, rejected, retired, and revoked releases fail new activation as applicable.
+- Revocation reaches selection, activation, resume, retry, recovery, assets, and operations.
+- Cached stale lifecycle state fails closed.
+- Dependency resolution is deterministic and locked.
+- Migration commits atomically or preserves the source binding.
+- Rollback never binds a revoked or incompatible release.
+- Package traversal, undeclared assets, and digest mismatch fail.
+- MCP and A2A injection cannot change policy, authority, ownership, or completion.
+- Remote subtask and handoff preserve different ownership semantics.
+- Upgrade and downgrade tests detect semantic loss.
+- Cross-runtime differential tests support any portability claim.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md
@@ -7,6 +7,7 @@
 | Primary decisions | SOAA-018 through SOAA-020 |
 | Primary invariants | SOAA-INV-147 through SOAA-INV-206 |
 | Source module | SOAA Packet 6 |
+| External format | [Agent Skills specification](https://agentskills.io/specification), accessed 2026-07-20 |
 
 ## Purpose
 
@@ -149,15 +150,17 @@ Revalidation triggers include changes to:
 
 Revalidation results in pass, constrained operation, deprecation, disablement, revocation, or suspension for insufficient evidence.
 
-## Agent Skills mapping
+## SOAA profile for Agent Skills packages
 
 The SOAA package profile uses:
 
 - `SKILL.md` for standard discovery and procedure
 - `soaa/manifest.yaml` for governance semantics
-- Namespaced metadata for profile, manifest path, manifest digest, and release identity
+- Flat string metadata keys `soaa-profile`, `soaa-manifest`, `soaa-manifest-digest`, and `soaa-release-id`
 
-`allowed-tools` is a requested ceiling, not a grant.
+The Agent Skills format permits additional files and directories. A generic client may ignore `soaa/` and remain Agent Skills-format compatible, but it must not claim SOAA conformance. A SOAA-aware client must first validate the standard `SKILL.md`, then validate the SOAA manifest, digest, release identity, declared package contents, compatibility, provenance, and evidence profile.
+
+`allowed-tools` is a requested ceiling, not a grant. Effective tool access is the intersection of that ceiling, runtime policy, task authority, and approval scope. Absence of the field never authorizes a tool.
 
 Package integrity covers instructions, manifest, profile files, scripts, assets, references, evaluations, schemas, migrations, license, and provenance. Parent traversal, symbolic-link escape, undeclared executable assets, and digest mismatch fail admission.
 

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_ORIENTED_AGENT_ARCHITECTURE.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_ORIENTED_AGENT_ARCHITECTURE.md
@@ -1,0 +1,183 @@
+# Skill-Oriented Agent Architecture
+
+## Contract status
+
+| Field | Value |
+|---|---|
+| Profile | GovKit SOAA implementation guidance |
+| Source architecture | Skill-Oriented Agent Architecture v0.2 |
+| Source status | Approved 2026-07-18 |
+| Decision scope | SOAA-001 through SOAA-020 |
+| Invariant scope | SOAA-INV-001 through SOAA-INV-206 |
+| Conformance claim | None |
+
+## Purpose
+
+This contract defines the architecture boundary for applications in which an agent run selects and applies governed procedural skills.
+
+It replaces framework-specific agent guidance with a provider-neutral model. Language, model provider, orchestration library, database, transport, and deployment topology remain implementation choices.
+
+## Architecture rule
+
+A governed skill-oriented agent system uses an accountable agent run to interpret an accepted task, select eligible procedural skills, activate exact skill releases, invoke bounded tools, incorporate authorized resources, adapt from observations, evaluate outcomes, and preserve evidence.
+
+Trusted deterministic components retain control over:
+
+- Task identity and ownership
+- Policy and effective authority
+- Skill admission and activation
+- Authoritative state
+- External side effects
+- Execution budgets
+- Evaluation and completion
+- Evidence and lifecycle state
+
+Model output is a proposal. A trusted controller validates and commits each consequential transition.
+
+## Defining properties
+
+Every design in scope must preserve:
+
+1. A human or organization accountable for each consequential task.
+2. Exactly one runtime owner for each active task.
+3. Adaptive choice inside deterministic control boundaries.
+4. Passive skills without task ownership or authority.
+5. Progressive context disclosure.
+6. Fresh authorization before each external operation.
+7. Evaluation before consequential completion.
+8. Durable evidence for state, action, outcome, and learning.
+
+## Responsibility classification
+
+Classify components by runtime responsibility, not file type, prompt shape, protocol, or deployment unit.
+
+| Primitive | Owns | Must not own |
+|---|---|---|
+| Principal | Accountability for intent and consequences | Runtime execution state |
+| Agent run | One bounded adaptive observation-action loop | Policy, authority, or authoritative business state |
+| Skill | Reusable procedure and contract metadata | Task, grant, persistent adaptive loop, or completion |
+| Tool | One typed bounded operation | Task or adaptive loop |
+| Resource | Contextual data | Instruction precedence, authority, or truth by declaration |
+| Workflow | Predetermined transitions and gates | Undeclared adaptive choice |
+| Policy | Permissions, denials, limits, and transition rules | Model-discretionary enforcement |
+| Evaluator | Measurement against explicit criteria | Authoritative gate decision |
+| Memory | Governed retained information | Task state, policy, skill release, authority, or evidence |
+
+## Skill versus application code
+
+| Belongs in a skill | Belongs in trusted application code |
+|---|---|
+| Applicability and exclusions | Task acceptance and ownership |
+| Procedure and heuristics | Permission and policy enforcement |
+| References and examples | Authoritative state transitions |
+| Input and output contracts | Transactions and concurrency control |
+| Declared dependencies | Input and output validation |
+| Required authority and approval points | Effective-authority calculation |
+| Success, failure, stop, and escalation conditions | Tool authorization and side-effect execution |
+| Evaluation and evidence obligations | Operation identity and idempotency |
+| Release identity and provenance references | Budgets, revocation, reconciliation, and recovery |
+| Progressive instruction content | Evaluation commits and completion gates |
+
+A prompt, model response, `SKILL.md`, tool annotation, Agent Card, or MCP descriptor never replaces application enforcement.
+
+## Required logical roles
+
+The implementation must assign all eighteen SOAA logical roles. Several roles may share one process or class. Shared deployment never removes distinct responsibilities, ports, state ownership, or trust boundaries.
+
+| Plane | Logical roles |
+|---|---|
+| Interaction and task | Interaction Adapter, Task Controller |
+| Adaptive decision | Agent Decision Runtime, Model Gateway |
+| Capability and context | Capability Controller, Context Controller, Skill Registry, Resource Gateway, Memory Gateway |
+| Control and action | Policy and Authority Controller, Workflow and Composition Controller, Tool Gateway, Skill Asset Runner, Delegation and Handoff Controller, Evaluation Controller |
+| Records and discovery | State Repository, Evidence Recorder, Agent Directory |
+
+Architecture preflight must map each role to:
+
+- Implementation owner
+- Inbound and outbound ports
+- Authoritative state
+- Trust boundary
+- Deployment location
+- Required verification
+
+## Proposal and commit boundary
+
+| Adaptive proposal | Trusted commit owner |
+|---|---|
+| Task interpretation or plan | Task Controller or Workflow and Composition Controller |
+| Skill ranking | Capability Controller |
+| Tool request | Policy and Authority Controller plus Tool Gateway |
+| Resource or memory request | Context Controller plus the relevant gateway |
+| Delegation or handoff | Delegation and Handoff Controller |
+| Completion claim | Evaluation Controller plus Task Controller |
+| Recovery choice | Owning controller under policy |
+
+Models must not write task, ownership, authority, activation, operation, evaluation, evidence, memory, release, or lifecycle records directly.
+
+## Ports and adapters
+
+Technology-neutral ports must cover:
+
+- Task offer, acceptance, transition, ownership, and completion
+- Candidate retrieval, deterministic admission, ranking, and activation
+- Authority calculation, approval, denial, and revocation
+- Context assembly, resource access, and memory access
+- Model invocation
+- Tool and skill-asset execution
+- Composition, amendment, and joins
+- Delegation, handoff, cancellation, and reconciliation
+- Evaluation execution and gate decisions
+- Evidence append and query
+- Skill release, compatibility, lifecycle, and dependency resolution
+- Agent discovery and protocol mapping
+
+Provider SDKs, model APIs, MCP clients, A2A clients, databases, message brokers, and external integrations remain adapters.
+
+## Required preflight decisions
+
+For every feature in scope, `architecture_preflight.md` must identify:
+
+- Accountable principal
+- Task offer and acceptance boundary
+- Task owner type and owner-epoch handling
+- Applicable primitives and logical roles
+- Adaptive proposals and trusted commit points
+- Authoritative aggregates and writers
+- Skill binding mode
+- External side effects and authority route
+- Context, memory, and resource trust needs
+- Failure, budget, and recovery policy
+- Evaluation and completion evidence
+- Applicable SOAA contract set
+
+## Prohibited patterns
+
+- A model or skill owning a task
+- Prompt text enforcing a permission or state transition
+- A skill declaration granting authority
+- External mutation without a trusted gateway
+- Durable state existing only in model context
+- Resource content promoting itself to instruction
+- Skill success or model confidence completing a task
+- Framework-specific types crossing domain ports
+- Hidden recursion, hidden dependencies, or unbounded loops
+- A conformance claim without the named profile, suite, target, environment, and evidence package
+
+## Minimum verification
+
+Verification must include:
+
+- Schema and port contract tests
+- State-transition and concurrency property tests
+- Authority, denial, and revocation tests
+- Selection and activation evaluation
+- Injection and untrusted-content tests
+- Side-effect, idempotency, and reconciliation tests
+- Failure, retry, cancellation, checkpoint, and recovery tests
+- Context, memory, and compaction tests
+- Delegation and handoff fault tests
+- Completion and evidence gates
+- Lifecycle and supply-chain tests
+
+The feature plan must link each affected control boundary to at least one verification family.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md
@@ -1,0 +1,208 @@
+# Skill Selection and Activation Contract
+
+## Source alignment
+
+| Field | Value |
+|---|---|
+| Primary decisions | SOAA-006, SOAA-008, SOAA-009 |
+| Primary invariants | SOAA-INV-021 through SOAA-INV-024 and SOAA-INV-030 through SOAA-INV-037 |
+| Source module | SOAA Packet 2 |
+
+## Purpose
+
+This contract separates semantic relevance from hard admission and separates proposed selection from active instruction binding.
+
+## Required four-stage pipeline
+
+Every dynamic skill selection follows:
+
+1. Candidate retrieval
+2. Deterministic admission
+3. Agent ranking
+4. Atomic activation
+
+No stage inherits the authority or result of a prior stage implicitly.
+
+## Stage 1: candidate retrieval
+
+Retrieval returns possibly relevant catalog entries based on task intent and visible metadata.
+
+Retrieval:
+
+- May use lexical, semantic, hierarchical, or rule-based search.
+- Must apply catalog visibility before returning a candidate.
+- Must use discovery metadata only.
+- Must record catalog snapshot and retrieval method.
+- Grants no eligibility, trust, authority, selection, or activation.
+
+Full skill instructions and executable assets remain unloaded.
+
+## Stage 2: deterministic admission
+
+Admission applies typed hard predicates to each candidate:
+
+- Release lifecycle state
+- Integrity and provenance
+- Runtime and protocol compatibility
+- Declared preconditions and exclusions
+- Dependency resolution
+- Conflict and composition policy
+- Trust and risk policy
+- Data-classification constraints
+- Authority feasibility
+
+Admission produces exactly one outcome:
+
+| Outcome | Meaning |
+|---|---|
+| `INELIGIBLE` | A hard non-authority requirement failed, or no permitted authority route exists |
+| `ELIGIBLE` | All hard requirements pass and required access is inside current effective authority |
+| `APPROVAL_ROUTABLE` | Hard requirements pass and one permitted scoped approval route exists |
+
+Semantic intent matching is prohibited inside the deterministic admission predicate.
+
+Admission must emit structured reason codes for every failed or approval-routable condition.
+
+## Stage 3: agent ranking
+
+The agent ranks only `ELIGIBLE` and `APPROVAL_ROUTABLE` entries.
+
+The ranking request and response must include:
+
+- Accepted task identity and revision
+- Candidate snapshot identity
+- Candidate status
+- Fit rationale
+- Uncertainty
+- Material alternatives
+- Approval need
+- Explicit null selection
+
+Null selection is always present. Ambiguity, insufficient fit, or unresolved same-level conflict produces null selection or escalation.
+
+The runtime must not silently substitute a different skill after ranking.
+
+## Binding modes
+
+| Mode | Selection source | Required controls |
+|---|---|---|
+| Dynamic | Agent ranks an admitted set | Retrieval, admission, ranking, authority, activation, lifecycle, context, evidence |
+| Fixed workflow | An approved workflow names an exact release or compatible range | Resolution, admission, authority, activation, lifecycle, context, evidence |
+
+Fixed workflow binding removes ranking for one node. It never bypasses admission or activation.
+
+## Conflict and composition
+
+Relationships among skills must be explicit:
+
+- Depends on
+- Conflicts with
+- Excludes
+- Replaces
+- Precedes
+- Follows
+- Composes with
+
+A multi-skill run requires a versioned CompositionPlan with exact nodes, data flow, dependencies, authority and budget allocation, conflict rules, joins, cancellation propagation, failure routes, and safe amendment points.
+
+Hidden recursive activation and hidden dependencies are prohibited.
+
+## Stage 4: atomic activation
+
+Before commit, the Capability Controller must revalidate:
+
+- Task identity, revision, owner, and owner epoch
+- Selection and candidate snapshot
+- Skill lifecycle state and package digest
+- Integrity, provenance, trust, and compatibility
+- Dependency lock
+- Policy and authority context
+- Approval validity
+- Composition or fixed-workflow binding
+- Evaluation and evidence profile
+- Context and instruction references
+
+One activation transaction commits:
+
+- Exact release identity and digest
+- Bound task and agent run
+- Selection record
+- Dependency lock
+- Effective authority envelope
+- Instruction binding
+- Context snapshot reference
+- Evaluation and evidence profile
+- Activation state
+- Activation evidence
+
+Instructions become visible only after commit. A failed transaction leaves zero active state and zero active instructions.
+
+## Activation lifecycle
+
+Supported states are:
+
+```text
+SELECTED
+APPROVAL_PENDING
+ACTIVATING
+ACTIVE
+SUSPENDED
+TERMINATING
+SUCCEEDED
+FAILED
+STOPPED
+ESCALATED
+DENIED
+STALE
+ACTIVATION_FAILED
+```
+
+Only the Capability Controller commits activation transitions.
+
+Material changes to task, owner, policy, authority, approval, catalog, lifecycle, dependency, workflow binding, context, or environment require revalidation. Stale inputs produce `STALE`, not best-effort activation.
+
+## Fallback rules
+
+Fallback may:
+
+- Select null
+- Select another independently admitted candidate
+- Request clarification
+- Route scoped approval
+- Escalate
+
+Fallback must not:
+
+- Weaken policy
+- Broaden authority
+- Use a revoked or incompatible release
+- Skip required evaluation
+- Substitute an unranked skill silently
+- Drop required evidence
+
+## Required evidence
+
+Preserve evidence for:
+
+- Candidate retrieval, including null outcome
+- Admission outcome and reason codes for every candidate
+- Ranking proposal, uncertainty, alternatives, and null option
+- Approval route and decision
+- Revalidation snapshots
+- Activation commit or failed transaction
+- Instruction exposure point
+- Exact release and dependency lock
+
+## Verification
+
+Tests must prove:
+
+- A highly ranked ineligible skill never reaches ranking or activation.
+- Admission uses typed hard predicates only.
+- Ranking always contains null selection.
+- Same-level conflict results in null or escalation.
+- Fault injection at each commit boundary leaves no partial activation.
+- Instructions remain hidden before commit.
+- Stale inputs block commit.
+- Fixed binding still passes admission, authority, and activation.
+- Fallback preserves or narrows every control.

--- a/extensions/skill-oriented-agent-architecture/manifest.yaml
+++ b/extensions/skill-oriented-agent-architecture/manifest.yaml
@@ -1,0 +1,171 @@
+id: skill-oriented-agent-architecture
+name: Skill-Oriented Agent Architecture Extension
+version: 0.1.0
+description: Adds provider-neutral architecture contracts for governed applications in which accountable agent runs select and apply versioned procedural skills inside deterministic control boundaries.
+govkit_min_version: 0.13.0
+extension_type: architecture
+supported_levels:
+  - 5
+supported_project_types:
+  - api
+  - cli
+
+contract_sets:
+  - id: soaa_core
+    description: Core SOAA semantics, responsibility boundaries, task ownership, runtime state, and skill contracts.
+    paths:
+      - docs/backend/architecture/SKILL_ORIENTED_AGENT_ARCHITECTURE.md
+      - docs/backend/architecture/SKILL_CONTRACT.md
+      - docs/backend/architecture/RUNTIME_STATE_AND_EXECUTION_CONTRACT.md
+    applies_to:
+      - "**/*agent*"
+      - "**/*skill*"
+      - "**/*task*"
+      - "**/*runtime*"
+      - "**/*orchestrat*"
+      - "**/*workflow*"
+    capabilities:
+      - governed-agent-runtime
+      - procedural-skills
+      - task-ownership
+      - deterministic-control-boundary
+      - provider-neutral-agent-architecture
+    relates_to:
+      extends:
+        - docs/backend/architecture/ARCH_CONTRACT.md
+        - docs/backend/architecture/BOUNDARIES.md
+      supersedes:
+        - docs/backend/architecture/AGENT_ARCHITECTURE.md
+
+  - id: soaa_selection_authority
+    description: Skill retrieval, deterministic admission, ranking, activation, effective authority, approval, revocation, and instruction precedence.
+    paths:
+      - docs/backend/architecture/SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md
+      - docs/backend/architecture/AUTHORITY_AND_APPROVAL_CONTRACT.md
+    applies_to:
+      - "**/*catalog*"
+      - "**/*registry*"
+      - "**/*select*"
+      - "**/*rank*"
+      - "**/*admission*"
+      - "**/*activation*"
+      - "**/*authoriz*"
+      - "**/*permission*"
+      - "**/*approval*"
+      - "**/*policy*"
+    capabilities:
+      - deterministic-skill-admission
+      - skill-ranking
+      - atomic-skill-activation
+      - effective-authority
+      - scoped-approval
+      - revocation
+      - instruction-precedence
+    relates_to:
+      extends:
+        - docs/backend/architecture/SECURITY_AUTH_PATTERNS.md
+        - docs/backend/architecture/GUARDRAILS_CONTRACT.md
+      supersedes: []
+
+  - id: soaa_context_resilience
+    description: Immutable context snapshots, progressive disclosure, resource trust, governed memory, failure handling, recovery, budgets, and operational telemetry.
+    paths:
+      - docs/backend/architecture/CONTEXT_MEMORY_AND_RESOURCE_CONTRACT.md
+      - docs/backend/architecture/RESILIENCE_AND_RECOVERY_CONTRACT.md
+    applies_to:
+      - "**/*context*"
+      - "**/*memory*"
+      - "**/*resource*"
+      - "**/*retriev*"
+      - "**/*checkpoint*"
+      - "**/*retry*"
+      - "**/*recover*"
+      - "**/*budget*"
+      - "**/*telemetr*"
+      - "**/*observab*"
+    capabilities:
+      - progressive-context
+      - context-snapshots
+      - resource-trust
+      - governed-memory
+      - bounded-retry
+      - reconciliation
+      - compensation
+      - execution-budgets
+    relates_to:
+      extends:
+        - docs/backend/architecture/OBSERVABILITY_PORT_CONTRACT.md
+        - docs/backend/architecture/OBSERVABILITY_LLM_CONTRACT.md
+      supersedes: []
+
+  - id: soaa_assurance
+    description: Evaluation definitions, oracle selection, completion gates, evidence integrity, and conformance claim boundaries.
+    paths:
+      - docs/backend/architecture/EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md
+    applies_to:
+      - "**/*eval*"
+      - "**/*grader*"
+      - "**/*evidence*"
+      - "**/*complete*"
+      - "**/*verify*"
+      - "**/*conformance*"
+      - "**/*test*"
+    capabilities:
+      - agent-evaluation
+      - skill-admission-evaluation
+      - completion-gates
+      - durable-evidence
+      - conformance-claims
+    relates_to:
+      extends:
+        - docs/backend/architecture/TESTING.md
+        - docs/backend/architecture/EVALUATION_LLM_CONTRACT.md
+      supersedes: []
+
+  - id: soaa_ecosystem
+    description: Governed skill release lifecycle, version identity, supply-chain controls, Agent Skills packaging, MCP and A2A mappings, and portability.
+    paths:
+      - docs/backend/architecture/SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md
+    applies_to:
+      - "**/SKILL.md"
+      - "**/soaa/manifest.yaml"
+      - "**/*release*"
+      - "**/*version*"
+      - "**/*package*"
+      - "**/*provenance*"
+      - "**/*mcp*"
+      - "**/*a2a*"
+      - "**/*protocol*"
+      - "**/*interop*"
+    capabilities:
+      - governed-skill-lifecycle
+      - exact-release-binding
+      - skill-supply-chain
+      - agent-skills-profile
+      - mcp-mapping
+      - a2a-mapping
+      - runtime-portability
+    relates_to:
+      extends:
+        - docs/backend/architecture/LLM_GATEWAY_CONTRACT.md
+      supersedes: []
+
+agent_guidance:
+  architecture_preflight:
+    - Read this manifest before planning any feature involving agents, skills, adaptive orchestration, tool use, delegation, memory, or agent evaluation.
+    - Load soaa_core first, then load only the additional contract sets matched by feature intent and touched files.
+    - Classify every relevant component as agent run, skill, tool, resource, workflow, policy, evaluator, memory, or trusted controller.
+    - Record the accountable principal, accepted task boundary, single runtime owner, authoritative state writers, external side effects, approval routes, and completion evidence.
+    - List every applicable SOAA contract in architecture_preflight.md.
+    - Require an ADR for an extension, override, or violation of these contracts.
+  implementation_plan:
+    - Separate adaptive model proposals from deterministic validation and commit paths.
+    - Map every authoritative aggregate to one trusted writer, typed port, persistence boundary, and verification family.
+    - Bind each activation to one exact admitted skill release, authority envelope, context snapshot, dependency lock, and evidence profile.
+    - Give every mutating external operation a durable identity, fresh authorization, idempotency rule, reconciliation route, and evidence record.
+    - Include negative, fault-injection, concurrency, recovery, evaluation, and evidence tests for every affected control boundary.
+  validation:
+    - Validate every declared contract path after extension installation.
+    - Reject direct model writes to authoritative state, direct skill grants, hidden skill activation, and task completion based only on skill or model success.
+    - Verify one active task owner, deterministic admission before ranking, atomic activation, fresh operation authorization, bounded execution, and an independent completion gate.
+    - Treat missing, stale, conflicting, or invalid evidence as a blocked or inconclusive gate, never implicit success.

--- a/plans/SKILL_ORIENTED_AGENT_ARCHITECTURE_EXTENSION_PLAN.md
+++ b/plans/SKILL_ORIENTED_AGENT_ARCHITECTURE_EXTENSION_PLAN.md
@@ -1,0 +1,93 @@
+# Skill-Oriented Agent Architecture Extension Plan
+
+## Status
+
+Implementation complete on `feature/skill-oriented-agent-architecture`.
+
+## Outcome
+
+Add a bundled GovKit architecture extension that translates the approved SOAA v0.2 architecture into focused guidance for Codex, Claude Code, and Copilot while they implement agentic applications.
+
+## Binding source
+
+- SOAA v0.2, approved 2026-07-18
+- Decisions SOAA-001 through SOAA-020
+- Invariants SOAA-INV-001 through SOAA-INV-206
+- Midpoint amendments SOAA-MID-001 through SOAA-MID-006
+- Packet 7 integration review score: 93.13 out of 100
+
+## Scope
+
+- [x] Inspect the current GovKit extension mechanism and bundled examples.
+- [x] Resolve the approved SOAA source set.
+- [x] Define profile-based contract loading.
+- [x] Add the new extension manifest and README.
+- [x] Add architecture guidance contracts.
+- [x] Add manifest, content, installation, and validation tests.
+- [x] Update root extension documentation.
+- [x] Run focused and full verification.
+
+## Verification result
+
+- Focused extension and schema suite: 167 passed.
+- Full repository suite: 1047 passed, 1 skipped.
+- Diff whitespace validation: passed.
+- Wheel build and bundled-extension inventory: passed.
+
+## Extension structure
+
+```text
+extensions/skill-oriented-agent-architecture/
+├── manifest.yaml
+├── README.md
+└── docs/backend/architecture/
+    ├── SKILL_ORIENTED_AGENT_ARCHITECTURE.md
+    ├── SKILL_CONTRACT.md
+    ├── RUNTIME_STATE_AND_EXECUTION_CONTRACT.md
+    ├── SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md
+    ├── AUTHORITY_AND_APPROVAL_CONTRACT.md
+    ├── CONTEXT_MEMORY_AND_RESOURCE_CONTRACT.md
+    ├── RESILIENCE_AND_RECOVERY_CONTRACT.md
+    ├── EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md
+    └── SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md
+```
+
+## Design rules
+
+- Preserve provider and framework neutrality.
+- Keep adaptive proposals separate from trusted commits.
+- Load contract sets progressively by feature applicability.
+- Preserve one task owner, deterministic admission, exact-release activation, effective authority, fresh operation authorization, and independent completion.
+- Treat skill procedure as context, not executable authority.
+- Map every authoritative aggregate to one trusted writer.
+- Require durable evidence across selection, activation, action, evaluation, and completion.
+- Keep SOAA conformance claims outside this guidance profile until the 206-assertion suite exists.
+
+## Existing agentic-skills extension
+
+The existing `agentic-skills` extension governs a specific skill-family and phase-state-machine design. It is a runtime application extension, not a coding-agent-only skill pack. Its scope overlaps the new SOAA extension.
+
+This increment leaves it unchanged to avoid an unrequested deletion. After the new extension is reviewed, retire `agentic-skills` or rename it only if its product-specific family model remains useful. Do not install both extensions in one consuming project.
+
+## LLM application extension decision
+
+Create a separate `llm-application` extension in a follow-on change.
+
+Rationale:
+
+- LLM applications exist without agents or skills.
+- SOAA does not require one model provider, gateway, evaluator, telemetry system, or guardrail product.
+- Skill runtimes and LLM operations evolve at different rates.
+- Separate packages prevent LLM vendor choices from entering the SOAA control model.
+- Vision, RAG, assistant, and agent extensions should reference one shared LLM application package.
+
+The package should own four provider-neutral contracts:
+
+- `LLM_GATEWAY_CONTRACT.md`
+- `LLM_EVALUATION_CONTRACT.md`
+- `LLM_OBSERVABILITY_CONTRACT.md`
+- `MODEL_GUARDRAILS_CONTRACT.md`
+
+Current product choices such as LiteLLM, OpenLLMetry, Langfuse, DeepEval, Promptfoo, RAGAS, NeMo Guardrails, and Guardrails AI should move into an implementation profile or guide layer rather than remain mandatory architecture.
+
+Extracting the package is a separate change because current Level 5 manifests, rules, skills, CI gates, starter features, setup guides, stack documents, tests, and the vision extension all reference the four core files.

--- a/plans/SKILL_ORIENTED_AGENT_ARCHITECTURE_EXTENSION_PLAN.md
+++ b/plans/SKILL_ORIENTED_AGENT_ARCHITECTURE_EXTENSION_PLAN.md
@@ -30,7 +30,8 @@ Add a bundled GovKit architecture extension that translates the approved SOAA v0
 ## Verification result
 
 - Focused extension and schema suite: 167 passed.
-- Full repository suite: 1047 passed, 1 skipped.
+- Agent Skills compatibility amendment suite: 28 passed.
+- Full repository suite: 1048 passed, 1 skipped.
 - Diff whitespace validation: passed.
 - Wheel build and bundled-extension inventory: passed.
 

--- a/tests/test_cmd_extension.py
+++ b/tests/test_cmd_extension.py
@@ -25,7 +25,11 @@ def test_extension_packs_dir_exists_and_has_bundled_packs():
         for p in paths.EXTENSION_PACKS_DIR.iterdir()
         if p.is_dir() and not p.name.startswith(".")
     }
-    assert {"agentic-skills", "vision-inference"} <= ids, f"bundled packs missing; found {ids}"
+    assert {
+        "agentic-skills",
+        "skill-oriented-agent-architecture",
+        "vision-inference",
+    } <= ids, f"bundled packs missing; found {ids}"
 
 
 def test_extension_list_prints_bundled_packs(capsys):
@@ -33,6 +37,7 @@ def test_extension_list_prints_bundled_packs(capsys):
     out = capsys.readouterr().out
     assert "vision-inference" in out
     assert "agentic-skills" in out
+    assert "skill-oriented-agent-architecture" in out
 
 
 def test_extension_list_shows_supported_levels_and_types(capsys):

--- a/tests/test_skill_oriented_agent_architecture.py
+++ b/tests/test_skill_oriented_agent_architecture.py
@@ -170,6 +170,48 @@ def test_completion_contract_rejects_self_asserted_success():
     assert "task controller transition" in folded
 
 
+def test_agent_skills_profile_defines_standard_compatibility_boundary():
+    contract = (
+        EXT_DIR
+        / "docs"
+        / "backend"
+        / "architecture"
+        / "SKILL_CONTRACT.md"
+    ).read_text(encoding="utf-8")
+    lifecycle = (
+        EXT_DIR
+        / "docs"
+        / "backend"
+        / "architecture"
+        / "SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md"
+    ).read_text(encoding="utf-8")
+
+    for phrase in (
+        "SOAA profile for Agent Skills packages",
+        "string keys mapped to string values",
+        "soaa-profile",
+        "soaa-manifest",
+        "soaa-manifest-digest",
+        "soaa-release-id",
+        "Generic-client behavior",
+        "must not claim SOAA package-profile or runtime conformance",
+        "skills-ref validate <skill-root>",
+        "Two-stage validation",
+        "intersect runtime_policy",
+        "intersect task_authority",
+        "intersect approval_scope",
+    ):
+        assert phrase in contract
+
+    for phrase in (
+        "Flat string metadata keys",
+        "may ignore `soaa/`",
+        "must not claim SOAA conformance",
+        "intersection of that ceiling, runtime policy, task authority, and approval scope",
+    ):
+        assert phrase in lifecycle
+
+
 def test_contracts_are_provider_and_framework_neutral():
     prohibited_product_names = {
         "langgraph",

--- a/tests/test_skill_oriented_agent_architecture.py
+++ b/tests/test_skill_oriented_agent_architecture.py
@@ -1,0 +1,207 @@
+"""Tests for the bundled Skill-Oriented Agent Architecture extension."""
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from cli.cmd_extension import cmd_extension_add
+from cli.extensions import discover_extensions, validate_extension
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXT_DIR = REPO_ROOT / "extensions" / "skill-oriented-agent-architecture"
+MANIFEST_PATH = EXT_DIR / "manifest.yaml"
+SCHEMA_PATH = (
+    REPO_ROOT
+    / "extensions"
+    / "agentic-skills"
+    / "schemas"
+    / "extension-manifest.schema.json"
+)
+
+REQUIRED_CONTRACT_SETS = {
+    "soaa_core",
+    "soaa_selection_authority",
+    "soaa_context_resilience",
+    "soaa_assurance",
+    "soaa_ecosystem",
+}
+
+REQUIRED_CONTRACTS = {
+    "docs/backend/architecture/SKILL_ORIENTED_AGENT_ARCHITECTURE.md",
+    "docs/backend/architecture/SKILL_CONTRACT.md",
+    "docs/backend/architecture/RUNTIME_STATE_AND_EXECUTION_CONTRACT.md",
+    "docs/backend/architecture/SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md",
+    "docs/backend/architecture/AUTHORITY_AND_APPROVAL_CONTRACT.md",
+    "docs/backend/architecture/CONTEXT_MEMORY_AND_RESOURCE_CONTRACT.md",
+    "docs/backend/architecture/RESILIENCE_AND_RECOVERY_CONTRACT.md",
+    "docs/backend/architecture/EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md",
+    "docs/backend/architecture/SKILL_LIFECYCLE_AND_INTEROPERABILITY_CONTRACT.md",
+}
+
+
+def _manifest() -> dict:
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def _declared_paths() -> list[str]:
+    return [
+        path
+        for contract_set in _manifest()["contract_sets"]
+        for path in contract_set.get("paths", [])
+    ]
+
+
+def test_extension_is_discovered():
+    extensions = discover_extensions(REPO_ROOT)
+    assert any(
+        extension.id == "skill-oriented-agent-architecture"
+        for extension in extensions
+    )
+
+
+def test_extension_validates_cleanly_against_repo():
+    extension = next(
+        (
+            item
+            for item in discover_extensions(REPO_ROOT)
+            if item.id == "skill-oriented-agent-architecture"
+        ),
+        None,
+    )
+    assert extension is not None
+    assert validate_extension(extension, REPO_ROOT) == []
+
+
+def test_manifest_matches_extension_schema():
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = list(Draft202012Validator(schema).iter_errors(_manifest()))
+    assert errors == []
+
+
+def test_manifest_targets_level_5_backend_shapes():
+    manifest = _manifest()
+    assert manifest["supported_levels"] == [5]
+    assert set(manifest["supported_project_types"]) == {"api", "cli"}
+
+
+def test_manifest_declares_all_soaa_contract_sets():
+    ids = {contract_set["id"] for contract_set in _manifest()["contract_sets"]}
+    assert ids == REQUIRED_CONTRACT_SETS
+
+
+def test_every_required_contract_is_declared_once_and_exists():
+    paths = _declared_paths()
+    assert set(paths) == REQUIRED_CONTRACTS
+    assert len(paths) == len(set(paths))
+    for path in paths:
+        assert (EXT_DIR / path).is_file(), f"missing declared contract: {path}"
+
+
+def test_core_profile_supersedes_generic_agent_architecture():
+    core = next(
+        item for item in _manifest()["contract_sets"] if item["id"] == "soaa_core"
+    )
+    supersedes = set(core["relates_to"]["supersedes"])
+    assert "docs/backend/architecture/AGENT_ARCHITECTURE.md" in supersedes
+
+
+def test_all_core_relationship_paths_exist():
+    for contract_set in _manifest()["contract_sets"]:
+        relationships = contract_set.get("relates_to", {})
+        for kind in ("extends", "supersedes"):
+            for path in relationships.get(kind, []):
+                assert (REPO_ROOT / path).is_file(), (
+                    f"{contract_set['id']} declares missing {kind} path: {path}"
+                )
+
+
+def test_architecture_contract_preserves_control_boundary():
+    text = (
+        EXT_DIR
+        / "docs"
+        / "backend"
+        / "architecture"
+        / "SKILL_ORIENTED_AGENT_ARCHITECTURE.md"
+    ).read_text(encoding="utf-8")
+    required_phrases = [
+        "exactly one runtime owner",
+        "Model output is a proposal",
+        "Fresh authorization before each external operation",
+        "Skill versus application code",
+        "Eighteen",
+    ]
+    for phrase in required_phrases:
+        assert phrase.casefold() in text.casefold()
+
+
+def test_selection_contract_preserves_four_stage_pipeline_and_null_option():
+    text = (
+        EXT_DIR
+        / "docs"
+        / "backend"
+        / "architecture"
+        / "SKILL_SELECTION_AND_ACTIVATION_CONTRACT.md"
+    ).read_text(encoding="utf-8")
+    for phrase in (
+        "Candidate retrieval",
+        "Deterministic admission",
+        "Agent ranking",
+        "Atomic activation",
+        "Null selection is always present",
+    ):
+        assert phrase in text
+
+
+def test_completion_contract_rejects_self_asserted_success():
+    text = (
+        EXT_DIR
+        / "docs"
+        / "backend"
+        / "architecture"
+        / "EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md"
+    ).read_text(encoding="utf-8")
+    folded = text.casefold()
+    assert "agent confidence" in folded
+    assert "skill success" in folded
+    assert "verifying" in folded
+    assert "task controller transition" in folded
+
+
+def test_contracts_are_provider_and_framework_neutral():
+    prohibited_product_names = {
+        "langgraph",
+        "langchain",
+        "litellm",
+        "langfuse",
+        "deepeval",
+        "promptfoo",
+        "ragas",
+        "nemo guardrails",
+        "guardrails ai",
+    }
+    for path in REQUIRED_CONTRACTS:
+        text = (EXT_DIR / path).read_text(encoding="utf-8").casefold()
+        found = sorted(name for name in prohibited_product_names if name in text)
+        assert found == [], f"{path} contains product-specific architecture: {found}"
+
+
+def test_bundled_extension_add_copies_profile(tmp_path, capsys):
+    args = type(
+        "Args",
+        (),
+        {
+            "extension_id": "skill-oriented-agent-architecture",
+            "target": str(tmp_path),
+            "force": False,
+        },
+    )()
+    cmd_extension_add(args)
+    capsys.readouterr()
+
+    installed = tmp_path / "extensions" / "skill-oriented-agent-architecture"
+    assert (installed / "manifest.yaml").is_file()
+    for path in REQUIRED_CONTRACTS:
+        assert (installed / path).is_file()


### PR DESCRIPTION
## Summary

- Add the bundled `skill-oriented-agent-architecture` extension.
- Translate approved SOAA v0.2 decisions into nine provider-neutral architecture contracts.
- Group guidance into five progressive contract sets for core semantics, selection and authority, context and resilience, assurance, and lifecycle interoperability.
- Supersede the generic `AGENT_ARCHITECTURE.md` contract when installed.
- Define a compatible SOAA profile for Agent Skills packages using a standard root `SKILL.md` plus an optional `soaa/` extension directory.
- Specify flat string metadata keys, generic-client behavior, two-stage validation, and the `allowed-tools` authority ceiling.
- Update extension discovery documentation, the changelog, and focused installation, manifest, and interoperability tests.

## Why

GovKit needs architecture guidance for agentic coding tools where adaptive model behavior remains inside deterministic control boundaries. The extension defines ownership of tasks, runtime state, authority, side effects, recovery, evidence, and completion without binding teams to one model provider or agent framework.

The Agent Skills package profile preserves base-format compatibility while reserving SOAA conformance claims for packages and runtimes that validate and enforce the additional governance contract.

The existing `agentic-skills` extension remains available for its product-specific skill-family and phase model. Projects should not install both extensions together.

## User impact

Level 5 API and CLI projects may install the package with:

```bash
govkit extension add skill-oriented-agent-architecture --target .
```

GovKit architecture preflight then loads the core SOAA set first and adds only the contract sets relevant to the feature and touched files.

## Validation

- Initial focused extension and schema suite: 167 passed.
- Agent Skills compatibility amendment suite: 28 passed.
- Full repository suite: 1,048 passed, 1 skipped.
- `git diff --check` passed.
- Built the wheel and verified every new extension file is bundled.
