### PR TITLE
feat: implementation-profile mechanism + AGENT_RUNTIME_STACK & GATEWAY_STACK profiles

### DIFF
--- a/cli/extensions.py
+++ b/cli/extensions.py
@@ -226,6 +226,33 @@ def _check_templates(manifest: dict, ext: Extension) -> list[str]:
     return issues
 
 
+def _check_implementation_profiles(manifest: dict, ext: Extension) -> list[str]:
+    """Validate implementation_profiles[].path like contract paths.
+
+    An implementation profile maps a contract set to concrete default product
+    bindings (e.g. "the runtime defaults to LangGraph"). Unlike contract_sets,
+    profiles are *allowed* to name products and refine a contract, so they are
+    deliberately excluded from the neutrality/overlap heuristic
+    (`_check_undeclared_overlap` scans contract_sets only). Here we only enforce
+    the same path-safety rules: each profile must declare a relative, contained,
+    existing file under the extension folder.
+    """
+    profiles = manifest.get("implementation_profiles")
+    if not isinstance(profiles, list):
+        return []
+    issues: list[str] = []
+    for i, prof in enumerate(profiles):
+        if not isinstance(prof, dict):
+            issues.append(f"implementation_profiles[{i}] must be a mapping")
+            continue
+        path = prof.get("path")
+        if path is None:
+            issues.append(f"implementation_profiles[{i}].path is required")
+            continue
+        issues.extend(_check_path_entry(f"implementation_profiles[{i}].path", path, ext))
+    return issues
+
+
 def _check_relates_to_field(
     label: str, paths: object, target: Path
 ) -> list[str]:
@@ -348,6 +375,8 @@ def validate_extension(ext: Extension, target: Path) -> list[str]:
       - id format and folder-name match
       - contract_sets[].paths exist under ext.root
       - templates[].path exist under ext.root
+      - implementation_profiles[].path exist under ext.root (product-naming
+        profiles; exempt from the neutrality/overlap heuristic by design)
 
     Returns [] when fully valid. The `target` parameter is used for
     project-root-relative checks (relates_to.extends/supersedes paths,
@@ -360,6 +389,7 @@ def validate_extension(ext: Extension, target: Path) -> list[str]:
         *_check_id(m, ext),
         *_check_contract_sets(m, ext),
         *_check_templates(m, ext),
+        *_check_implementation_profiles(m, ext),
         *_check_relates_to(m, target),
         *_check_undeclared_overlap(m, target),
     ]

--- a/extensions/agentic-skills/schemas/extension-manifest.schema.json
+++ b/extensions/agentic-skills/schemas/extension-manifest.schema.json
@@ -80,6 +80,40 @@
         }
       }
     },
+    "implementation_profiles": {
+      "type": "array",
+      "description": "Product-naming profiles that map contract sets to concrete default product bindings the consuming team may customize. Unlike contract_sets, a profile is allowed to name products (LangGraph, LiteLLM, …) and refine a contract; it is advisory and the neutral contract remains authoritative on conflict. Profiles are exempt from the undeclared-overlap heuristic.",
+      "items": {
+        "type": "object",
+        "required": ["id", "path"],
+        "properties": {
+          "id": { "type": "string" },
+          "description": { "type": "string" },
+          "path": {
+            "type": "string",
+            "description": "Extension-folder-relative path to the implementation-profile document (defaults the team can customize)."
+          },
+          "profiles_for": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "contract_set ids this profile supplies default product bindings for."
+          },
+          "authority": {
+            "type": "string",
+            "enum": ["defaults"],
+            "description": "'defaults' — the profile is advisory; the neutral contract wins on any conflict."
+          },
+          "product_selection_requires_adr": {
+            "type": "boolean",
+            "description": "When true, deviating from the profile's default product bindings requires an ADR in the consuming project."
+          },
+          "gate": {
+            "type": "string",
+            "description": "Reserved for a future blocking conformance gate. Advisory-only today; no CI gate is wired to profiles."
+          }
+        }
+      }
+    },
     "agent_guidance": {
       "type": "object",
       "description": "Named guidance blocks read by agent skills. Keys are phase names (e.g. architecture_preflight, implementation_plan, validation); values are arrays of instruction strings.",

--- a/extensions/llm-application/README.md
+++ b/extensions/llm-application/README.md
@@ -53,3 +53,14 @@ Install both for a skill-oriented agent that invokes language models. SOAA const
 ## Implementation profiles
 
 An implementation profile may select a gateway, evaluation framework, telemetry backend, or guardrail library. A profile must map each product to the ports and evidence defined here, pin compatible versions, document operational ownership, and preserve substitutability. Product selection never grants an SDK permission to cross an application boundary.
+
+The extension ships one such profile — `docs/backend/architecture/GATEWAY_STACK.md` —
+with **default product bindings** (LiteLLM for the gateway, OpenLLMetry → Langfuse
+for telemetry, NeMo Guardrails / Guardrails AI for guardrails) that a team can adopt
+and then customize. It is **advisory** (`authority: defaults`): the contracts remain
+authoritative, and deviating from a default requires an ADR
+(`product_selection_requires_adr: true`). It is declared under `implementation_profiles`
+in the manifest, not `contract_sets`, because it names products — the neutrality the
+contracts hold does not apply to it. Evaluation products are not restated in the
+profile; they are governed by the core `EVAL_STACK.md`. No blocking CI conformance
+gate is wired to the profile today.

--- a/extensions/llm-application/docs/backend/architecture/GATEWAY_STACK.md
+++ b/extensions/llm-application/docs/backend/architecture/GATEWAY_STACK.md
@@ -1,0 +1,90 @@
+# Gateway Stack
+
+This document defines the **default product bindings** for the LLM application
+ports. It is an *implementation profile*: it maps the provider-neutral concerns
+that this extension's contracts define — model access, guardrails, observability,
+evaluation — to concrete products a team can adopt as a starting point and then
+customize.
+
+**Authority: advisory (`defaults`).** The contracts remain authoritative:
+`LLM_GATEWAY_CONTRACT.md`, `MODEL_GUARDRAILS_CONTRACT.md`,
+`LLM_OBSERVABILITY_CONTRACT.md`, and `LLM_EVALUATION_CONTRACT.md`. Where this
+profile and a contract disagree, the contract wins. Selecting a product never
+grants its SDK permission to cross an application boundary — every product below
+sits inside an outbound adapter behind a typed application port. Deviating from a
+default binding requires an **ADR** in the consuming project.
+
+The contracts define the *what* (an application-owned `ModelGatewayPort`, logical
+model routing, fail-closed guardrails, immutable provenance). This document
+defines a default *how*.
+
+> **No blocking CI conformance gate ships with this profile.** The products below
+> are guidance. Bundled setup guides under `docs/backend/guides/` show concrete
+> configuration; the evaluation row is governed by the core `EVAL_STACK.md`.
+
+---
+
+## 1. Concern → port → default binding
+
+| Concern (contract) | Application port | Default binding | Setup guide |
+|---|---|---|---|
+| Model access · logical routing · resilience · budgets (`LLM_GATEWAY_CONTRACT`) | **`ModelGatewayPort`** | **LiteLLM** proxy (model aliases, fallback chains) | `docs/backend/guides/litellm-setup.md` |
+| Providers behind the gateway | `ModelGatewayPort` adapters | **OpenAI · Anthropic · Azure OpenAI** (logical identities, not hard-coded model ids) | — |
+| Model telemetry · trace correlation · provenance (`LLM_OBSERVABILITY_CONTRACT`) | **`ObservabilityPort`** | **OpenLLMetry** (instrumentation) → **Langfuse** (traces, prompt versions, dashboards) | `docs/backend/guides/openllmetry-setup.md`, `langfuse-integration.md` |
+| Input · context · tool-call · output controls (`MODEL_GUARDRAILS_CONTRACT`) | guardrail adapter | **NeMo Guardrails** (dialog/behavioral) + **Guardrails AI** (structured-output validation) | `docs/backend/guides/nemo-guardrails-setup.md`, `guardrails-ai-setup.md` |
+| Quality · adversarial · retrieval · regression evaluation (`LLM_EVALUATION_CONTRACT`) | evaluation port | **DeepEval** (quality) · **Promptfoo** (adversarial) · **RAGAS** (retrieval) | governed by core `EVAL_STACK.md` |
+
+The evaluation row is **not duplicated here** — the core `docs/backend/evaluation/EVAL_STACK.md`
+already owns the evaluator product mapping and its CI gates. This profile points
+to it so the gateway and evaluation stories stay consistent.
+
+Keep every vendor SDK inside `adapters/`; domain and application services depend
+only on the typed ports (per `ARCH_CONTRACT.md` / `BOUNDARIES.md`). Model output is
+a proposal — deterministic validation, authorization, and side-effect commit paths
+stay separate from the model call.
+
+## 2. Defaults by environment
+
+| Environment | Gateway | Observability | Guardrails | Evaluation |
+|---|---|---|---|---|
+| Local dev | LiteLLM optional (direct provider ok) | optional | optional | per `EVAL_STACK.md` |
+| CI | LiteLLM (recorded/replayed) | disabled | **enforced for untrusted-input features** | per `EVAL_STACK.md` |
+| Staging | LiteLLM | Langfuse enabled | enforced | per `EVAL_STACK.md` |
+| Production | **LiteLLM (required)** | **Langfuse (required)** | **enforced, fail-closed** | per `EVAL_STACK.md` |
+
+## 3. Relationship to the agent runtime
+
+This profile governs **model calls**. When those calls happen inside a
+skill-oriented agent runtime, the runtime itself is governed by the
+`skill-oriented-agent-architecture` extension and its `AGENT_RUNTIME_STACK.md`
+profile. The two are complementary: the runtime profile owns the graph, task
+ownership, and evidence; this profile owns the gateway, guardrails, telemetry, and
+evaluation of the model calls the runtime makes.
+
+## 4. Customization for new projects
+
+Review, in order:
+
+- **Gateway** — LiteLLM by default; a hosted gateway or direct provider adapters
+  are legitimate, but the application-owned `ModelGatewayPort` boundary is not
+  optional. Swapping the gateway product requires an ADR.
+- **Providers** — declare logical model identities; never hard-code provider model
+  ids in domain code.
+- **Observability** — OpenLLMetry → Langfuse by default; confirm redaction of raw
+  prompts/responses per the observability contract.
+- **Guardrails** — enable the input/output controls the feature's trust boundary
+  requires; guardrails are fail-closed.
+- **Evaluation** — follow `EVAL_STACK.md`; do not re-specify evaluators here.
+
+## 5. When an ADR is required
+
+An ADR must be created when:
+
+- Selecting or replacing the gateway product or a provider.
+- Replacing the observability or guardrail products named above.
+- Bypassing the `ModelGatewayPort` boundary for any model call.
+- Any material change to routing, safety, evaluation, or telemetry policy.
+
+Record the selected products and every deviation from this profile in an ADR
+(`docs/backend/architecture/ADR/`), and reflect the standing choice wherever your
+project records its approved stack (e.g. `TECH_STACK.md`).

--- a/extensions/llm-application/manifest.yaml
+++ b/extensions/llm-application/manifest.yaml
@@ -113,10 +113,22 @@ contract_sets:
         - docs/backend/architecture/TESTING.md
       supersedes: []
 
+implementation_profiles:
+  - id: gateway_profile
+    description: Default product bindings for the LLM application ports (gateway, guardrails, observability). Advisory — the contracts remain authoritative; deviations require an ADR. Evaluation products are governed by the core EVAL_STACK.md.
+    path: docs/backend/architecture/GATEWAY_STACK.md
+    profiles_for:
+      - llm_gateway
+      - llm_observability
+      - model_guardrails
+    authority: defaults
+    product_selection_requires_adr: true
+
 agent_guidance:
   architecture_preflight:
     - Read this manifest before planning any feature that invokes, embeds, evaluates, monitors, or constrains a language model.
     - Load llm_gateway for every model-backed feature, then load only the additional contract sets matched by feature intent and touched files.
+    - Read GATEWAY_STACK.md for default product bindings, but treat it as advisory — the contracts win on any conflict, and deviating from a default requires an ADR.
     - Record logical model capabilities, data classifications, trust boundaries, side effects, guardrail policy, evaluation gates, telemetry fields, budgets, and failure behavior.
     - List every applicable LLM application contract in architecture_preflight.md.
     - Require an ADR for a provider or product selection, contract exception, or material routing, safety, evaluation, or telemetry policy change.

--- a/extensions/skill-oriented-agent-architecture/README.md
+++ b/extensions/skill-oriented-agent-architecture/README.md
@@ -71,6 +71,21 @@ The extension ships these guidance contracts under `docs/backend/architecture/`:
 
 Each document identifies its approved SOAA decision scope and invariant range.
 
+## Implementation profile
+
+The contracts above are product neutral. The extension also ships one
+**implementation profile** — `docs/backend/architecture/AGENT_RUNTIME_STACK.md` —
+that maps the runtime responsibilities to concrete **default product bindings**
+(e.g. LangGraph for the decision loop, a durable checkpointer for restart) a team
+can adopt and then customize.
+
+The profile is **advisory** (`authority: defaults`). `RUNTIME_STATE_AND_EXECUTION_CONTRACT.md`
+remains authoritative; where they disagree, the contract wins. Deviating from a
+default binding requires an ADR (`product_selection_requires_adr: true`). It is
+declared under `implementation_profiles` in the manifest, not `contract_sets`,
+precisely because it names products — the neutrality that the contracts hold does
+not apply to it. No blocking CI conformance gate is wired to the profile today.
+
 ## Relationship to LLM application governance
 
 SOAA does not prescribe an LLM provider, model family, gateway product, evaluation product, observability product, or guardrail product. Those concerns also apply to LLM applications without skills and are owned by the separate `llm-application` extension.

--- a/extensions/skill-oriented-agent-architecture/docs/backend/architecture/AGENT_RUNTIME_STACK.md
+++ b/extensions/skill-oriented-agent-architecture/docs/backend/architecture/AGENT_RUNTIME_STACK.md
@@ -1,0 +1,108 @@
+# Agent Runtime Stack
+
+This document defines the **default product bindings** for the SOAA agent
+runtime. It is an *implementation profile*: it maps the runtime responsibilities
+that `RUNTIME_STATE_AND_EXECUTION_CONTRACT.md` defines to concrete products a
+team can adopt as a starting point and then customize.
+
+**Authority: advisory (`defaults`).** The neutral contracts in `soaa_core` —
+above all `RUNTIME_STATE_AND_EXECUTION_CONTRACT.md` — remain authoritative. Where
+this profile and a contract disagree on any specific point, the contract wins.
+This profile never relaxes an invariant; it only names a default way to satisfy
+one. Deviating from these defaults requires an **ADR** in the consuming project.
+
+The contract defines the *what* (one runtime owner, durable operation records,
+restart without a provider transcript, atomic state+evidence commit). This
+document defines a default *how*.
+
+> **No blocking CI gate ships with this profile.** SOAA runtime conformance
+> (the invariant-to-assertion suite) is future work in the SOAA source set, so
+> the products below are guidance, not an enforced gate. Treat the contract's
+> verification list as the bar; wire your own tests to it.
+
+---
+
+## 1. The runtime is more than a graph library
+
+The single most common mistake is "our runtime is LangGraph." A graph/orchestration
+library supplies the adaptive decision loop and composition — roughly **two** of
+the responsibilities the runtime contract enumerates. The trusted controllers,
+durable operation records, evidence, and completion gate are things you build
+*around* the library. Naming one product as "the runtime" implies a conformance
+the library alone cannot deliver.
+
+So the default set is a **responsibility → default implementation** table, not a
+single product.
+
+## 2. Responsibility → default binding
+
+| SOAA responsibility (see contract) | Default binding | Notes |
+|---|---|---|
+| Agent Decision Runtime · adaptive loop · composition plan | **LangGraph** (`StateGraph`) | The part a graph library actually owns. Alternatives by ADR: Temporal, a homegrown state machine. |
+| Durable task/activation state · restart reconstruction | **LangGraph checkpointer on PostgreSQL** | An in-memory checkpointer **fails** the restart rule — it cannot reconstruct active work without a provider transcript. Durable checkpointer is mandatory outside local dev. |
+| Task Controller · one-owner rule · `owner_epoch` fencing | **Application-owned (build)** | Not a library feature. Enforces exactly one runtime owner and fences former-owner commands after transfer. |
+| Policy & Authority Controller · approvals · revocation | **Application-owned (build)** + model guardrails from `llm-application` | Fresh authorization before each external operation; approvals are durable records, not prompt state. |
+| Operation boundary · `OperationRecord` · Tool Gateway | **Application-owned adapter (build)** | Every mutating external operation gets a durable record with an idempotency key and side-effect class *before* invocation. Unknown effect is a distinct result. |
+| Evidence Recorder | **Append-only store** (PostgreSQL or object storage) | Immutable; historical evidence is never overwritten on retry or recovery. |
+| Evaluation Controller · completion gate | **`llm-application` evaluation** + the govkit evaluation gates | Only an Evaluation Controller pass permits `COMPLETED`; skill success never completes a task. |
+
+LangGraph is the default for two rows. The controller, operation, and evidence
+rows are "you build this, behind ports, regardless of graph library." Keep the
+graph library and all vendor SDKs inside `adapters/`; domain and services depend
+only on typed ports (per `ARCH_CONTRACT.md` / `BOUNDARIES.md`).
+
+## 3. Durability by environment
+
+The restart rule (contract §"Restart rule") is the load-bearing constraint. State
+durability is therefore not uniform across environments:
+
+| Environment | Checkpointer | Evidence store | Rationale |
+|---|---|---|---|
+| Local dev | in-memory acceptable | local file/db | fast iteration; restart not exercised |
+| CI | in-memory or ephemeral pg | ephemeral | deterministic test runs |
+| Staging | **durable (PostgreSQL)** | **append-only** | restart, fencing, and evidence paths must be real |
+| Production | **durable (PostgreSQL)** | **append-only, retained** | full restart-without-transcript guarantee |
+
+Shipping an in-memory checkpointer to staging or production is a profile
+violation and, because it breaks a contract invariant, a contract violation —
+not merely a default swap.
+
+## 4. Relationship to model calls
+
+This profile governs the **runtime**. When a decision-loop node calls a language
+model, that call goes through the `llm-application` extension's `ModelGatewayPort`
+and its `GATEWAY_STACK.md` profile — not through anything defined here. Install
+`llm-application` alongside SOAA for model-backed agents. Model output entering
+the loop is a **proposal**; a trusted controller decision, not the model, commits
+any transition.
+
+## 5. Customization for new projects
+
+Review, in order:
+
+- **Graph library** — LangGraph by default. Temporal or a homegrown state machine
+  are legitimate; swapping requires an ADR because it is "altering agent
+  orchestration strategy."
+- **Durable state backend** — PostgreSQL checkpointer by default; confirm it is
+  active in staging and production.
+- **Evidence store** — append-only Postgres or object storage; confirm immutability.
+- **Which controllers you build vs. adopt** — the Task, Authority, and Evaluation
+  controllers are application-owned here; if you adopt a framework that provides
+  any of them, record how it satisfies the contract's authoritative-writer table.
+
+The controller/evidence rows are not optional defaults you can drop — they are the
+contract's requirements with a default implementation strategy attached.
+
+## 6. When an ADR is required
+
+An ADR must be created when:
+
+- Replacing LangGraph with a different orchestration runtime (Temporal, homegrown, …).
+- Running any environment above local dev on a non-durable checkpointer.
+- Delegating any authoritative-writer responsibility (Task, Authority, Operation,
+  Evidence, Evaluation) to a third-party product instead of application-owned code.
+- Introducing a runtime pattern the contract's "Prohibited patterns" list forbids.
+
+Record the selected runtime and every deviation from this profile in an ADR
+(`docs/backend/architecture/ADR/`), and reflect the standing choice wherever your
+project records its approved stack (e.g. `TECH_STACK.md`).

--- a/extensions/skill-oriented-agent-architecture/manifest.yaml
+++ b/extensions/skill-oriented-agent-architecture/manifest.yaml
@@ -146,10 +146,21 @@ contract_sets:
         - docs/backend/architecture/ARCH_CONTRACT.md
       supersedes: []
 
+implementation_profiles:
+  - id: agent_runtime_profile
+    description: Default product bindings for the SOAA runtime responsibilities. Advisory — the runtime contract remains authoritative; deviations require an ADR.
+    path: docs/backend/architecture/AGENT_RUNTIME_STACK.md
+    profiles_for:
+      - soaa_core
+      - soaa_context_resilience
+    authority: defaults
+    product_selection_requires_adr: true
+
 agent_guidance:
   architecture_preflight:
     - Read this manifest before planning any feature involving agents, skills, adaptive orchestration, tool use, delegation, memory, or agent evaluation.
     - Load soaa_core first, then load only the additional contract sets matched by feature intent and touched files.
+    - Read AGENT_RUNTIME_STACK.md for default runtime product bindings, but treat it as advisory — the runtime contract wins on any conflict, and deviating from a default requires an ADR.
     - Classify every relevant component as agent run, skill, tool, resource, workflow, policy, evaluator, memory, or trusted controller.
     - Record the accountable principal, accepted task boundary, single runtime owner, authoritative state writers, external side effects, approval routes, and completion evidence.
     - List every applicable SOAA contract in architecture_preflight.md.

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -707,3 +707,107 @@ class TestRunValidationExtensions:
         exit_code = run_validation(tmp_path, level="3")
         assert exit_code == 0
         capsys.readouterr()  # drain
+
+
+# ---------------------------------------------------------------------------
+# implementation_profiles — product-naming profiles that map a contract set to
+# default product bindings. Validated for path safety like contract_sets, but
+# deliberately EXEMPT from the neutrality/overlap heuristic (a profile is meant
+# to name products and refine a contract).
+# ---------------------------------------------------------------------------
+
+
+_PROFILE_BLOCK = textwrap.dedent("""\
+    implementation_profiles:
+      - id: sample_profile
+        description: Default product bindings for the sample contract.
+        path: docs/SAMPLE_STACK.md
+        profiles_for:
+          - sample
+        authority: defaults
+        product_selection_requires_adr: true
+    """)
+
+
+class TestImplementationProfileValidation:
+    def test_valid_profile_passes(self, tmp_path):
+        body = VALID_MANIFEST + _PROFILE_BLOCK
+        ext_dir = _write_extension(tmp_path, "sample-ext", body)
+        (ext_dir / "docs").mkdir(exist_ok=True)
+        (ext_dir / "docs" / "SAMPLE.md").write_text("# sample", encoding="utf-8")
+        (ext_dir / "docs" / "SAMPLE_STACK.md").write_text(
+            "# profile\nDefault: SomeProduct", encoding="utf-8"
+        )
+        ext = discover_extensions(tmp_path)[0]
+        assert validate_extension(ext, tmp_path) == []
+
+    def test_missing_profile_path_reported(self, tmp_path):
+        body = VALID_MANIFEST + _PROFILE_BLOCK
+        ext_dir = _write_extension(tmp_path, "sample-ext", body)
+        (ext_dir / "docs").mkdir(exist_ok=True)
+        (ext_dir / "docs" / "SAMPLE.md").write_text("# sample", encoding="utf-8")
+        # NOTE: do NOT create docs/SAMPLE_STACK.md
+        ext = discover_extensions(tmp_path)[0]
+        issues = validate_extension(ext, tmp_path)
+        assert any("SAMPLE_STACK.md" in i and "does not exist" in i for i in issues), issues
+
+    def test_profile_without_path_reported(self, tmp_path):
+        body = VALID_MANIFEST + textwrap.dedent("""\
+            implementation_profiles:
+              - id: sample_profile
+                description: missing its path
+            """)
+        ext_dir = _write_extension(tmp_path, "sample-ext", body)
+        (ext_dir / "docs").mkdir(exist_ok=True)
+        (ext_dir / "docs" / "SAMPLE.md").write_text("# sample", encoding="utf-8")
+        ext = discover_extensions(tmp_path)[0]
+        issues = validate_extension(ext, tmp_path)
+        assert any("implementation_profiles[0].path" in i for i in issues), issues
+
+    def test_absolute_profile_path_reported(self, tmp_path):
+        body = VALID_MANIFEST + _PROFILE_BLOCK.replace(
+            "docs/SAMPLE_STACK.md", "/etc/passwd"
+        )
+        ext_dir = _write_extension(tmp_path, "sample-ext", body)
+        (ext_dir / "docs").mkdir(exist_ok=True)
+        (ext_dir / "docs" / "SAMPLE.md").write_text("# sample", encoding="utf-8")
+        ext = discover_extensions(tmp_path)[0]
+        issues = validate_extension(ext, tmp_path)
+        assert any("must be relative" in i for i in issues), issues
+
+    def test_profile_escaping_extension_dir_reported(self, tmp_path):
+        outside = tmp_path / "outside.md"
+        outside.write_text("x", encoding="utf-8")
+        body = VALID_MANIFEST + _PROFILE_BLOCK.replace(
+            "docs/SAMPLE_STACK.md", "../../outside.md"
+        )
+        ext_dir = _write_extension(tmp_path, "sample-ext", body)
+        (ext_dir / "docs").mkdir(exist_ok=True)
+        (ext_dir / "docs" / "SAMPLE.md").write_text("# sample", encoding="utf-8")
+        ext = discover_extensions(tmp_path)[0]
+        issues = validate_extension(ext, tmp_path)
+        assert any("resolves outside" in i for i in issues), issues
+
+    def test_profile_is_exempt_from_overlap_warning(self, tmp_path):
+        """A profile that shares a topic token with a *different* core contract
+        must NOT trigger the undeclared-overlap heuristic — that heuristic is
+        scoped to contract_sets, which are the neutral surface. A profile is
+        meant to name products and refine a contract, so overlap is expected."""
+        core = tmp_path / "docs" / "backend" / "architecture"
+        core.mkdir(parents=True)
+        (core / "AGENT_EXECUTION_CONTRACT.md").write_text("x", encoding="utf-8")
+        body = VALID_MANIFEST + textwrap.dedent("""\
+            implementation_profiles:
+              - id: runtime_profile
+                description: names products for the runtime contract
+                path: docs/RUNTIME_EXECUTION_CONTRACT.md
+            """)
+        ext_dir = _write_extension(tmp_path, "sample-ext", body)
+        (ext_dir / "docs").mkdir(exist_ok=True)
+        (ext_dir / "docs" / "SAMPLE.md").write_text("# sample", encoding="utf-8")
+        (ext_dir / "docs" / "RUNTIME_EXECUTION_CONTRACT.md").write_text(
+            "Default runtime: SomeProduct", encoding="utf-8"
+        )
+        ext = discover_extensions(tmp_path)[0]
+        issues = validate_extension(ext, tmp_path)
+        assert not any("overlaps core" in i for i in issues), issues

--- a/tests/test_llm_application.py
+++ b/tests/test_llm_application.py
@@ -169,6 +169,64 @@ def test_bundled_extension_add_copies_profile(tmp_path, capsys):
         assert (installed / path).is_file()
 
 
+# ---------------------------------------------------------------------------
+# GATEWAY_STACK implementation profile — product-naming default bindings for the
+# LLM application ports. Advisory; the gateway/observability/guardrail contracts
+# stay authoritative. Names concrete products (LiteLLM, …) teams swap via ADR,
+# so it lives under implementation_profiles, NOT contract_sets.
+# ---------------------------------------------------------------------------
+
+GATEWAY_PROFILE_PATH = "docs/backend/architecture/GATEWAY_STACK.md"
+
+
+def test_manifest_declares_gateway_profile():
+    profiles = _manifest().get("implementation_profiles", [])
+    profile = next((p for p in profiles if p["id"] == "gateway_profile"), None)
+    assert profile is not None, "gateway_profile not declared"
+    assert profile["path"] == GATEWAY_PROFILE_PATH
+    assert profile["authority"] == "defaults"
+    assert profile["product_selection_requires_adr"] is True
+    assert "llm_gateway" in profile["profiles_for"]
+
+
+def test_gateway_profile_file_exists():
+    assert (EXT_DIR / GATEWAY_PROFILE_PATH).is_file()
+
+
+def test_gateway_profile_is_not_a_neutral_contract():
+    assert GATEWAY_PROFILE_PATH not in _declared_paths()
+    assert GATEWAY_PROFILE_PATH not in REQUIRED_CONTRACTS
+
+
+def test_gateway_profile_names_default_products():
+    text = (EXT_DIR / GATEWAY_PROFILE_PATH).read_text(encoding="utf-8").casefold()
+    assert "litellm" in text, "profile should name a concrete default gateway product"
+
+
+def test_gateway_profile_maps_to_ports_and_defers():
+    text = (EXT_DIR / GATEWAY_PROFILE_PATH).read_text(encoding="utf-8")
+    folded = text.casefold()
+    assert "ModelGatewayPort" in text
+    assert "advisory" in folded or "authoritative" in folded
+    assert "adr" in folded
+
+
+def test_bundled_extension_add_copies_gateway_profile(tmp_path, capsys):
+    args = type(
+        "Args",
+        (),
+        {
+            "extension_id": "llm-application",
+            "target": str(tmp_path),
+            "force": False,
+        },
+    )()
+    cmd_extension_add(args)
+    capsys.readouterr()
+    installed = tmp_path / "extensions" / "llm-application"
+    assert (installed / GATEWAY_PROFILE_PATH).is_file()
+
+
 def test_extension_add_validates_cleanly_in_level_5_project(tmp_path, capsys):
     target = tmp_path / "project"
     target.mkdir()

--- a/tests/test_skill_oriented_agent_architecture.py
+++ b/tests/test_skill_oriented_agent_architecture.py
@@ -249,3 +249,65 @@ def test_bundled_extension_add_copies_profile(tmp_path, capsys):
     assert (installed / "manifest.yaml").is_file()
     for path in REQUIRED_CONTRACTS:
         assert (installed / path).is_file()
+
+
+# ---------------------------------------------------------------------------
+# AGENT_RUNTIME_STACK implementation profile — product-naming default bindings
+# for the SOAA runtime. Advisory; RUNTIME_STATE_AND_EXECUTION_CONTRACT stays
+# authoritative. Names concrete products (LangGraph, …) that teams may swap
+# via ADR, so it lives under implementation_profiles, NOT contract_sets.
+# ---------------------------------------------------------------------------
+
+RUNTIME_PROFILE_PATH = "docs/backend/architecture/AGENT_RUNTIME_STACK.md"
+
+
+def test_manifest_declares_agent_runtime_profile():
+    profiles = _manifest().get("implementation_profiles", [])
+    profile = next((p for p in profiles if p["id"] == "agent_runtime_profile"), None)
+    assert profile is not None, "agent_runtime_profile not declared"
+    assert profile["path"] == RUNTIME_PROFILE_PATH
+    assert profile["authority"] == "defaults"
+    assert profile["product_selection_requires_adr"] is True
+    assert "soaa_core" in profile["profiles_for"]
+
+
+def test_agent_runtime_profile_file_exists():
+    assert (EXT_DIR / RUNTIME_PROFILE_PATH).is_file()
+
+
+def test_agent_runtime_profile_is_not_a_neutral_contract():
+    """The profile names products, so it must stay out of contract_sets (the
+    neutral surface) and out of the product-neutrality assertion set."""
+    assert RUNTIME_PROFILE_PATH not in _declared_paths()
+    assert RUNTIME_PROFILE_PATH not in REQUIRED_CONTRACTS
+
+
+def test_agent_runtime_profile_names_a_default_runtime_product():
+    text = (EXT_DIR / RUNTIME_PROFILE_PATH).read_text(encoding="utf-8").casefold()
+    assert "langgraph" in text, "profile should name a concrete default runtime"
+
+
+def test_agent_runtime_profile_defers_to_the_authoritative_contract():
+    text = (EXT_DIR / RUNTIME_PROFILE_PATH).read_text(encoding="utf-8")
+    folded = text.casefold()
+    # It supplies defaults, not law: the runtime contract wins on conflict.
+    assert "RUNTIME_STATE_AND_EXECUTION_CONTRACT" in text
+    assert "advisory" in folded or "authoritative" in folded
+    # No blocking CI conformance gate ships this round.
+    assert "adr" in folded
+
+
+def test_bundled_extension_add_copies_agent_runtime_profile(tmp_path, capsys):
+    args = type(
+        "Args",
+        (),
+        {
+            "extension_id": "skill-oriented-agent-architecture",
+            "target": str(tmp_path),
+            "force": False,
+        },
+    )()
+    cmd_extension_add(args)
+    capsys.readouterr()
+    installed = tmp_path / "extensions" / "skill-oriented-agent-architecture"
+    assert (installed / RUNTIME_PROFILE_PATH).is_file()


### PR DESCRIPTION
## Summary

Extensions ship provider-neutral **contracts** but had no first-class home for "which concrete product do we actually use." Teams were left to hand-edit `TECH_STACK.md` (a refreshable stack-overlay file) or scatter the decision into ADRs, and the `skill-oriented-agent-architecture` extension in particular had no place at all to pin a runtime product.

This adds a generic **`implementation_profiles`** manifest mechanism and ships the first two profiles on top of it: opinionated default product bindings a team can adopt and then customize, kept separate from the neutral contracts.

## What changed (3 scoped, test-first commits)

**1. Generic `implementation_profiles` manifest key** — the load-bearing change
- `cli/extensions.py`: validates `implementation_profiles[].path` with the same relative/contained/existing-file safety as contract paths. Profiles are deliberately **exempt from the neutrality/overlap heuristic** (which scans `contract_sets` only) — that exemption is exactly what lets a profile name products and refine a contract.
- `extension-manifest.schema.json`: documents the key and its shape (`id`, `path`, `profiles_for`, `authority: defaults`, `product_selection_requires_adr`, and a **reserved `gate` field** for a future conformance check — declared but unwired).
- `doctor` already routes profile path errors to D013 (hard) via existing message classification; no change needed there.

**2. `AGENT_RUNTIME_STACK.md`** (skill-oriented-agent-architecture)
- Built as a **responsibility → product table**, not "runtime = LangGraph." A graph library owns ~2 of the runtime contract's responsibilities (adaptive loop, composition); the Task/Authority/Operation/Evidence/Evaluation controllers are application-owned. Naming one product as "the runtime" would imply a conformance the library can't deliver.
- Durability is split by environment because the restart rule forbids an in-memory checkpointer outside local dev.

**3. `GATEWAY_STACK.md`** (llm-application)
- Maps `ModelGatewayPort` / `ObservabilityPort` / guardrail adapter to LiteLLM, OpenLLMetry → Langfuse, and NeMo Guardrails / Guardrails AI, each pointing to its existing `docs/backend/guides/` setup guide.
- Evaluation is **not** duplicated — it points to the core `EVAL_STACK.md`, which already owns the evaluator mapping and CI gates.

Both profiles are **advisory** (`authority: defaults`): the neutral contracts stay authoritative and deviating from a default requires an ADR. Both manifests gained a preflight-guidance line telling the agent to read the profile as defaults, not law.

## Not in scope (deliberate)

- **No blocking CI conformance gate this round** — the `gate` field is reserved in the schema but unwired.
- **Core `TECH_STACK.md` left untouched** — the profiles are self-contained and discoverable via the manifest, READMEs, and preflight guidance; a core pointer would also mean touching the 6 stack overlays for consistency (separate increment).
- **`docs/backend/guides/` referenced in place, not relocated** — the layering cleanup (moving LLM product guides under the extension) is orthogonal and riskier.

## Testing

- Test-first for all three increments; new tests in `tests/test_extensions.py`, `tests/test_skill_oriented_agent_architecture.py`, `tests/test_llm_application.py` (including a test proving profiles are exempt from the overlap heuristic).
- Full suite green: **1077 passed, 1 pre-existing skip**. Ruff clean on changed Python.
- End-to-end CLI smoke: `apply --level 5` → `extension add` both → both profile docs land in the target → `doctor` exits 0 (no D013/D014 from the new key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)