### PR TITLE
fix(govkit): retire pre-namespace rules/skills on upgrade (+ drop duplicated block)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed — internal
 
+- Version comparison now treats absent components as zero, so `0.14` and
+  `0.14.0` compare equal. Comparing the parsed tuples directly made
+  `(0, 14) < (0, 14, 0)`, which sorted a version before the release it names —
+  enough to put a marker on the wrong side of the gates that gate on `0.7.0`
+  and `0.14.0`. Markers are not schema-validated, so abbreviated versions are
+  reachable by hand-editing.
 - `write_managed_agent_block` and `install_agent_file` were each defined twice,
   byte-identically, in `cli/install_common.py`; the redundant copy is removed.
   Python kept the second definition and the two matched, so there was no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-07-22
+
 ### Added
 
+- Added a first-class `implementation_profiles` mechanism for extensions. An
+  extension can now ship advisory **default product bindings** — a profile that
+  maps a neutral contract set to concrete products a team may customize —
+  separate from its provider-neutral `contract_sets`. The generic
+  extension-manifest schema documents the key (`id`, `path`, `profiles_for`,
+  `authority`, `product_selection_requires_adr`, and a reserved `gate`), and
+  profiles are validated for path safety while remaining exempt from the
+  contract-neutrality overlap heuristic (a profile is meant to name products).
+  Two profiles ship on top of it: `AGENT_RUNTIME_STACK.md`
+  (`skill-oriented-agent-architecture`) mapping the SOAA runtime
+  responsibilities to default bindings, and `GATEWAY_STACK.md`
+  (`llm-application`) mapping the model-gateway/observability/guardrail ports.
+  Both are advisory, require an ADR to deviate, and wire no blocking CI gate.
 - Added the bundled `skill-oriented-agent-architecture` extension. It translates
   approved SOAA v0.2 decisions into five progressively loaded contract sets for
   core semantics, selection and authority, context and resilience, assurance,
@@ -45,6 +60,25 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   (`stack.id: null`). `apply`, `stack apply`, and `calibrate` already carried
   these through; `upgrade` was the lone writer that did not. `applied_at` still
   advances on upgrade — that is a re-install, and edit-protection depends on it.
+- `govkit upgrade` now retires the pre-namespace rules and skills it used to
+  leave behind. Moving govkit's rules under `.claude/rules/govkit/` (and
+  `.github/instructions/govkit/`) and prefixing its skills `govkit-` changed
+  where those files install, but upgrade wrote the new paths without removing
+  the copies govkit itself had written at the old ones — so an agent that
+  auto-loads its rules directory recursively ingested both, duplicating
+  governance and contradicting it wherever the two versions had drifted.
+  Upgrade now removes a superseded rule or skill when it is provably govkit's
+  own (byte-identical to what govkit installs today, or untouched since the
+  last apply); a file the team wrote or edited at the old path is kept, and
+  govkit's namespaced copy installs alongside it — which is the point of the
+  namespace. The cleanup runs only while the marker predates the move, and a
+  delete it cannot perform warns instead of aborting the upgrade.
+- `govkit upgrade` no longer crashes when the marker's `applied_at` is
+  timezone-naive, or when a superseded file cannot be deleted. The first
+  raised `TypeError` comparing a naive timestamp against a timezone-aware
+  mtime; both are now treated as unknown history, which never authorizes a
+  delete.
+
 ### Changed
 
 - Removed the duplicate core `AGENT_ARCHITECTURE.md`,
@@ -60,8 +94,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   govkit's `api` rule; both coexist and load. Skill namespacing is not included
   here (it would change how govkit skills are invoked, e.g. `/spec-planning`), and
   codex's nested per-layer `AGENTS.md` files are unchanged for now.
-### Changed
-
 - **govkit's skills are now prefixed `govkit-`**, so a team's own skill that shares
   a bare name with one of govkit's is no longer overwritten. This renames both the
   installed skill directory and its invocation name — e.g. `/spec-planning` becomes
@@ -74,13 +106,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   govkit fences its per-layer guidance in the same `BEGIN/END GOVKIT GOVERNANCE`
   block used for the root `AGENTS.md`, preserving a team's own content in those
   files.
-- **govkit's layer rules now install under a `govkit/` subdirectory**, so a team's
-  own same-named rule survives. claude-code rules move to `.claude/rules/govkit/`
-  and copilot's to `.github/instructions/govkit/` — a team that keeps their own
-  `.claude/rules/api.md` (or `api.instructions.md`) is no longer clobbered by
-  govkit's `api` rule; both coexist and load. Skill namespacing is not included
-  here (it would change how govkit skills are invoked, e.g. `/spec-planning`), and
-  codex's nested per-layer `AGENTS.md` files are unchanged for now.
 - **govkit no longer overwrites your `CLAUDE.md` or `.github/copilot-instructions.md`.**
   Both agents natively auto-load a separate instructions directory, so govkit's
   governance now installs there — `.claude/rules/govkit/governance.md` for
@@ -95,10 +120,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   governance install is skipped (with a warning) so you never get duplicate
   governance. Codex (`AGENTS.md`, which has no native rules directory) is
   unchanged for now.
-  instruction file is retired automatically when it is byte-identical to govkit's
-  governance; if you edited it, it is kept and governance install is skipped
-  (with a warning) so you never get duplicate governance. Codex (`AGENTS.md`,
-  which has no native rules directory) is unchanged for now.
 - `govkit doctor`'s rule-glob check (D001) now scans the rules directory
   recursively, so rules in subdirectories — including govkit's own
   `.claude/rules/govkit/` — are validated instead of silently skipped.
@@ -114,6 +135,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed — internal
 
+- `write_managed_agent_block` and `install_agent_file` were each defined twice,
+  byte-identically, in `cli/install_common.py`; the redundant copy is removed.
+  Python kept the second definition and the two matched, so there was no
+  behavior change.
 - The two stack marker records (the `stack.id` assumption and the `stack`
   metadata block) are now built only by `stack_select.build_stack_assumption`
   / `build_stack_meta`; `govkit stack apply` consumes them instead of

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -22,6 +22,7 @@ from .install_common import (
     install_agent_file,
     post_install_finalize,
     reconcile_legacy_instruction_files,
+    retire_pre_namespace_agent_files,
 )
 from .manifest import load_manifest, resolve_variant_files
 from .marker import _compare_version, read_govkit_marker, write_govkit_marker
@@ -118,6 +119,12 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
     # A6: retire any pre-namespace top-level instruction file (CLAUDE.md etc.)
     # before installing governance into the rules namespace.
     files = reconcile_legacy_instruction_files(target, agent_dir, files, prior_applied_at)
+
+    # Retire the pre-namespace rules/skills a pre-0.14 install left at the old
+    # paths, so the agent does not auto-load govkit's governance twice.
+    retire_pre_namespace_agent_files(
+        target, agent_dir, files, prior_applied_at, stored_version,
+    )
 
     print("Agent files (refreshed):")
     for entry in files:

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -13,6 +13,7 @@ them inward without duplicating logic or reaching back into cli/govkit.py.
 
 from __future__ import annotations
 
+import shutil
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -21,7 +22,7 @@ from typing import TYPE_CHECKING
 from . import paths
 from .fs import copy_entry
 from .headers import GOVKIT_BLOCK_BEGIN, upsert_govkit_block
-from .marker import read_govkit_marker
+from .marker import _compare_version, read_govkit_marker
 
 if TYPE_CHECKING:
     from .detect import RepoProfile
@@ -169,6 +170,101 @@ def reconcile_legacy_instruction_files(
                 file=sys.stderr,
             )
     return keep
+
+
+# 0.14.0 moved govkit's own agent files into a namespace govkit owns, so a
+# team's same-named rules and skills survive alongside them:
+#   .claude/rules/X.md          -> .claude/rules/govkit/X.md
+#   .github/instructions/X      -> .github/instructions/govkit/X
+#   .claude|.agents/skills/Y/   -> .../skills/govkit-Y/
+# Upgrading a pre-0.14 install writes the new paths but leaves govkit's old
+# copy behind, and the agent auto-loads both — duplicated and, once the two
+# drift, contradictory governance. Both moves are mechanical, so the superseded
+# path is derived rather than enumerated per agent.
+_NAMESPACE_MIGRATION_VERSION = "0.14.0"
+
+
+def _superseded_agent_path(dest: str) -> str | None:
+    """The pre-namespace path `dest` superseded, or None when `dest` is not a
+    namespaced (or `govkit-` prefixed) govkit agent file."""
+    if "/govkit/" in dest:
+        return dest.replace("/govkit/", "/", 1)
+    if "/skills/govkit-" in dest:
+        return dest.replace("/skills/govkit-", "/skills/", 1)
+    return None
+
+
+def _tree_unmodified_since(root: Path, applied_at: str | None) -> bool:
+    """True when every file under `root` is unmodified since `applied_at`.
+
+    One user-touched file protects the whole directory: a skill the team
+    edited is theirs even if they changed only part of it. An empty tree
+    returns False — there is nothing to prove ownership with, so it stays.
+    """
+    contents = [p for p in root.rglob("*") if p.is_file()]
+    return bool(contents) and all(_unmodified_since(p, applied_at) for p in contents)
+
+
+def _is_govkit_pre_namespace_copy(
+    legacy: Path, src: Path, applied_at: str | None,
+) -> bool:
+    """True when `legacy` is provably govkit's own copy rather than the team's.
+
+    A directory qualifies when nothing inside it was touched since the last
+    apply. A file qualifies when it is byte-identical to what govkit installs
+    today (a same-version orphan) or untouched since the last apply (an older
+    govkit version's file the team never edited).
+    """
+    if legacy.is_dir():
+        return _tree_unmodified_since(legacy, applied_at)
+    if src.is_file():
+        try:
+            if legacy.read_text(encoding="utf-8") == src.read_text(encoding="utf-8"):
+                return True
+        except (OSError, UnicodeDecodeError):
+            pass
+    return _unmodified_since(legacy, applied_at)
+
+
+def retire_pre_namespace_agent_files(
+    target: Path, agent_dir: Path, files: list,
+    applied_at: str | None = None, stored_version: str | None = None,
+) -> None:
+    """Remove the pre-namespace rules/skills an upgrade would otherwise orphan.
+
+    Runs only while the marker predates the namespace move, so a same-named
+    file the team authors at an old path *after* migrating is never a
+    candidate. Inside that window a path is removed only when it is provably
+    govkit's own (see `_is_govkit_pre_namespace_copy`); anything else is the
+    team's and is left untouched — govkit's namespaced copy installs alongside
+    it, which is the entire point of the namespace. A failed delete warns and
+    never aborts the upgrade.
+    """
+    if _compare_version(stored_version or "", _NAMESPACE_MIGRATION_VERSION) >= 0:
+        return
+    for entry in files:
+        legacy_rel = _superseded_agent_path(entry["dest"])
+        if legacy_rel is None:
+            continue
+        legacy = target / legacy_rel
+        if not legacy.exists():
+            continue
+        if not _is_govkit_pre_namespace_copy(legacy, agent_dir / entry["src"], applied_at):
+            continue
+        try:
+            if legacy.is_dir():
+                shutil.rmtree(legacy)
+            else:
+                legacy.unlink()
+        except OSError as exc:
+            print(
+                f"  warning: could not remove superseded {legacy_rel} ({exc}); "
+                f"it now duplicates {entry['dest']}. Delete {legacy_rel} manually "
+                "so the agent does not load both copies.",
+                file=sys.stderr,
+            )
+            continue
+        print(f"  retired {legacy_rel}  (superseded by {entry['dest']})")
 
 
 def copy_governed_or_shared(

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -108,47 +108,6 @@ def install_agent_file(
         copy_entry(src, dest)
 
 
-def write_managed_agent_block(dest: Path, body: str, applied_at: str | None = None) -> None:
-    """Install govkit's governance into `dest` as a managed block.
-
-    For an agent (codex) whose only mechanism is a shared AGENTS.md, govkit
-    cannot move its governance elsewhere, so it fences it between markers and
-    preserves the team's own content in the same file. When the file already
-    exists without a block, it is replaced wholesale only if it is provably
-    govkit's own pre-block copy (byte-identical to the governance body, or
-    untouched since the marker's `applied_at`); otherwise it is treated as the
-    team's and the block is appended below their content.
-    """
-    existing: str | None = None
-    if dest.exists():
-        try:
-            existing = dest.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            existing = None
-    replace_unblocked = False
-    if existing is not None and GOVKIT_BLOCK_BEGIN not in existing:
-        replace_unblocked = existing == body or _unmodified_since(dest, applied_at)
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_text(
-        upsert_govkit_block(existing, body, replace_unblocked=replace_unblocked),
-        encoding="utf-8",
-    )
-    print(f"  wrote   {dest}  (govkit governance block)")
-
-
-def install_agent_file(
-    agent_dir: Path, entry: dict, target: Path, applied_at: str | None = None,
-) -> None:
-    """Install one agent-file manifest entry: a managed block when the entry
-    opts in (`managed_block`), otherwise a plain overwrite copy."""
-    src = agent_dir / entry["src"]
-    dest = target / entry["dest"]
-    if entry.get("managed_block"):
-        write_managed_agent_block(dest, src.read_text(encoding="utf-8"), applied_at)
-    else:
-        copy_entry(src, dest)
-
-
 def reconcile_legacy_instruction_files(
     target: Path, agent_dir: Path, files: list, applied_at: str | None = None,
 ) -> list:

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -186,7 +186,19 @@ _NAMESPACE_MIGRATION_VERSION = "0.14.0"
 
 def _superseded_agent_path(dest: str) -> str | None:
     """The pre-namespace path `dest` superseded, or None when `dest` is not a
-    namespaced (or `govkit-` prefixed) govkit agent file."""
+    namespaced (or `govkit-` prefixed) govkit agent file.
+
+    Governance entries are exempt. Their superseded location is a top-level
+    instruction file (`CLAUDE.md`, `.github/copilot-instructions.md`, …) that
+    `_LEGACY_INSTRUCTION_DEST` maps explicitly and
+    `reconcile_legacy_instruction_files` already retires — not the namespaced
+    sibling this derivation would produce. Deriving
+    `.claude/rules/governance.md` from `.claude/rules/govkit/governance.md`
+    would claim a path govkit has never written, so a team's own file sitting
+    there could be deleted.
+    """
+    if dest in _LEGACY_INSTRUCTION_DEST:
+        return None
     if "/govkit/" in dest:
         return dest.replace("/govkit/", "/", 1)
     if "/skills/govkit-" in dest:

--- a/cli/marker.py
+++ b/cli/marker.py
@@ -62,6 +62,12 @@ _DIRECTORY_MIGRATION_WARNING = _OneTimeWarning("GOVKIT_NO_DIRECTORY_MIGRATION_WA
 def _compare_version(v1: str, v2: str) -> int:
     """Compare dotted version strings. Returns -1, 0, or 1.
 
+    Absent components read as zero, so `0.14` and `0.14.0` compare equal.
+    Markers are not schema-validated, so a hand-edited or truncated version
+    reaches this comparator; comparing the parsed tuples directly made
+    `(0, 14) < (0, 14, 0)`, which would sort a version *before* the release it
+    names and drop callers that gate on it into the wrong branch.
+
     Non-parseable versions (e.g. 'dev', 'unknown') compare equal to anything,
     so development builds and corrupt markers don't trigger the migration
     warning.
@@ -71,6 +77,9 @@ def _compare_version(v1: str, v2: str) -> int:
         t2 = tuple(int(p) for p in v2.split("."))
     except (ValueError, AttributeError):
         return 0
+    width = max(len(t1), len(t2))
+    t1 += (0,) * (width - len(t1))
+    t2 += (0,) * (width - len(t2))
     if t1 < t2:
         return -1
     if t1 > t2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.13.0"
+version = "0.14.0"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -3,6 +3,7 @@
 import argparse
 import json
 import textwrap
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -2607,6 +2608,187 @@ class TestUpgradeMigratesLegacyInstructionFile:
         err = capsys.readouterr().err
         assert "CLAUDE.md" in err
         assert "could not remove" in err
+
+
+def _make_namespaced_repo(tmp_path: Path, agent: str = "test-agent") -> Path:
+    """A repo whose manifest installs one `govkit/`-namespaced rule and one
+    `govkit-`-prefixed skill dir (the post-0.14 agent-file layout)."""
+    agents = tmp_path / "agents" / agent
+    (agents / "rules").mkdir(parents=True, exist_ok=True)
+    (agents / "rules" / "test-first.md").write_text(
+        "# govkit test-first rule (current)\n", encoding="utf-8",
+    )
+    skill = agents / "skills" / "spec-planning"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: govkit-spec-planning\ndescription: plan a spec\n---\n", encoding="utf-8",
+    )
+    manifest = {
+        "agent": agent,
+        "description": "namespaced-layout test agent",
+        "options": {
+            "level": {"prompt": "Level?", "choices": ["3", "4", "5"], "default": "4"},
+            "type": {"prompt": "Type?", "choices": ["api"], "default": "api"},
+            "ci": {"prompt": "CI?", "choices": ["github"], "default": "github"},
+        },
+        "variants": {
+            "type": {
+                "api": {
+                    "files": [
+                        {"src": "rules/test-first.md",
+                         "dest": ".claude/rules/govkit/test-first.md"},
+                        {"src": "skills/spec-planning",
+                         "dest": ".claude/skills/govkit-spec-planning/"},
+                    ],
+                    "shared": [],
+                    "governed": [],
+                }
+            },
+            "ci": {"github": {"files": [], "shared": [], "governed": []}},
+        },
+        "base_files": [],
+    }
+    (agents / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return tmp_path
+
+
+class TestUpgradeRetiresPreNamespaceAgentFiles:
+    """0.14.0 moved govkit's rules under a `govkit/` namespace and prefixed its
+    skills with `govkit-`. Upgrading a pre-0.14 install must retire the copies
+    govkit itself wrote at the old paths — otherwise the agent auto-loads both
+    and gets duplicated (and, where content drifted, contradictory) governance.
+    A file the team authored at the old path is never removed: coexistence is
+    the whole point of the namespace."""
+
+    APPLIED_AT = "2026-01-01T00:00:00+00:00"
+
+    def _target(self, tmp_path: Path, marker_version: str = "0.13.0") -> Path:
+        target = tmp_path / "project"
+        target.mkdir()
+        marker = {
+            "version": marker_version, "level": "4", "agent": "test-agent",
+            "options": {"type": "api", "ci": "github"},
+            "applied_at": self.APPLIED_AT,
+        }
+        (target / ".govkit").mkdir()
+        (target / ".govkit" / "marker.json").write_text(json.dumps(marker), encoding="utf-8")
+        return target
+
+    def _stamp(self, path: Path, when: datetime) -> None:
+        import os
+        ts = when.timestamp()
+        os.utime(path, (ts, ts))
+
+    def _legacy_rule(self, target: Path, body: str, when: datetime) -> Path:
+        rule = target / ".claude" / "rules" / "test-first.md"
+        rule.parent.mkdir(parents=True, exist_ok=True)
+        rule.write_text(body, encoding="utf-8")
+        self._stamp(rule, when)
+        return rule
+
+    def _legacy_skill(self, target: Path, when: datetime) -> Path:
+        skill = target / ".claude" / "skills" / "spec-planning"
+        skill.mkdir(parents=True, exist_ok=True)
+        f = skill / "SKILL.md"
+        f.write_text("---\nname: spec-planning\n---\n", encoding="utf-8")
+        self._stamp(f, when)
+        return skill
+
+    def _run(self, tmp_path, target, monkeypatch, govkit_version="0.14.0"):
+        repo = _make_namespaced_repo(tmp_path)
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", govkit_version)
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+    # -- rules ---------------------------------------------------------------
+
+    def test_removes_untouched_pre_namespace_rule(self, tmp_path, monkeypatch):
+        """A rule at the old path, untouched since applied_at, is govkit's own
+        orphan → removed; the namespaced rule is installed in its place."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_rule(
+            target, "# govkit test-first rule (v0.13)\n",
+            datetime(2025, 12, 1, tzinfo=timezone.utc),
+        )
+        self._run(tmp_path, target, monkeypatch)
+
+        assert not legacy.exists()
+        assert (target / ".claude" / "rules" / "govkit" / "test-first.md").is_file()
+
+    def test_keeps_team_authored_rule_and_still_installs_namespaced(
+        self, tmp_path, monkeypatch,
+    ):
+        """A rule the team edited after applied_at is theirs: kept. The
+        namespaced govkit rule is STILL installed — they coexist by design."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_rule(
+            target, "# ACME house rule\n", datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+        self._run(tmp_path, target, monkeypatch)
+
+        assert legacy.read_text(encoding="utf-8") == "# ACME house rule\n"
+        assert (target / ".claude" / "rules" / "govkit" / "test-first.md").is_file()
+
+    # -- skills --------------------------------------------------------------
+
+    def test_removes_untouched_pre_prefix_skill_dir(self, tmp_path, monkeypatch):
+        """An un-prefixed skill dir untouched since applied_at is govkit's
+        orphan → removed; the govkit- prefixed skill is installed."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_skill(target, datetime(2025, 12, 1, tzinfo=timezone.utc))
+        self._run(tmp_path, target, monkeypatch)
+
+        assert not legacy.exists()
+        assert (target / ".claude" / "skills" / "govkit-spec-planning" / "SKILL.md").is_file()
+
+    def test_keeps_skill_dir_the_team_edited(self, tmp_path, monkeypatch):
+        """One user-edited file inside the skill dir protects the whole dir."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_skill(target, datetime(2026, 6, 1, tzinfo=timezone.utc))
+        self._run(tmp_path, target, monkeypatch)
+
+        assert legacy.is_dir()
+        assert (legacy / "SKILL.md").is_file()
+
+    # -- gating + failure safety --------------------------------------------
+
+    def test_skips_when_marker_already_namespaced(self, tmp_path, monkeypatch):
+        """Marker already at/after the namespace version: there is no
+        pre-namespace install to clean, so old paths are never touched — a
+        same-named file there is the team's, even though its mtime predates
+        applied_at. Upgrading 0.14.0 -> 0.15.0 must not delete it."""
+        target = self._target(tmp_path, marker_version="0.14.0")
+        legacy = self._legacy_rule(
+            target, "# ACME rule\n", datetime(2025, 12, 1, tzinfo=timezone.utc),
+        )
+        self._run(tmp_path, target, monkeypatch, govkit_version="0.15.0")
+
+        assert legacy.exists()
+        assert legacy.read_text(encoding="utf-8") == "# ACME rule\n"
+
+    def test_removal_failure_warns_and_continues(self, tmp_path, monkeypatch, capsys):
+        """A failed delete (permissions, sharing violation) must warn, not
+        crash the upgrade."""
+        target = self._target(tmp_path)
+        self._legacy_rule(
+            target, "# govkit test-first rule (v0.13)\n",
+            datetime(2025, 12, 1, tzinfo=timezone.utc),
+        )
+        real_unlink = Path.unlink
+
+        def failing_unlink(self, *args, **kwargs):
+            if self.name == "test-first.md" and "govkit" not in str(self.parent):
+                raise OSError("simulated sharing violation")
+            return real_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        self._run(tmp_path, target, monkeypatch)  # must not raise
+
+        err = capsys.readouterr().err
+        assert "could not remove" in err
+        assert (target / ".claude" / "rules" / "govkit" / "test-first.md").is_file()
 
 
 class TestCmdUpgradeEditProtection:

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2610,6 +2610,33 @@ class TestUpgradeMigratesLegacyInstructionFile:
         assert "could not remove" in err
 
 
+class TestCompareVersion:
+    """Marker versions are not schema-validated, so a hand-edited or truncated
+    string like `0.14` reaches the comparator. Components that are absent must
+    read as zero rather than making the shorter string sort first."""
+
+    def test_missing_patch_component_compares_equal(self):
+        from cli.marker import _compare_version
+
+        assert _compare_version("0.14", "0.14.0") == 0
+        assert _compare_version("0.14.0", "0.14") == 0
+        assert _compare_version("1", "1.0.0") == 0
+
+    def test_ordering_is_preserved(self):
+        from cli.marker import _compare_version
+
+        assert _compare_version("0.13.0", "0.14.0") == -1
+        assert _compare_version("0.15.0", "0.14.0") == 1
+        assert _compare_version("0.14.1", "0.14") == 1
+        assert _compare_version("0.9", "0.14.0") == -1
+
+    def test_unparseable_versions_compare_equal(self):
+        from cli.marker import _compare_version
+
+        assert _compare_version("dev", "0.14.0") == 0
+        assert _compare_version("unknown", "0.7.0") == 0
+
+
 def _make_namespaced_repo(tmp_path: Path, agent: str = "test-agent") -> Path:
     """A repo whose manifest installs one `govkit/`-namespaced rule and one
     `govkit-`-prefixed skill dir (the post-0.14 agent-file layout)."""
@@ -2759,6 +2786,43 @@ class TestUpgradeRetiresPreNamespaceAgentFiles:
         same-named file there is the team's, even though its mtime predates
         applied_at. Upgrading 0.14.0 -> 0.15.0 must not delete it."""
         target = self._target(tmp_path, marker_version="0.14.0")
+        legacy = self._legacy_rule(
+            target, "# ACME rule\n", datetime(2025, 12, 1, tzinfo=timezone.utc),
+        )
+        self._run(tmp_path, target, monkeypatch, govkit_version="0.15.0")
+
+        assert legacy.exists()
+        assert legacy.read_text(encoding="utf-8") == "# ACME rule\n"
+
+    def test_governance_entry_is_exempt_from_mechanical_derivation(
+        self, tmp_path, monkeypatch,
+    ):
+        """Governance's superseded location is a top-level CLAUDE.md, which
+        `_LEGACY_INSTRUCTION_DEST` already owns — NOT `.claude/rules/
+        governance.md`. Deriving that path mechanically would let upgrade
+        delete a team file that govkit never wrote."""
+        target = self._target(tmp_path)
+        team = target / ".claude" / "rules" / "governance.md"
+        team.parent.mkdir(parents=True, exist_ok=True)
+        team.write_text("# ACME governance notes\n", encoding="utf-8")
+        # Older than applied_at, so only the exemption keeps it alive.
+        self._stamp(team, datetime(2025, 12, 1, tzinfo=timezone.utc))
+
+        repo, _ = _make_governance_repo(tmp_path)
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.14.0")
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        assert team.exists()
+        assert team.read_text(encoding="utf-8") == "# ACME governance notes\n"
+
+    def test_abbreviated_marker_version_is_not_pre_migration(self, tmp_path, monkeypatch):
+        """A marker written `0.14` (no patch component) IS the namespace
+        version, not older than it. Comparing raw int tuples made
+        (0, 14) < (0, 14, 0), dropping an already-migrated install back into
+        the cleanup window."""
+        target = self._target(tmp_path, marker_version="0.14")
         legacy = self._legacy_rule(
             target, "# ACME rule\n", datetime(2025, 12, 1, tzinfo=timezone.utc),
         )


### PR DESCRIPTION
## The bug

0.14.0 moved govkit's own agent files into a namespace govkit owns, so a team's same-named files survive alongside them:

```
.claude/rules/X.md          ->  .claude/rules/govkit/X.md
.github/instructions/X      ->  .github/instructions/govkit/X
.claude|.agents/skills/Y/   ->  .../skills/govkit-Y/
```

Upgrading a pre-0.14 install wrote the new paths but **left govkit's own copy at the old one**. Claude Code auto-loads `.claude/rules/**` recursively, so the agent ingested **both** — duplicated governance, and *contradictory* wherever the two versions had drifted.

`reconcile_legacy_instruction_files()` retired only the three top-level instruction files (`CLAUDE.md`, `src/CLAUDE.md`, `.github/copilot-instructions.md`). The rules-namespace (#53) and skill-prefix (#54) moves shipped without extending it. The tell: `governance.md` was the *only* file not duplicated — the one migration that was implemented.

Reproduced on a real 0.13.0 install: **8 duplicated rules** (4 with *drifted* content) and **4 duplicated skills**.

## The fix

Both moves are mechanical, so the superseded path is **derived** rather than enumerated per agent — covering claude-code, copilot, and codex uniformly with **no payload change** (parity unaffected).

Safety mirrors the existing reconcile:
- **Version-gated** on the marker predating the namespace move, so a same-named file the team authors at an old path *after* migrating is never a candidate.
- Removes only what is **provably govkit's own** — byte-identical to what govkit installs today, or untouched since the last apply. For a skill directory, one user-touched file protects the whole tree.
- Anything else is the team's and is **left alone**; govkit's namespaced copy installs alongside it, which is the point of the namespace.
- A failed delete **warns and never aborts** the upgrade.

## Second commit: duplicated block

`write_managed_agent_block` and `install_agent_file` were each defined **twice, byte-identically**, in `install_common.py`. Python kept the second definition and the copies matched, so behavior and tests were unaffected — nothing caught it.

It entered during the #51–#56 stack rebase and rode through the squash merges into `main` via the #57 reconcile. That reconcile was validated by comparing its tree against the stack tip, which already carried the duplicate — a tree-equality check can't surface it.

## Validation

- 6 new tests, written first and confirmed red: rule removal, skill-dir removal, team-file preservation (both kinds), version gate, and delete-failure warning.
- Full suite **1059 passed, 1 skipped**; `pytest -k parity` 6 passed; ruff clean.
- **End-to-end on a real sandbox**: a 0.13.0 install upgraded with the built wheel retired all 8 stale rules + 4 stale skills; `govkit doctor` reports zero un-namespaced rules afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)