### PR TITLE
fix(govkit): retire pre-namespace agent files and content-hash edit-protection (0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- Edit-protection for governed and shared docs is now content-based. The
+  `govkit:editable` header records a SHA-256 hash of the installed doc body,
+  and a doc counts as user-edited iff its body no longer matches — so team
+  edits survive consecutive upgrades (previously the `applied_at` re-stamp
+  made protection forget edits after one upgrade) and fresh clones no longer
+  trigger mass false refusals (mtime is no longer an ownership signal for
+  hashed docs). Docs installed before the hash field keep the old
+  mtime-vs-`applied_at` comparison until their next overwrite records a hash;
+  refusing such a doc now prints a note about that protection window. Two
+  edits are invisible to the hash by design: line-ending-only changes and
+  changes confined to the header itself (e.g. tweaking `see:`). Legacy
+  agent-file reconciliation (managed instruction blocks) still uses mtime.
+
 ## [0.14.0] — 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   edits are invisible to the hash by design: line-ending-only changes and
   changes confined to the header itself (e.g. tweaking `see:`). Legacy
   agent-file reconciliation (managed instruction blocks) still uses mtime.
+- Pre-namespace retirement no longer uses timestamps as proof of ownership.
+  A legacy rule file is deleted only when identical to the bundled source; a
+  legacy skill directory only when its whole tree matches (same paths, same
+  content, no extra files). Previously a team-authored file or directory
+  merely predating the marker's `applied_at` could be deleted. Unverifiable
+  leftovers are kept, with a note pointing at the possible duplicate.
+- `is_user_edited` no longer raises `TypeError` on the mtime fallback path
+  when the marker's `applied_at` is timezone-naive; unknown history now means
+  no protection triggered, matching the legacy-instruction reconciliation.
 
 ## [0.14.0] — 2026-07-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is (read this first)
+
+This repo is the **source for `govkit`**, a Python CLI that installs governance artifacts into *other people's* projects. It is **not** a govkit-governed project itself — there is no `features/` workflow, no `/govkit-*` skills, and no `.govkit/` marker governing development here.
+
+That distinction drives everything. The tree splits into two kinds of content:
+
+- **The installer** — `cli/*.py`. Real Python source. This is the code you test and lint.
+- **The payload** — `agents/`, `docs/`, `governance/`, `ci/`, `features/`, `extensions/`. Markdown specs, YAML configs, Gherkin, and JSON schemas that `govkit apply` copies into a target project. Editing these changes what *users* receive, not how the CLI behaves.
+
+When a task says "fix the API conventions" or "update the spec-planning skill," you are almost always editing **payload**, not the installer. When it says "apply is writing the wrong marker" or "doctor crashes," you are editing the **installer**.
+
+## Commands
+
+```bash
+pip install -e ".[test]"      # dev install (extra is [test]; CONTRIBUTING.md's ".[dev]" is stale — [dev] doesn't exist)
+pytest                        # full suite (~765 tests across tests/)
+pytest tests/test_doctor.py                          # one file
+pytest tests/test_doctor.py::TestRunDoctor           # one class
+pytest -k parity                                     # by keyword (parity checks span several files)
+ruff check cli/ && ruff format cli/   # lint + format (fix=true is on; scope to changed files, never a dir-wide run)
+govkit list                   # smoke-run the CLI after an editable install
+```
+
+Ruff has `fix = true` in `pyproject.toml`, so `ruff check` **rewrites files**. Scope it to the files you changed rather than the whole tree, or it will reformat unrelated code into your diff.
+
+### Local end-to-end smoke (PowerShell, Windows)
+
+```powershell
+.\scripts\smoke.ps1 -Agents claude-code -Levels 4 -Force   # apply+validate across agent×type×level
+```
+
+Bootstraps its own `scripts/.venv/` (gitignored) and writes sandboxes under `scripts/projects*/`. See [scripts/README.md](scripts/README.md). L4/L5 `validate` is **expected to fail** in these sandboxes — the starter features intentionally omit `plan.md` / `architecture_preflight.md`.
+
+## Installer architecture (`cli/`)
+
+The CLI is deliberately layered so command modules depend **inward** only, avoiding import cycles:
+
+- **`paths.py` — the dependency-free kernel.** Every module resolves bundled-asset locations (`AGENTS_DIR`, `EXTENSION_PACKS_DIR`, `REPO_ROOT`) through it. It imports nothing internal. **Reference attributes at call time (`paths.AGENTS_DIR`), never `from .paths import AGENTS_DIR`** — tests monkeypatch these attributes to point govkit at a fake bundle, and a copied binding won't see the patch.
+- **`govkit.py` — dispatch only.** Each subcommand lives in its own `cmd_*.py` (or `doctor.py`/`calibrate.py`) module exposing a `register(subparsers)` that binds its handler via `set_defaults(func=...)`. Adding a command = new module + append to `_REGISTRARS`.
+- **Domain modules** — `manifest.py` (variant resolution), `marker.py` (`.govkit/` read/write), `stack_select.py`/`overlay.py` (stack overlays), `detect.py` (repo inference), `headers.py` (edit-protection markers), `install_common.py` (copy loop shared by apply + upgrade), `extensions.py` (extension-pack discovery).
+
+### Two behaviors that recur across the codebase
+
+**Bundled-asset path resolution (dev vs. wheel).** In an editable install, assets are read from the repo root (`agents/`, `extensions/`). In the built wheel, `pyproject.toml`'s `force-include` remaps them under the `cli/` package (`agents/`→`cli/agents/`, `extensions/`→`cli/extension_packs/`, etc.). `paths.py` has the `if (_HERE / "agents").exists() else _HERE.parent / "agents"` fallback for exactly this. **Consequence:** editable-install tests can pass while the wheel is broken (missing force-include). The `wheel-smoke` job in `.github/workflows/test.yml` builds a real wheel and installs into a clean venv to catch this — mirror it if you touch packaging or add a new bundled asset dir. Note `extensions/` ships to `cli/extension_packs/`, **not** `cli/extensions/` — the latter name is the discovery *module* `cli/extensions.py`.
+
+**File categories + edit-protection.** `apply`/`upgrade` treat installed files in three categories with different overwrite rules: **agent config** (govkit-owned namespace — always overwritten), **governed contracts** (write-once on apply, overwritten on upgrade), and **project artifacts** (never overwritten once present). User edits to governed docs are detected by content: the `<!-- govkit:editable -->` header (`headers.py`) records a SHA-256 of the installed body, and a differing body hash means user-edited (headers without a `hash:` field — pre-hash installs — fall back to file mtime vs. the marker's `applied_at`); `--force` overrides. govkit **never** writes or touches a file the user authored.
+
+## Payload architecture
+
+### Three agents, enforced parity
+
+The payload ships for three agents — `agents/{claude-code,codex,copilot}/` — that install to different locations (`.claude/`, `AGENTS.md`+`.agents/`, `.github/`) but must stay behaviorally identical. **The test suite enforces parity.** In particular, a skill's `SKILL.md` frontmatter (`name:`, `description:`) must be **byte-identical** across all three agents. When you add or change a skill, rule, or governance doc, **change it for all three agents in lockstep** and run the parity tests (`pytest -k parity`, plus `tests/test_agent_skills.py`, `tests/test_govkit.py`). Do not claim a per-agent gap without diffing the three inventories first — they are meant to match.
+
+Skills follow the **Open Skills** standard: frontmatter is `name`+`description` only (no `argument-hint:`, no `user-invocable:`, no `$ARGUMENTS`). Feature names are derived from natural language. Skills install with a `govkit-` prefix (`.claude/skills/govkit-spec-planning/`) so they never collide with a user's own skills.
+
+### Variant manifests
+
+Each agent's `manifest.json` declares install sets as **variants** keyed by options (`level` ∈ {3,4,5}, `type` ∈ {api,cli,ui-react,ui-angular,data}, `ci` ∈ {github,azure}). `manifest.py` merges/replaces variant declarations (`by_type`, `by_stack`) into a concrete `(files, shared, governed)` list. A flat `files` format is retained for legacy/custom agents (`_apply_legacy_install`). The chosen options are recorded in the target's `.govkit/marker.json` so later commands (`calibrate`, `doctor`, `validate`, `upgrade`) need no re-specification.
+
+### Maturity levels are additive
+
+L3 ⊂ L4 ⊂ L5. **L3** = agent rules + architecture contracts, no `features/` dir (`govkit init` errors, `validate` no-ops). **L4** adds the `features/<name>/` 5-artifact contract and FIRST/7-Virtue prediction (avg ≥ 4.0). **L5** adds GenAI-ops contracts via `extensions/`. Only the governance file is re-issued per level; lower-level files are never replaced by higher levels.
+
+### Stack overlays
+
+Only 6 architecture docs vary per backend/data stack (`TECH_STACK.md`, `API_CONVENTIONS.md`, `TESTING.md`, `LAYER_IMPLEMENTATION.md`, `SECURITY_AUTH_PATTERNS.md`, `OBSERVABILITY_PORT_CONTRACT.md`). They live in `cli/stacks/<id>/` with an `overlay.yaml`. Everything else in `docs/` is stack-agnostic baseline. `govkit stack apply <id>` swaps overlays post-install, respecting edit-protection.
+
+## When changing behavior, keep the payload internally consistent
+
+A change is rarely one file. Changing a schema means updating starter templates and worked examples that must still validate against it. Changing a CI gate template means updating both `ci/github/` and `ci/azure/` and `ci/README.md`. Changing an architecture doc that agents read means reflecting it in the affected skills/rules. Tests assert this cross-consistency (`tests/test_schemas.py`, `tests/test_fixtures.py`, the per-extension tests). The commit convention is `type(scope): description` with types `feat|fix|docs|test|refactor|chore`.

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ If you omit `--stack`, govkit detects your stack from the repo and falls back to
 govkit stack apply java-spring-boot --target .
 ```
 
-Re-applies the new overlay on top of the existing install. Edit-protection respects user changes: any of the 6 stack docs you've modified since the last apply are preserved unless you pass `--force` (your edits are detected via the `govkit:editable` header + file mtime vs. the marker's `applied_at`).
+Re-applies the new overlay on top of the existing install. Edit-protection respects user changes: any of the 6 stack docs you've modified are preserved unless you pass `--force` (your edits are detected by content — the `govkit:editable` header records a hash of the installed body; docs installed before the hash field fall back to file mtime vs. the marker's `applied_at`).
 
 ### Why only 6 files?
 

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -122,9 +122,7 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
 
     # Retire the pre-namespace rules/skills a pre-0.14 install left at the old
     # paths, so the agent does not auto-load govkit's governance twice.
-    retire_pre_namespace_agent_files(
-        target, agent_dir, files, prior_applied_at, stored_version,
-    )
+    retire_pre_namespace_agent_files(target, agent_dir, files, stored_version)
 
     print("Agent files (refreshed):")
     for entry in files:

--- a/cli/fs.py
+++ b/cli/fs.py
@@ -64,8 +64,17 @@ def is_user_edited(dest: Path, applied_at: str | None) -> bool:
         applied_dt = datetime.fromisoformat(applied_at)
     except (ValueError, TypeError):
         return False
+    # A timezone-naive applied_at cannot be compared to the aware UTC mtime
+    # without TypeError; treat it as unknown history (no protection), same as
+    # install_common._unmodified_since. The comparison is also wrapped as a
+    # final safety net.
+    if applied_dt.tzinfo is None:
+        return False
     mtime_dt = datetime.fromtimestamp(dest.stat().st_mtime, tz=timezone.utc)
-    return mtime_dt > applied_dt
+    try:
+        return mtime_dt > applied_dt
+    except TypeError:
+        return False
 
 
 def _copy_entry_should_refuse(

--- a/cli/fs.py
+++ b/cli/fs.py
@@ -19,19 +19,33 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from .headers import has_editable_header, prepend_header_to_file
+from .headers import (
+    compute_body_hash,
+    has_editable_header,
+    parse_editable_header,
+    prepend_header_to_file,
+)
 
 
 def is_user_edited(dest: Path, applied_at: str | None) -> bool:
-    """True if `dest` carries a govkit:editable header and was modified after
-    the recorded apply time. Used by edit-protection (A2) to avoid clobbering
-    team edits during `apply` / `upgrade` / `stack apply`.
+    """True if `dest` carries a govkit:editable header and its body no longer
+    matches the content govkit installed. Used by edit-protection (A2) to
+    avoid clobbering team edits during `apply` / `upgrade` / `stack apply`.
+
+    Headers written since the hash field exists record the installed body's
+    SHA-256; the file is user-edited iff the current body hash differs.
+    Timestamps play no part — a re-stamped applied_at (upgrade, stack apply)
+    or a fresh clone's new mtimes cannot flip the answer. Headers without a
+    `hash:` field (pre-hash installs, or a header the user broke) fall back
+    to the mtime-vs-applied_at comparison.
 
     Returns False (no protection triggered) when:
-      - applied_at is None or unparseable (no prior install to compare to)
+      - applied_at is None (no prior install; protection is off) — for the
+        hash path this is purely an enable flag, not a timestamp
       - dest doesn't exist or isn't a regular file
       - dest has no editable header (was never govkit-managed)
-      - dest's mtime is at or before applied_at (no edit since)
+      - the recorded hash matches the current body, or on the fallback path
+        the mtime is at or before applied_at / applied_at is unparseable
     """
     if applied_at is None:
         return False
@@ -43,6 +57,9 @@ def is_user_edited(dest: Path, applied_at: str | None) -> bool:
         return False
     if not has_editable_header(content):
         return False
+    fields = parse_editable_header(content)
+    if fields is not None and "hash" in fields:
+        return compute_body_hash(content) != fields["hash"]
     try:
         applied_dt = datetime.fromisoformat(applied_at)
     except (ValueError, TypeError):
@@ -67,6 +84,19 @@ def _copy_entry_should_refuse(
             "re-run with --force to overwrite)",
             file=sys.stderr,
         )
+        # A refused pre-hash file keeps mtime-only protection, which a future
+        # upgrade's applied_at re-stamp resets — warn about the window.
+        try:
+            fields = parse_editable_header(dest.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            fields = None
+        if not fields or "hash" not in fields:
+            print(
+                f"  note: {dest} predates content-hash protection; its edits "
+                "stay protected only until the next upgrade or stack apply — "
+                "merge them or re-run with --force before then",
+                file=sys.stderr,
+            )
         return True
     print(
         f"  warning: overwriting user edits at {dest} (--force set)",

--- a/cli/headers.py
+++ b/cli/headers.py
@@ -19,6 +19,7 @@ The header is a plain markdown comment so it travels in source control and
 renders invisibly in tooling that respects markdown comments.
 """
 
+import hashlib
 from pathlib import Path
 
 _HEADER_START = "<!-- govkit:editable"
@@ -70,18 +71,34 @@ def format_editable_header(
     baseline: str,
     reason: str | None = None,
     see: str = _DEFAULT_SEE,
+    body_hash: str | None = None,
 ) -> str:
     """Produce the editable-header block as a string.
 
     The output ends with a blank line so it slots cleanly above a markdown
-    body when prepended.
+    body when prepended. `body_hash` records the SHA-256 of the doc body so
+    edit-protection can compare content instead of timestamps; headers
+    without it fall back to mtime comparison (pre-hash installs).
     """
     lines = [_HEADER_START, f"  baseline: {baseline}"]
     if reason:
         lines.append(f"  reason: {reason}")
+    if body_hash:
+        lines.append(f"  hash: {body_hash}")
     lines.append(f"  see: {see}")
     lines.append(_HEADER_END)
     return "\n".join(lines) + "\n\n"
+
+
+def compute_body_hash(text: str) -> str:
+    """SHA-256 hex digest of the doc body below the editable header.
+
+    Accepts full file content (any leading header is stripped first) so
+    check-time callers can hash what they read without reassembling the body.
+    Hashing operates on the decoded string, so on-disk line-ending changes
+    (git autocrlf on a fresh clone) never register as edits.
+    """
+    return hashlib.sha256(_strip_existing_header(text).encode("utf-8")).hexdigest()
 
 
 def has_editable_header(content: str) -> bool:
@@ -159,5 +176,11 @@ def prepend_header_to_file(
         return
 
     body = _strip_existing_header(content)
-    header = format_editable_header(baseline=baseline, reason=reason, see=see)
+    # Hash the exact string written below the header — not compute_body_hash,
+    # which would strip again and diverge from check-time hashing whenever the
+    # body itself opens with a literal editable-header block.
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    header = format_editable_header(
+        baseline=baseline, reason=reason, see=see, body_hash=digest,
+    )
     path.write_text(header + body, encoding="utf-8")

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -206,49 +206,64 @@ def _superseded_agent_path(dest: str) -> str | None:
     return None
 
 
-def _tree_unmodified_since(root: Path, applied_at: str | None) -> bool:
-    """True when every file under `root` is unmodified since `applied_at`.
+def _trees_identical(legacy: Path, src: Path) -> bool:
+    """True when `legacy` contains exactly govkit's bundled `src` tree: the
+    same relative file paths, no extras, every file's content identical.
 
-    One user-touched file protects the whole directory: a skill the team
-    edited is theirs even if they changed only part of it. An empty tree
-    returns False — there is nothing to prove ownership with, so it stays.
+    One extra or differing file protects the whole directory — it is (or may
+    be) the team's work. Content is compared as decoded text so a checkout's
+    line-ending rewrite cannot disguise govkit's own copy. An empty legacy
+    tree proves nothing and returns False, so it stays.
     """
-    contents = [p for p in root.rglob("*") if p.is_file()]
-    return bool(contents) and all(_unmodified_since(p, applied_at) for p in contents)
+    legacy_files = [p for p in legacy.rglob("*") if p.is_file()]
+    if not legacy_files:
+        return False
+    src_files = {p.relative_to(src) for p in src.rglob("*") if p.is_file()}
+    for p in legacy_files:
+        rel = p.relative_to(legacy)
+        if rel not in src_files:
+            return False
+        try:
+            if p.read_text(encoding="utf-8") != (src / rel).read_text(encoding="utf-8"):
+                return False
+        except (OSError, UnicodeDecodeError):
+            return False
+    return True
 
 
-def _is_govkit_pre_namespace_copy(
-    legacy: Path, src: Path, applied_at: str | None,
-) -> bool:
+def _is_govkit_pre_namespace_copy(legacy: Path, src: Path) -> bool:
     """True when `legacy` is provably govkit's own copy rather than the team's.
 
-    A directory qualifies when nothing inside it was touched since the last
-    apply. A file qualifies when it is byte-identical to what govkit installs
-    today (a same-version orphan) or untouched since the last apply (an older
-    govkit version's file the team never edited).
+    Provenance is content, not timestamps: a file qualifies only when it is
+    identical to what govkit installs today; a directory only when its whole
+    tree is (`_trees_identical`). Merely predating the marker's `applied_at`
+    proves nothing — a team file authored before the last apply also has an
+    old mtime, and deleting it would destroy their work. The cost of the
+    stricter test is that an older govkit version's drifted copy is left for
+    the team to remove; the caller prints a note pointing at it.
     """
     if legacy.is_dir():
-        return _tree_unmodified_since(legacy, applied_at)
-    if src.is_file():
-        try:
-            if legacy.read_text(encoding="utf-8") == src.read_text(encoding="utf-8"):
-                return True
-        except (OSError, UnicodeDecodeError):
-            pass
-    return _unmodified_since(legacy, applied_at)
+        return src.is_dir() and _trees_identical(legacy, src)
+    if not src.is_file():
+        return False
+    try:
+        return legacy.read_text(encoding="utf-8") == src.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
 
 
 def retire_pre_namespace_agent_files(
     target: Path, agent_dir: Path, files: list,
-    applied_at: str | None = None, stored_version: str | None = None,
+    stored_version: str | None = None,
 ) -> None:
     """Remove the pre-namespace rules/skills an upgrade would otherwise orphan.
 
     Runs only while the marker predates the namespace move, so a same-named
     file the team authors at an old path *after* migrating is never a
     candidate. Inside that window a path is removed only when it is provably
-    govkit's own (see `_is_govkit_pre_namespace_copy`); anything else is the
-    team's and is left untouched — govkit's namespaced copy installs alongside
+    govkit's own — identical to the bundled source (see
+    `_is_govkit_pre_namespace_copy`); anything else may be the team's and is
+    left in place with a note — govkit's namespaced copy installs alongside
     it, which is the entire point of the namespace. A failed delete warns and
     never aborts the upgrade.
     """
@@ -261,7 +276,13 @@ def retire_pre_namespace_agent_files(
         legacy = target / legacy_rel
         if not legacy.exists():
             continue
-        if not _is_govkit_pre_namespace_copy(legacy, agent_dir / entry["src"], applied_at):
+        if not _is_govkit_pre_namespace_copy(legacy, agent_dir / entry["src"]):
+            print(
+                f"  kept    {legacy_rel}  (cannot verify it is govkit's own "
+                f"copy; if it is a leftover govkit file it duplicates "
+                f"{entry['dest']} — review and remove it manually)",
+                file=sys.stderr,
+            )
             continue
         try:
             if legacy.is_dir():

--- a/cli/setup_review.py
+++ b/cli/setup_review.py
@@ -188,9 +188,11 @@ this file — author your notes in ADRs or a separate doc instead.
 ## Next steps
 
 - After reviewing, edit the docs above to match your repo. GovKit detects your
-  edits (via the `govkit:editable` header + file mtime vs. the marker's
-  `applied_at`) and refuses to overwrite them on `govkit upgrade` or
-  `govkit stack apply`. Use `--force` to override.
+  edits by content: the `govkit:editable` header records a hash of each doc's
+  installed body, and a doc whose body no longer matches is refused on
+  `govkit upgrade` or `govkit stack apply`. (Docs installed before the hash
+  field fall back to file mtime vs. the marker's `applied_at`.) Use `--force`
+  to override.
 - GovKit's own agent guidance is refreshed on every upgrade and is not meant to
   be hand-edited — steer it through the architecture docs above and
   `govkit calibrate`, not by editing the installed governance files.

--- a/plans/DATA_ENFORCEMENT_HARDENING_PLAN.md
+++ b/plans/DATA_ENFORCEMENT_HARDENING_PLAN.md
@@ -1,0 +1,304 @@
+# Data Enforcement Hardening Plan
+
+Close the gap between what govkit's `--type data` install *promises* (spec-first
+delivery, modifiable architecture contracts, CI-checked evaluation criteria) and
+what the code *delivers*. Source: the 2026-07-23 data-teams code review
+(`govkit-data-teams-review.md`), "What I'd do, in priority order." Every finding
+below was verified against the working tree; file/line anchors are from that
+review.
+
+Ordering principle: trust foundation first (edit-protection), then cheap
+validation fixes, then the spec machinery, then net-new enforcement. Each
+increment is independently committable, full suite green, ruff scoped to
+changed files. Parity: any change to claude-code agent assets must land
+identically for codex and copilot in the same increment (see `PARITY_TEST.md`).
+
+## Motivation (evidence)
+
+| Promise | Reality today | Anchor |
+|---|---|---|
+| "govkit never overwrites files you authored" | Edit-protection survives exactly one upgrade: `is_user_edited` compares mtime vs marker `applied_at`, and `cmd_upgrade` re-stamps `applied_at` after refusing — the *next* upgrade clobbers silently. Fresh git clones invert the failure (all mtimes newer than `applied_at` → mass false refusals → `--force` nukes real edits). | `cli/fs.py:25-51`, `cli/cmd_upgrade.py:147` |
+| "The eval gate checks that every NFR category has at least one tagged scenario" (`l4-data.md`) | `known_categories` omits freshness/quality/pii/lineage/cost; the populated-section heuristic requires `- ` bullets while data NFRs use tables. Data NFR coverage is unvalidated. | `cli/validate.py:271-274, 261` |
+| "Governed by evaluation criteria validated against a JSON Schema" | Data installs ship no schema (`variants.type.data.governed` = `docs/data/architecture/` only); the starter doesn't conform to the backend schema; `check_eval_criteria` invokes `check-jsonschema --check-metaschema` on the *instance* (wrong invocation). Nothing executes the criteria. | `agents/*/manifest.json`, `cli/validate.py:197-205` |
+| Skills "do NOT assume hexagonal … whatever your layer mapping is" (`l4-data.md`) | L4 data installs get the backend skills, which hardcode `docs/backend/architecture/` and cite API/security docs a data install doesn't have. | `agents/*/manifest.json` data.level_4, `skills/backend/spec-planning/SKILL.md:17-20` |
+| Databricks stack support | Overlay swaps 6 docs, but the layer rules stay dbt-worded (`{{ source() }}`, materializations, staging/marts globs) and are govkit-owned (overwritten on upgrade). | `cli/stacks/databricks-lakehouse/`, `agents/*/rules/data/` |
+| — | Latent: `validate.STARTERS` omits `starter_data`; `cmd_init` ignores the marker's `options.type` and defaults the prompt to `backend` in data repos; the data starter's virtue vocabulary forked from the documented 7 Virtues. | `cli/validate.py:71-74`, `cli/cmd_init.py`, `features/starter_data/plan.md` |
+
+---
+
+## Phase A — Trust foundation
+
+### Increment 1: Content-hash edit-protection (replaces mtime)
+
+The one defect that can destroy a team's calibrated contracts. Fix before
+anything else ships on top.
+
+Target design: the `govkit:editable` header gains a `hash:` field — SHA-256 of
+the doc **body** (content below the header), computed at install time. A doc is
+user-edited iff its current body hash differs from the recorded hash.
+Timestamps stop being an ownership signal entirely.
+
+1. Failing tests first (`tests/test_fs.py`):
+   - install → edit body → `is_user_edited` True; **stays True after a
+     simulated second upgrade re-stamps `applied_at`** (the amnesia repro)
+   - install → `touch` the file / copy to a new mtime without content change
+     (the fresh-clone repro) → False
+   - legacy file with header but no `hash:` field → fall back to today's
+     mtime comparison (no behavior break for existing installs)
+   - `--force` overwrite refreshes the recorded hash
+2. `cli/headers.py`: `format_editable_header` accepts `body_hash`;
+   `parse_editable_header` already returns arbitrary fields — no change.
+   `prepend_header_to_file` computes the hash of the body it writes.
+3. `cli/fs.py`: `is_user_edited` prefers hash comparison; mtime path survives
+   only for headers lacking `hash:`.
+4. Ride-along: `doctor` D006 gains nothing here, but confirm its baseline
+   parsing tolerates the new field (it parses key:value generically).
+
+Diff: headers.py, fs.py, test_fs.py, test_headers.py. CHANGELOG under
+Unreleased ("edit-protection is now content-based; team edits survive
+consecutive upgrades and fresh clones").
+
+Non-goal: recording refused files in the marker. Hash comparison makes the
+refusal state derivable from the file itself; no second bookkeeping surface.
+
+---
+
+## Phase B — Validation quick wins (all `cli/validate.py` + `cli/cmd_init.py`)
+
+### Increment 2: Data NFR categories are validated
+
+1. Failing tests: a data-shaped `nfrs.md` (table-style sections for
+   `@nfr-freshness`, `@nfr-pii`, …) + an `acceptance.feature` missing
+   `@nfr-freshness` → FAIL; with all tags present → PASS.
+2. Add `freshness`, `quality`, `pii`, `lineage`, `cost` to
+   `known_categories`. Normalize headings so `## @nfr-freshness` and
+   `## Freshness` both map to `freshness`.
+3. Make the populated-section heuristic recognize table rows (`| … |`) and
+   checkbox lines, not just `- ` bullets.
+
+Diff: validate.py, tests/test_validate.py.
+
+### Increment 3: Starter + init hygiene
+
+1. Add `starter_data` (and a guard test asserting `STARTERS` ⊇ every bundled
+   `features/starter_*` dir name, so the *next* starter can't repeat this) to
+   `cli/validate.py`.
+2. `cmd_init`: read `options.type` from the marker and derive the starter
+   default (`data` → `data`, `ui-*` → matching UI, else `backend`). Prompt
+   text shows the detected default. Explicit `--starter` still wins.
+3. Failing tests first for both: `govkit init` in a marker-typed data repo
+   with no `--starter` and piped empty input → data starter scaffolded.
+
+Diff: validate.py, cmd_init.py, tests. One increment — both are small and
+share no risk.
+
+### Increment 4: Honest schema validation plumbing
+
+`check_eval_criteria` currently runs `check-jsonschema --check-metaschema`
+against the instance file — it validates the YAML *as a schema*, which is
+meaningless here for every project type, not just data.
+
+1. Resolve the schema path from the install
+   (`governance/*/schemas/eval_criteria.schema.json`); when present, run
+   `check-jsonschema --schemafile <schema> <instance>`; when absent, WARN
+   "no schema installed for this project type" (true for data until
+   Increment 7).
+2. Pin behavior with tests using a stub `check-jsonschema` on PATH (pass,
+   fail, missing binary → WARN).
+
+Diff: validate.py, tests/test_validate.py. This increment intentionally makes
+the data gap *visible* (WARN) rather than silently green.
+
+---
+
+## Phase C — Spec machinery becomes type-aware
+
+### Increment 5: Skills resolve the docs area from the install
+
+The backend skills hardcode `docs/backend/…`. Rather than fork per-type
+skills, template the area the same way rule globs are already templated at
+install time (`rule_templating.py` precedent: agents can't resolve
+skill_context at runtime, so resolve at install).
+
+1. Add a `docs_area` fact to `skill_context.yaml` (`backend` | `ui` | `data`,
+   derived from marker `options.type`).
+2. SKILL.md sources gain `{{docs_area}}` tokens (`docs/{{docs_area}}/architecture/`);
+   `post_install_finalize` expands tokens when copying skills — same pass,
+   same degradation rule (unknown token → leave source text, doctor flags).
+3. Guard test: after `apply --type data`, no installed skill file contains
+   the literal string `docs/backend/`.
+4. Parity: identical change in codex (`.agents/skills/`) and copilot
+   (`.github/skills/`) sources.
+
+Diff: skill_context.py, install_common.py (or a small skill_templating
+helper), 3 agents × 4 skill sources, tests.
+
+### Increment 6: Data-native preflight sections
+
+Section vocabulary is still backend ("API Impact", "Security Impact") even
+with correct paths. Give the preflight skill a per-area section block:
+
+1. Data variant sections: Pipeline Impact (schedule/SLA/backfill), Contract
+   Impact (mart schema changes vs the breaking-change table in `marts.md`),
+   PII Impact, Lineage Impact. Backend/UI keep today's sections.
+2. Source of truth for the sections is the skill source per area — accept the
+   duplication across 3 agents (parity test pins it) rather than inventing a
+   template engine.
+3. Update `features/starter_data/architecture_preflight.md` so the worked
+   example is exactly what the shipped skill now produces (it was
+   hand-adapted; make that true by construction).
+
+Diff: 3 agents × architecture-preflight + spec-planning SKILL.md, starter_data
+preflight, PARITY_TEST.md additions.
+
+---
+
+## Phase D — Data evaluation criteria become enforceable
+
+### Increment 7: A data eval-criteria schema that the starter passes
+
+1. New `governance/data/schemas/eval_criteria.schema.json`: `version`
+   (integer), `mode` (`deterministic` | `none` for data; no `llm`),
+   `criteria[]` with `id`/`description`/`measurement`/`threshold`
+   (string — data thresholds are query predicates, not 0–1 floats)/
+   `severity` (`error`|`warn`). Deliberately *not* the backend criterion
+   shape; data criteria are checked by queries and CI outcomes, not
+   evaluator tools.
+2. Fix `features/starter_data/eval_criteria.yaml` to conform (`version: 1`
+   integer).
+3. Manifests: data variant `governed` gains `governance/data/schemas/` (all
+   3 agents). Increment 4's schema resolution then picks it up automatically
+   — local validate goes from WARN to real instance validation.
+4. Tests: starter validates against the new schema; backend starter still
+   validates against the backend schema.
+
+Diff: new schema, starter yaml, 3 manifests, tests/test_schemas.py.
+
+### Increment 8: dbt-gate enforces the mart contract
+
+The highest-leverage move in the whole plan: convert the docs teams edit into
+checks the build runs.
+
+1. `ci/github/dbt-gate.yml` (+ azure twin) static checks gain, blocking:
+   - every model under `models/marts/` declares `contract: {enforced: true}`
+     in its YAML (dbt-native column contract — the machine form of "marts
+     are the public API")
+   - every mart appears in at least one `exposures:` entry (operationalizes
+     `marts.md`'s "no exposure = dead code or undocumented")
+2. Opt-in (documented in the gate's trailer, same pattern as warehouse
+   checks): `dbt-project-evaluator` for layer-boundary enforcement —
+   machine-checks `BOUNDARIES.md` §1's allowed-reads table.
+3. Update `cli/stacks/python-dbt/MODEL_LAYERING.md` + `TESTING.md` to
+   document model contracts and versions as the mart change-control
+   mechanism (deprecation via `deprecation_date`, breaking change via new
+   model version + ADR). These are `editable: true` docs — bump overlay
+   version (this *is* doc content, unlike the stack-metadata precedent).
+4. Gate-behavior tests: extend the CI fixture approach used for the existing
+   static checker (pure-python check script is already embedded — factor it
+   into `scripts/` if embedding grows past ~150 lines, else keep inline).
+
+Diff: 2 CI gate files ×2 platforms, 2 overlay docs, overlay.yaml version,
+CHANGELOG.
+
+Risk: teams on dbt-core < 1.5 lack model contracts. The check keys off
+`dbt_project.yml` requiring `require-dbt-version: ">=1.5"` or the presence of
+any `contract:` key; otherwise it downgrades to a warning with an upgrade
+pointer. Conservative-gate philosophy preserved.
+
+---
+
+## Phase E — Rules follow the stack and the team
+
+### Increment 9: Stack-overlaid data rules
+
+1. Overlays gain an optional `rules:` list (schema change to
+   `stack-overlay.schema.json`, same two-layer enforcement as the
+   `supported_types` precedent in `STACK_METADATA_UNIFICATION_PLAN.md`).
+2. `databricks-lakehouse` ships medallion-worded rule bodies
+   (bronze/silver/gold vocabulary, Delta/PySpark idioms, globs
+   `**/bronze/**` etc. templated via `layers.*` as today); `python-dbt`
+   ships the current dbt rules unchanged.
+3. Install path: when the active stack declares rules, they replace the
+   type-default rule set for the overlapping filenames; `stack apply` swaps
+   them (agent files are govkit-owned — unconditional refresh is correct
+   here *because* Increment 10 removes team-tunable values from rule
+   bodies).
+4. Parity across 3 agents; D001 fixtures for a `src/bronze` repo.
+
+Diff: schema, 2 overlay.yaml, new rule sources under
+`cli/stacks/databricks-lakehouse/rules/` (or agent-variant subdirs — decide
+in-increment against how manifests resolve rule sources today), install
+plumbing, tests.
+
+### Increment 10: Team-tunable values move out of rule bodies
+
+1. Inventory the constants duplicated in `rules/data/*`: PII keyword list
+   (`staging.md`), materialization defaults, naming patterns.
+2. PII keywords → `skill_context.yaml` (`pii.keyword_list`, seeded from
+   today's default); rules templated at install time with the list (same
+   expansion pass as Increment 5); `dbt-gate`'s PII regex documented as
+   generated from the same list (single source).
+3. Materialization/naming stay in the **docs** (already editable) — rules
+   drop the literal values and cite the doc, per the Authority pattern the
+   rules already use.
+
+Diff: rules sources ×3 agents, skill_context.py, dbt-gate PII section, tests.
+
+---
+
+## Phase F — Scoring honesty at data L4
+
+### Increment 11: Decide and reconcile the prediction gate (ADR first)
+
+Not a code-first increment — an ADR under `docs/data/architecture/ADR/`
+choosing between:
+
+- **(a)** drop the `evaluation_prediction` requirement for `--type data`
+  (validate skips `check_plan_eval_prediction` when marker type is data;
+  artifact completeness + Increments 7–8 carry enforcement), or
+- **(b)** replace FIRST/Virtues with a data-native rubric (contract
+  completeness, test-tier coverage, lineage coverage) with its own rubric
+  doc.
+
+Recommendation: (a) now, (b) only if a team asks for a scored gate — a
+self-predicted ≥4.0 is ceremony either way, and (b) invents a rubric nobody
+has calibrated. Whichever lands: fix the starter's virtue vocabulary drift
+(`correctness/clarity/…` vs the documented `Working/Unique/Simple/…`) — under
+(a) by deleting the block from `starter_data/plan.md`, under (b) by the new
+rubric. Update `l4-data.md` ×3 agents to match.
+
+Diff: ADR, validate.py (one level/type guard), starter_data/plan.md,
+l4-data.md ×3, CHANGELOG.
+
+---
+
+## Sequencing and release shape
+
+| Release | Increments | Theme |
+|---|---|---|
+| N | 1–4 | Trust + honest validation (no new features; safe patch/minor) |
+| N+1 | 5–7 | Spec machinery works for data (minor) |
+| N+2 | 8 | Mart contracts enforced in CI (minor; the headline) |
+| N+3 | 9–11 | Databricks rules parity + tunables + scoring ADR |
+
+Phases B and A are independent — B can land first if release pressure
+demands, but nothing in C–E should ship before 1 (every later increment
+rewrites installed files; doing that on top of mtime-based protection risks
+the exact clobber the review flagged).
+
+## Risks / non-goals
+
+- **No new hard gates on existing installs without an escape hatch.**
+  Increment 8's contract check warns (not fails) when the repo predates dbt
+  1.5; Increment 2 can only fail features whose nfrs.md populates a category
+  with no tag — which is the contract `l4-data.md` already claims.
+- **Non-goal: executing data eval criteria in CI** (freshness queries,
+  masked-value assertions). That requires warehouse credentials and stays
+  behind the documented opt-in line. This plan makes the criteria
+  *structurally valid and visible*, and moves the enforceable subset
+  (contracts, exposures, boundaries) into static checks.
+- **Non-goal: per-type skill forks.** Templating (Increments 5–6) keeps one
+  skill source per agent; a `skills/data/` tree is fallback only if the
+  section-block divergence outgrows templating.
+- **Non-goal: touching L5 for data.** Data remains L3/L4 per the v0.13
+  ruling; nothing here changes that boundary.

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,0 +1,168 @@
+"""Tests for cli/fs.py — content-hash edit-protection.
+
+Increment 1 of the data-enforcement hardening plan: `is_user_edited` prefers
+the header's recorded `hash:` (SHA-256 of the doc body) over the legacy
+mtime-vs-applied_at comparison. Content decides ownership; timestamps stop
+mattering for hashed files.
+
+The legacy mtime-path pins (hashless headers, copy_entry refusal flow) live
+in tests/test_govkit.py (TestIsUserEdited, TestCopyEntryEditProtection) and
+are unchanged — those now ARE the legacy-fallback tests.
+"""
+
+# applied_at fixtures: with hash-based detection the timestamp must not
+# matter, so tests pin both extremes explicitly.
+PAST = "2000-01-01T00:00:00+00:00"
+FUTURE = "2099-01-01T00:00:00+00:00"
+
+
+def _write_hashed_doc(path, body, recorded_body=None):
+    """Write a doc with an editable header whose hash: records
+    `recorded_body` (defaults to `body` — an unedited install)."""
+    from cli.headers import compute_body_hash, format_editable_header
+
+    header = format_editable_header(
+        baseline="govkit@0.14.0",
+        body_hash=compute_body_hash(recorded_body if recorded_body is not None else body),
+    )
+    path.write_text(header + body, encoding="utf-8")
+
+
+class TestIsUserEditedHashBranch:
+    def test_edited_body_detected_despite_restamped_applied_at(self, tmp_path):
+        """The amnesia repro: upgrade re-stamps applied_at to now, so the
+        edited file's mtime is older than applied_at. mtime logic forgets the
+        edit; the hash must not."""
+        from cli.fs import is_user_edited
+
+        doc = tmp_path / "contract.md"
+        _write_hashed_doc(doc, body="# Doc\n\nTeam edit.\n", recorded_body="# Doc\n\nOriginal.\n")
+
+        assert is_user_edited(doc, FUTURE) is True
+
+    def test_unchanged_body_not_flagged_when_mtime_newer(self, tmp_path):
+        """The fresh-clone repro: a clone gives every file a new mtime. An
+        unedited body must not trigger refusal."""
+        from cli.fs import is_user_edited
+
+        doc = tmp_path / "contract.md"
+        _write_hashed_doc(doc, body="# Doc\n\nOriginal.\n")
+
+        assert is_user_edited(doc, PAST) is False
+
+    def test_hash_decides_despite_malformed_applied_at(self, tmp_path):
+        """The hash branch must not depend on applied_at being parseable."""
+        from cli.fs import is_user_edited
+
+        doc = tmp_path / "contract.md"
+        _write_hashed_doc(doc, body="# Doc\n\nTeam edit.\n", recorded_body="# Doc\n\nOriginal.\n")
+
+        assert is_user_edited(doc, "not-a-timestamp") is True
+
+    def test_empty_body_round_trip_not_flagged(self, tmp_path):
+        from cli.fs import is_user_edited
+
+        doc = tmp_path / "empty.md"
+        _write_hashed_doc(doc, body="")
+
+        assert is_user_edited(doc, PAST) is False
+
+    def test_hashless_header_falls_back_to_mtime(self, tmp_path):
+        """Pre-hash installs keep the old semantics: mtime newer than
+        applied_at means edited, older means not."""
+        from cli.fs import is_user_edited
+        from cli.headers import format_editable_header
+
+        doc = tmp_path / "legacy.md"
+        doc.write_text(
+            format_editable_header(baseline="govkit@0.13.0") + "# Doc\n",
+            encoding="utf-8",
+        )
+
+        assert is_user_edited(doc, PAST) is True
+        assert is_user_edited(doc, FUTURE) is False
+
+    def test_force_overwrite_refreshes_recorded_hash(self, tmp_path):
+        """--force over an edited hashed doc installs the new body and
+        records ITS hash, so the file reads as unedited afterwards."""
+        from cli.fs import copy_entry, is_user_edited
+        from cli.headers import compute_body_hash, parse_editable_header
+
+        src = tmp_path / "src.md"
+        src.write_text("# New baseline\n", encoding="utf-8")
+        dest = tmp_path / "dest.md"
+        _write_hashed_doc(dest, body="# Edited\n", recorded_body="# Original\n")
+
+        copy_entry(
+            src,
+            dest,
+            applied_at=FUTURE,
+            force=True,
+            header_baseline="govkit@0.14.0",
+        )
+
+        content = dest.read_text(encoding="utf-8")
+        assert parse_editable_header(content)["hash"] == compute_body_hash("# New baseline\n")
+        assert is_user_edited(dest, FUTURE) is False
+
+    def test_refusing_hashless_file_notes_migration_gap(self, tmp_path, capsys):
+        """A pre-hash file is still under mtime semantics: its edits survive
+        only until the next upgrade re-stamps applied_at. The refusal must
+        say so."""
+        from cli.fs import copy_entry
+        from cli.headers import format_editable_header
+
+        src = tmp_path / "src.md"
+        src.write_text("# New baseline\n", encoding="utf-8")
+        dest = tmp_path / "dest.md"
+        dest.write_text(
+            format_editable_header(baseline="govkit@0.13.0") + "# Edited\n",
+            encoding="utf-8",
+        )
+
+        copy_entry(
+            src,
+            dest,
+            applied_at=PAST,
+            force=False,
+            header_baseline="govkit@0.14.0",
+        )
+
+        err = capsys.readouterr().err
+        assert "refused" in err
+        assert "predates content-hash protection" in err
+
+    def test_refusing_hashed_file_emits_no_migration_note(self, tmp_path, capsys):
+        from cli.fs import copy_entry
+
+        src = tmp_path / "src.md"
+        src.write_text("# New baseline\n", encoding="utf-8")
+        dest = tmp_path / "dest.md"
+        _write_hashed_doc(dest, body="# Edited\n", recorded_body="# Original\n")
+
+        copy_entry(
+            src,
+            dest,
+            applied_at=FUTURE,
+            force=False,
+            header_baseline="govkit@0.14.0",
+        )
+
+        err = capsys.readouterr().err
+        assert "refused" in err
+        assert "predates content-hash protection" not in err
+
+    def test_unterminated_header_falls_back_without_crash(self, tmp_path):
+        """A user edit that deletes the closing --> makes the header
+        unparseable (parse returns None). That must degrade to the mtime
+        path, not raise."""
+        from cli.fs import is_user_edited
+
+        doc = tmp_path / "broken.md"
+        doc.write_text(
+            "<!-- govkit:editable\n  baseline: govkit@0.14.0\n  hash: deadbeef\n# Doc\n",
+            encoding="utf-8",
+        )
+
+        assert is_user_edited(doc, PAST) is True
+        assert is_user_edited(doc, FUTURE) is False

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -152,6 +152,22 @@ class TestIsUserEditedHashBranch:
         assert "refused" in err
         assert "predates content-hash protection" not in err
 
+    def test_naive_applied_at_on_fallback_path_returns_false(self, tmp_path):
+        """A timezone-naive applied_at parses fine but cannot be compared to
+        the aware UTC mtime; unknown history must mean 'not edited', not
+        TypeError (mirrors install_common._unmodified_since)."""
+        from cli.fs import is_user_edited
+        from cli.headers import format_editable_header
+
+        doc = tmp_path / "legacy.md"
+        doc.write_text(
+            format_editable_header(baseline="govkit@0.13.0") + "# Doc\n",
+            encoding="utf-8",
+        )
+
+        assert is_user_edited(doc, "2000-01-01T00:00:00") is False
+        assert is_user_edited(doc, "2099-01-01T00:00:00") is False
+
     def test_unterminated_header_falls_back_without_crash(self, tmp_path):
         """A user edit that deletes the closing --> makes the header
         unparseable (parse returns None). That must degrade to the mtime

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2713,11 +2713,19 @@ class TestUpgradeRetiresPreNamespaceAgentFiles:
         self._stamp(rule, when)
         return rule
 
-    def _legacy_skill(self, target: Path, when: datetime) -> Path:
+    # What _make_namespaced_repo bundles today — byte-identical legacy copies
+    # of these are provably govkit's own.
+    BUNDLED_RULE = "# govkit test-first rule (current)\n"
+    BUNDLED_SKILL_MD = "---\nname: govkit-spec-planning\ndescription: plan a spec\n---\n"
+
+    def _legacy_skill(
+        self, target: Path, when: datetime,
+        body: str = "---\nname: spec-planning\n---\n",
+    ) -> Path:
         skill = target / ".claude" / "skills" / "spec-planning"
         skill.mkdir(parents=True, exist_ok=True)
         f = skill / "SKILL.md"
-        f.write_text("---\nname: spec-planning\n---\n", encoding="utf-8")
+        f.write_text(body, encoding="utf-8")
         self._stamp(f, when)
         return skill
 
@@ -2730,9 +2738,26 @@ class TestUpgradeRetiresPreNamespaceAgentFiles:
 
     # -- rules ---------------------------------------------------------------
 
-    def test_removes_untouched_pre_namespace_rule(self, tmp_path, monkeypatch):
-        """A rule at the old path, untouched since applied_at, is govkit's own
-        orphan → removed; the namespaced rule is installed in its place."""
+    def test_removes_rule_identical_to_bundled_source(self, tmp_path, monkeypatch):
+        """A rule at the old path that is byte-identical to what govkit
+        installs today is provably govkit's own orphan → removed; the
+        namespaced rule is installed in its place."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_rule(
+            target, self.BUNDLED_RULE, datetime(2025, 12, 1, tzinfo=timezone.utc),
+        )
+        self._run(tmp_path, target, monkeypatch)
+
+        assert not legacy.exists()
+        assert (target / ".claude" / "rules" / "govkit" / "test-first.md").is_file()
+
+    def test_keeps_drifted_rule_even_when_untouched_since_apply(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """An old-mtime rule whose content does not match the bundled source
+        is NOT deleted — mtime alone is no proof of govkit provenance (a team
+        file authored before the last apply also has an old mtime). It stays,
+        with a note that a possible duplicate remains."""
         target = self._target(tmp_path)
         legacy = self._legacy_rule(
             target, "# govkit test-first rule (v0.13)\n",
@@ -2740,8 +2765,12 @@ class TestUpgradeRetiresPreNamespaceAgentFiles:
         )
         self._run(tmp_path, target, monkeypatch)
 
-        assert not legacy.exists()
+        assert legacy.exists()
+        assert legacy.read_text(encoding="utf-8") == "# govkit test-first rule (v0.13)\n"
         assert (target / ".claude" / "rules" / "govkit" / "test-first.md").is_file()
+        err = capsys.readouterr().err
+        assert "cannot verify" in err
+        assert "remove it manually" in err
 
     def test_keeps_team_authored_rule_and_still_installs_namespaced(
         self, tmp_path, monkeypatch,
@@ -2759,23 +2788,58 @@ class TestUpgradeRetiresPreNamespaceAgentFiles:
 
     # -- skills --------------------------------------------------------------
 
-    def test_removes_untouched_pre_prefix_skill_dir(self, tmp_path, monkeypatch):
-        """An un-prefixed skill dir untouched since applied_at is govkit's
-        orphan → removed; the govkit- prefixed skill is installed."""
+    def test_removes_skill_dir_identical_to_bundled_tree(self, tmp_path, monkeypatch):
+        """An un-prefixed skill dir whose tree exactly matches the bundled
+        source (same paths, same content, no extras) is govkit's orphan →
+        removed — even with a post-apply mtime; provenance is content, not
+        timestamps. The govkit- prefixed skill is installed."""
         target = self._target(tmp_path)
-        legacy = self._legacy_skill(target, datetime(2025, 12, 1, tzinfo=timezone.utc))
+        legacy = self._legacy_skill(
+            target, datetime(2026, 6, 1, tzinfo=timezone.utc),
+            body=self.BUNDLED_SKILL_MD,
+        )
         self._run(tmp_path, target, monkeypatch)
 
         assert not legacy.exists()
         assert (target / ".claude" / "skills" / "govkit-spec-planning" / "SKILL.md").is_file()
 
     def test_keeps_skill_dir_the_team_edited(self, tmp_path, monkeypatch):
-        """One user-edited file inside the skill dir protects the whole dir."""
+        """A drifted file inside the skill dir protects the whole dir."""
         target = self._target(tmp_path)
         legacy = self._legacy_skill(target, datetime(2026, 6, 1, tzinfo=timezone.utc))
         self._run(tmp_path, target, monkeypatch)
 
         assert legacy.is_dir()
+        assert (legacy / "SKILL.md").is_file()
+
+    def test_keeps_old_skill_dir_with_drifted_content(self, tmp_path, monkeypatch):
+        """The data-loss repro: a dir whose files all predate applied_at but
+        whose content is not govkit's (a team skill authored before the last
+        apply) must survive the migration window."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_skill(target, datetime(2025, 12, 1, tzinfo=timezone.utc))
+        self._run(tmp_path, target, monkeypatch)
+
+        assert legacy.is_dir()
+        assert (legacy / "SKILL.md").read_text(encoding="utf-8") == (
+            "---\nname: spec-planning\n---\n"
+        )
+
+    def test_keeps_skill_dir_with_extra_team_file(self, tmp_path, monkeypatch):
+        """A dir matching the bundled tree but carrying an extra team file is
+        not deletable — the extra file is the team's work."""
+        target = self._target(tmp_path)
+        legacy = self._legacy_skill(
+            target, datetime(2025, 12, 1, tzinfo=timezone.utc),
+            body=self.BUNDLED_SKILL_MD,
+        )
+        notes = legacy / "notes.md"
+        notes.write_text("# team notes on this skill\n", encoding="utf-8")
+        self._stamp(notes, datetime(2025, 12, 1, tzinfo=timezone.utc))
+        self._run(tmp_path, target, monkeypatch)
+
+        assert legacy.is_dir()
+        assert notes.read_text(encoding="utf-8") == "# team notes on this skill\n"
         assert (legacy / "SKILL.md").is_file()
 
     # -- gating + failure safety --------------------------------------------
@@ -2836,8 +2900,7 @@ class TestUpgradeRetiresPreNamespaceAgentFiles:
         crash the upgrade."""
         target = self._target(tmp_path)
         self._legacy_rule(
-            target, "# govkit test-first rule (v0.13)\n",
-            datetime(2025, 12, 1, tzinfo=timezone.utc),
+            target, self.BUNDLED_RULE, datetime(2025, 12, 1, tzinfo=timezone.utc),
         )
         real_unlink = Path.unlink
 

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2929,6 +2929,60 @@ class TestCmdUpgradeEditProtection:
         err = capsys.readouterr().err
         assert "overwriting user edits" in err
 
+    def test_upgrade_refuses_edited_hashed_file_across_consecutive_upgrades(
+        self, tmp_path, monkeypatch, capsys,
+    ):
+        """The amnesia contract: an edited doc installed with a body hash is
+        refused by EVERY subsequent upgrade, not just the first. Upgrade
+        re-stamps applied_at; content-hash protection must not care. (The
+        file's mtime is deliberately older than applied_at, so the legacy
+        mtime signal says 'unedited' — only the hash remembers.)"""
+        import json
+        import os
+        from datetime import datetime, timezone
+
+        from cli.headers import compute_body_hash, format_editable_header
+
+        repo = _make_upgrade_repo(tmp_path)
+        (repo / "docs" / "contract.md").write_text("# Contract v2 (refreshed)\n", encoding="utf-8")
+
+        target = tmp_path / "project"
+        target.mkdir()
+        (target / "CLAUDE.md").write_text("# old\n", encoding="utf-8")
+        contract = target / "docs" / "contract.md"
+        contract.parent.mkdir(parents=True)
+        header = format_editable_header(
+            baseline="govkit@0.1.0", body_hash=compute_body_hash("# Contract v1\n"),
+        )
+        contract.write_text(header + "# Contract user edits\n", encoding="utf-8")
+        old_time = datetime(2026, 5, 27, 9, 0, 0, tzinfo=timezone.utc).timestamp()
+        os.utime(contract, (old_time, old_time))
+
+        applied_at = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc).isoformat()
+        marker = {
+            "version": "0.1.0", "level": "4", "agent": "test-agent",
+            "options": {"type": "api", "ci": "github"},
+            "applied_at": applied_at,
+        }
+        marker_dir = target / ".govkit"
+        marker_dir.mkdir()
+        (marker_dir / "marker.json").write_text(json.dumps(marker), encoding="utf-8")
+
+        monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.2.0")
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+        assert "refused" in capsys.readouterr().err
+
+        monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.3.0")
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+        assert "refused" in capsys.readouterr().err
+
+        body = contract.read_text(encoding="utf-8")
+        assert "Contract user edits" in body
+        assert "Contract v2 (refreshed)" not in body
+
     def test_upgrade_refreshes_unedited_headed_file(self, tmp_path, monkeypatch):
         """A headed governed doc that hasn't been edited since applied_at
         gets refreshed normally, with the header regenerated for the new

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -46,6 +46,54 @@ class TestFormatEditableHeader:
         out = format_editable_header(baseline="govkit@0.10.0", see="docs/governance.md")
         assert "see: docs/governance.md" in out
 
+    def test_header_includes_hash_when_provided(self):
+        from cli.headers import format_editable_header
+
+        out = format_editable_header(baseline="govkit@0.10.0", body_hash="a" * 64)
+        assert f"hash: {'a' * 64}" in out
+
+    def test_header_omits_hash_when_not_provided(self):
+        from cli.headers import format_editable_header
+
+        out = format_editable_header(baseline="govkit@0.10.0")
+        assert "hash:" not in out
+
+
+class TestComputeBodyHash:
+    """SHA-256 of the doc body — the content-based ownership signal that
+    replaces mtime comparison in edit-protection."""
+
+    def test_is_sha256_of_utf8_body(self):
+        import hashlib
+
+        from cli.headers import compute_body_hash
+
+        body = "# Doc\n\nBody text.\n"
+        assert compute_body_hash(body) == hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    def test_full_content_hashes_same_as_bare_body(self):
+        """Check-time callers pass whole file content (header included); the
+        header must be stripped before hashing so the result matches the hash
+        recorded at write time."""
+        from cli.headers import compute_body_hash, format_editable_header
+
+        body = "# Doc\n\nBody text.\n"
+        full = format_editable_header(baseline="govkit@0.10.0") + body
+        assert compute_body_hash(full) == compute_body_hash(body)
+
+    def test_empty_body(self):
+        import hashlib
+
+        from cli.headers import compute_body_hash, format_editable_header
+
+        header_only = format_editable_header(baseline="govkit@0.10.0")
+        assert compute_body_hash(header_only) == hashlib.sha256(b"").hexdigest()
+
+    def test_differs_when_body_differs(self):
+        from cli.headers import compute_body_hash
+
+        assert compute_body_hash("# A\n") != compute_body_hash("# B\n")
+
 
 class TestHasEditableHeader:
     def test_returns_true_when_header_at_top(self):
@@ -132,6 +180,14 @@ class TestParseEditableHeader:
         assert parsed["reason"] == "Default Python baseline."
         assert parsed["see"] == "GOVKIT_SETUP_REVIEW.md"
 
+    def test_roundtrip_includes_hash(self):
+        from cli.headers import format_editable_header, parse_editable_header
+
+        digest = "b" * 64
+        formatted = format_editable_header(baseline="govkit@0.14.0", body_hash=digest)
+        parsed = parse_editable_header(formatted)
+        assert parsed["hash"] == digest
+
 
 class TestPrependHeaderToFile:
     """Convenience writer that adds the header to a doc body."""
@@ -188,6 +244,63 @@ class TestPrependHeaderToFile:
         # Should not raise.
         prepend_header_to_file(missing, baseline="govkit@0.10.0")
         assert not missing.exists()
+
+    def test_records_hash_of_written_body(self, tmp_path):
+        import hashlib
+
+        from cli.headers import parse_editable_header, prepend_header_to_file
+
+        body = "# Technology Stack\n\nContent here.\n"
+        doc = tmp_path / "TECH_STACK.md"
+        doc.write_text(body, encoding="utf-8")
+
+        prepend_header_to_file(doc, baseline="govkit@0.14.0")
+
+        parsed = parse_editable_header(doc.read_text(encoding="utf-8"))
+        assert parsed["hash"] == hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+    def test_reprepend_refreshes_hash(self, tmp_path):
+        """Overwriting a doc (upgrade, --force) rewrites the header; the
+        recorded hash must describe the newly written body, not the old one."""
+        from cli.headers import (
+            compute_body_hash,
+            format_editable_header,
+            parse_editable_header,
+            prepend_header_to_file,
+        )
+
+        stale_header = format_editable_header(
+            baseline="govkit@0.13.0", body_hash=compute_body_hash("# Old body\n"),
+        )
+        doc = tmp_path / "TECH_STACK.md"
+        doc.write_text(stale_header + "# New body\n", encoding="utf-8")
+
+        prepend_header_to_file(doc, baseline="govkit@0.14.0")
+
+        parsed = parse_editable_header(doc.read_text(encoding="utf-8"))
+        assert parsed["hash"] == compute_body_hash("# New body\n")
+
+    def test_body_opening_with_literal_header_hashes_consistently(self, tmp_path):
+        """A body that itself begins with a literal editable-header block must
+        round-trip: the hash recorded at write time has to equal the hash a
+        checker computes from the full file, or the doc reports user-edited
+        forever."""
+        from cli.headers import (
+            compute_body_hash,
+            format_editable_header,
+            parse_editable_header,
+            prepend_header_to_file,
+        )
+
+        body = "<!-- govkit:editable\n  baseline: example@1.0\n-->\n\nActual content.\n"
+        doc = tmp_path / "EXAMPLES.md"
+        doc.write_text(format_editable_header(baseline="govkit@0.13.0") + body, encoding="utf-8")
+
+        prepend_header_to_file(doc, baseline="govkit@0.14.0")
+
+        content = doc.read_text(encoding="utf-8")
+        parsed = parse_editable_header(content)
+        assert parsed["hash"] == compute_body_hash(content)
 
 
 class TestUpsertGovkitBlock:


### PR DESCRIPTION
## What

Ships the 0.14.0 pre-namespace cleanup work and replaces mtime-based edit-protection with content hashing so team edits to governed docs survive consecutive upgrades and fresh clones.

## Why

Two trust problems in the upgrade path:

- Installs predating the `govkit-` namespace left orphaned rules/skills behind on upgrade, and `write_managed_agent_block`/`install_agent_file` had drifted into duplicates.
- Edit-protection compared file mtime vs the marker's `applied_at`, which fails both ways: `upgrade`/`stack apply` re-stamp `applied_at`, so a refused user-edited doc was silently clobbered by the *next* upgrade (amnesia); and a fresh `git clone` makes every mtime newer than `applied_at`, mass-refusing unedited docs and pushing teams toward `--force`, which destroys real edits. This is Increment 1 of `plans/DATA_ENFORCEMENT_HARDENING_PLAN.md` (included in this PR).

## Changes

**Pre-namespace retirement (0.14.0):**
- Retire pre-namespace rules and skills on upgrade; scope the pre-namespace derivation and harden the version gate (`cli/install_common.py`, `cli/cmd_upgrade.py`, `cli/marker.py`)
- Drop the duplicated `write_managed_agent_block`/`install_agent_file`
- Release prep: version bump + CHANGELOG for 0.14.0

**Content-hash edit-protection:**
- `cli/headers.py`: the `govkit:editable` header records `hash:` (SHA-256 of the installed doc body); `prepend_header_to_file` hashes the exact body it writes; new `compute_body_hash()` for check-time use
- `cli/fs.py`: `is_user_edited` compares body hashes when a hash is recorded — timestamps no longer decide ownership; headers without `hash:` (pre-hash installs) keep the mtime fallback, and refusing one prints a note about its one-upgrade protection window
- Hashing operates on the decoded string (universal newlines), so CRLF/LF checkout differences never register as edits
- Docs: CHANGELOG, README, generated `GOVKIT_SETUP_REVIEW.md` text, new `CLAUDE.md`, and the data-enforcement hardening plan

## Testing

- `pytest` — 1084 passed, 1 skipped (pre-existing skip)
- New `tests/test_fs.py` pins the amnesia repro, fresh-clone repro, legacy mtime fallback, malformed-header degradation, and `--force` hash refresh; `tests/test_govkit.py` adds an end-to-end double-upgrade refusal test
- Manual smoke: `govkit apply` → header carries `hash:`; edited doc refused by two consecutive upgrades with the edit intact; unedited doc with a bumped mtime overwritten cleanly instead of falsely refused
- `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)