### PR TITLE
fix(govkit): honest validation for data installs (Phase B: increments 2-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   the marker's recorded `options.type` — a data repo defaults to the data
   starter, a cli repo to the cli starter — instead of always suggesting
   backend. An explicit `--starter` still wins.
+- `govkit validate` now really validates `eval_criteria.yaml` against the
+  installed schema. Previously it ran `check-jsonschema --check-metaschema`
+  on the instance file — validating the YAML *as a schema*, which proved
+  nothing for any project type. The check now resolves
+  `governance/*/schemas/eval_criteria.schema.json` from the install and runs
+  `check-jsonschema --schemafile <schema> <instance>`; a non-conforming file
+  is a FAIL with the validator's message. When no schema is installed for the
+  project type (data, today) the check WARNs visibly instead of passing.
 
 ## [0.14.0] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `- ` bullet. Header-and-delimiter-only tables are scaffolding and demand no
   tag. The data starter gains the two tagged scenarios (`@nfr-observability`,
   `@nfr-compliance`) it was missing under its own contract.
+- `govkit validate` no longer misreads the installed `starter_data` directory
+  as a user feature (it was missing from the starter skip-list, so data repos
+  always saw a spurious failure); a guard test now asserts the skip-list
+  covers every bundled starter. `govkit init` derives its prompt default from
+  the marker's recorded `options.type` — a data repo defaults to the data
+  starter, a cli repo to the cli starter — instead of always suggesting
+  backend. An explicit `--starter` still wins.
 
 ## [0.14.0] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `check-jsonschema --schemafile <schema> <instance>`; a non-conforming file
   is a FAIL with the validator's message. When no schema is installed for the
   project type (data, today) the check WARNs visibly instead of passing.
+  Schema resolution follows the marker's recorded `options.type` (api/cli →
+  backend, ui-* → ui, data → data), so a stale governance tree left by a
+  previous `apply --type` is never validated against; without a marker to
+  choose by, multiple installed schemas WARN as ambiguous rather than
+  silently picking one.
 
 ## [0.14.0] — 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 - `is_user_edited` no longer raises `TypeError` on the mtime fallback path
   when the marker's `applied_at` is timezone-naive; unknown history now means
   no protection triggered, matching the legacy-instruction reconciliation.
+- `govkit validate` now actually checks data NFR coverage, closing the gap
+  against what `l4-data.md` promises. The Gherkin tag check knows the data
+  categories (`freshness`, `quality`, `pii`, `lineage`, `cost`), normalizes
+  `## @nfr-<category>` headings to the same category as plain `## <Category>`
+  headings, and recognizes table-style sections (the data NFR format) — a
+  section now counts as populated on a non-TBD table data row, not just a
+  `- ` bullet. Header-and-delimiter-only tables are scaffolding and demand no
+  tag. The data starter gains the two tagged scenarios (`@nfr-observability`,
+  `@nfr-compliance`) it was missing under its own contract.
 
 ## [0.14.0] — 2026-07-22
 

--- a/cli/cmd_init.py
+++ b/cli/cmd_init.py
@@ -14,16 +14,33 @@ from pathlib import Path
 from . import paths
 from .compat import validate_level_type
 from .fs import copy_entry
-from .marker import read_govkit_level
+from .marker import read_govkit_marker
+
+# The starter each marker options.type implies. The apply-time type choice is
+# recorded precisely so later commands need no re-specification; a data repo
+# defaulting its init prompt to backend contradicts that contract.
+_MARKER_TYPE_TO_STARTER = {
+    "api": "backend",
+    "cli": "cli",
+    "ui-react": "ui-react",
+    "ui-angular": "ui-angular",
+    "data": "data",
+}
 
 
-def _prompt_starter_type() -> str:
+def _default_starter_type(marker_type: str | None) -> str:
+    """The starter implied by the marker's options.type; backend when the
+    marker is absent or carries an unknown type."""
+    return _MARKER_TYPE_TO_STARTER.get(marker_type or "", "backend")
+
+
+def _prompt_starter_type(default: str = "backend") -> str:
     """Interactively prompt for the starter template type."""
     choices = ["backend", "cli", "ui-react", "ui-angular", "data"]
-    prompt_text = f"  Feature type? [{' / '.join(choices)}] (default: backend): "
+    prompt_text = f"  Feature type? [{' / '.join(choices)}] (default: {default}): "
     answer = input(prompt_text).strip().lower()
     if answer == "":
-        answer = "backend"
+        answer = default
     if answer not in choices:
         print(f"Error: invalid choice '{answer}'. Must be one of: {', '.join(choices)}")
         sys.exit(1)
@@ -67,8 +84,10 @@ def cmd_init(args: argparse.Namespace) -> None:
     """Create a new feature folder from the appropriate starter template."""
     target = Path(args.target).resolve()
 
+    stored = read_govkit_marker(target) or {}
+
     # Determine level early so we can gate L3 before any other checks.
-    level = args.level or read_govkit_level(target) or "3"
+    level = args.level or stored.get("level") or "3"
 
     if level == "3":
         print(
@@ -91,7 +110,8 @@ def cmd_init(args: argparse.Namespace) -> None:
         print(f"Error: feature '{feature_name}' already exists at {feature_dir}")
         sys.exit(1)
 
-    starter_type = args.starter or _prompt_starter_type()
+    marker_type = (stored.get("options") or {}).get("type")
+    starter_type = args.starter or _prompt_starter_type(_default_starter_type(marker_type))
     starter_dir = _resolve_starter_dir(starter_type, level)
 
     if not starter_dir.exists():

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -69,7 +69,7 @@ FAIL = "\033[31mFAIL\033[0m"
 WARN = "\033[33mWARN\033[0m"
 
 STARTERS = {
-    "starter_backend", "starter_ui", "starter_cli",
+    "starter_backend", "starter_ui", "starter_cli", "starter_data",
     "starter_backend_l5", "starter_cli_l5",
 }
 

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -241,8 +241,20 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[bool, str]:
     return True, f"{_PLAN_MD} evaluation_prediction averages OK ({', '.join(averages)})"
 
 
+# A markdown table's delimiter row (`|---|:---:|`). Rows before it are the
+# header; rows after it are data. Only data rows prove a section is populated.
+_RE_TABLE_DELIMITER = re.compile(r"^\|(?:\s*:?-+:?\s*\|)+$")
+
+
 def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
-    """Cross-reference populated NFR categories vs @nfr-* tags in acceptance.feature."""
+    """Cross-reference populated NFR categories vs @nfr-* tags in acceptance.feature.
+
+    A section heading may be either the plain category (`## Freshness`) or the
+    tag form the data starter uses (`## @nfr-freshness`); both normalize to the
+    same category. A section counts as populated when it has a non-TBD bullet
+    (checkbox lines included) or a non-TBD table data row — a header-and-
+    delimiter-only table is scaffolding, like a lone TBD bullet.
+    """
     nfrs_path = feature_dir / _NFRS_MD
     feature_path = feature_dir / _ACCEPTANCE_FEATURE
     if not nfrs_path.exists() or not feature_path.exists():
@@ -253,12 +265,23 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
 
     populated = []
     current_heading = None
+    in_table = False
     for line in nfrs_text.splitlines():
         heading_match = re.match(r"^##\s+(.+)", line)
         if heading_match:
             current_heading = heading_match.group(1).strip().lower()
+            current_heading = current_heading.removeprefix("@nfr-")
+            in_table = False
             continue
-        if current_heading and line.strip().startswith("- ") and "TBD" not in line:
+        if current_heading is None:
+            continue
+        stripped = line.strip()
+        if _RE_TABLE_DELIMITER.match(stripped):
+            in_table = True
+            continue
+        is_bullet = stripped.startswith("- ")
+        is_table_row = in_table and stripped.startswith("|")
+        if (is_bullet or is_table_row) and "TBD" not in line:
             populated.append(current_heading)
             current_heading = None
 
@@ -271,6 +294,7 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
     known_categories = frozenset({
         "performance", "availability", "security", "compliance",
         "scalability", "observability", "reliability", "compatibility",
+        "freshness", "quality", "pii", "lineage", "cost",
     })
 
     missing_tags = [

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -29,7 +29,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from .marker import read_govkit_level
+from .marker import read_govkit_level, read_govkit_marker
 
 # ---------------------------------------------------------------------------
 # Artifact file name constants
@@ -180,18 +180,61 @@ def check_nfrs_sections(feature_dir: Path) -> tuple[bool | None, str]:
     return True, f"{_NFRS_MD} section contract OK (Repository Scope + Out of scope populated)"
 
 
-def _resolve_eval_schema(feature_dir: Path) -> Path | None:
-    """The installed eval_criteria schema governing this feature, or None.
+# Governance area whose schemas govern each marker options.type. data maps to
+# its own area, which ships no schema yet — the resolver then reports the gap
+# instead of consulting another type's (possibly stale) governance tree.
+_TYPE_TO_GOVERNANCE_AREA = {
+    "api": "backend",
+    "cli": "backend",
+    "ui-react": "ui",
+    "ui-angular": "ui",
+    "data": "data",
+}
 
-    Standard layout: feature_dir is <target>/features/<name> and the install
-    put the schema at <target>/governance/<area>/schemas/. Walk a few
-    ancestors so a non-standard nesting still resolves.
+_NO_SCHEMA_REASON = "no eval_criteria schema installed for this project type"
+
+
+def _resolve_eval_schema(feature_dir: Path) -> tuple[Path | None, str]:
+    """Resolve the installed eval_criteria schema governing this feature.
+
+    Returns (schema, "") when resolved, or (None, reason) when instance
+    validation must be skipped. The marker's options.type decides the
+    governance area — a stale tree left by a previous `apply --type` must
+    not be validated against. Scanning is the fallback for markerless or
+    unknown-type layouts, and it refuses to guess when more than one area
+    ships a schema.
+
+    Standard layout: feature_dir is <target>/features/<name>; the marker and
+    governance/ live at <target>. A few ancestors are walked so a
+    non-standard nesting still resolves.
     """
-    for ancestor in list(feature_dir.parents)[:3]:
+    ancestors = list(feature_dir.parents)[:3]
+    for ancestor in ancestors:
+        marker = read_govkit_marker(ancestor)
+        if not marker:
+            continue
+        area = _TYPE_TO_GOVERNANCE_AREA.get((marker.get("options") or {}).get("type"))
+        if area is None:
+            break  # marker present but type unknown — fall back to scanning
+        schema = ancestor / "governance" / area / "schemas" / "eval_criteria.schema.json"
+        if schema.is_file():
+            return schema, ""
+        return None, _NO_SCHEMA_REASON
+
+    matches: list[Path] = []
+    for ancestor in ancestors:
         matches = sorted(ancestor.glob("governance/*/schemas/eval_criteria.schema.json"))
         if matches:
-            return matches[0]
-    return None
+            break
+    if len(matches) > 1:
+        areas = ", ".join(sorted(p.parent.parent.name for p in matches))
+        return None, (
+            f"ambiguous eval_criteria schemas installed ({areas}) "
+            "and no marker type to choose by"
+        )
+    if matches:
+        return matches[0], ""
+    return None, _NO_SCHEMA_REASON
 
 
 def check_eval_criteria(feature_dir: Path) -> tuple[bool | None, str]:
@@ -213,12 +256,9 @@ def check_eval_criteria(feature_dir: Path) -> tuple[bool | None, str]:
     if issues:
         return False, f"{_EVAL_CRITERIA_YAML}: {'; '.join(issues)}"
 
-    schema = _resolve_eval_schema(feature_dir)
+    schema, skip_reason = _resolve_eval_schema(feature_dir)
     if schema is None:
-        return None, (
-            f"{_EVAL_CRITERIA_YAML} structure OK — no eval_criteria schema "
-            "installed for this project type; instance validation skipped"
-        )
+        return None, f"{_EVAL_CRITERIA_YAML} structure OK — {skip_reason}; instance validation skipped"
     try:
         result = subprocess.run(
             ["check-jsonschema", "--schemafile", str(schema), str(path)],

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -180,8 +180,27 @@ def check_nfrs_sections(feature_dir: Path) -> tuple[bool | None, str]:
     return True, f"{_NFRS_MD} section contract OK (Repository Scope + Out of scope populated)"
 
 
+def _resolve_eval_schema(feature_dir: Path) -> Path | None:
+    """The installed eval_criteria schema governing this feature, or None.
+
+    Standard layout: feature_dir is <target>/features/<name> and the install
+    put the schema at <target>/governance/<area>/schemas/. Walk a few
+    ancestors so a non-standard nesting still resolves.
+    """
+    for ancestor in list(feature_dir.parents)[:3]:
+        matches = sorted(ancestor.glob("governance/*/schemas/eval_criteria.schema.json"))
+        if matches:
+            return matches[0]
+    return None
+
+
 def check_eval_criteria(feature_dir: Path) -> tuple[bool | None, str]:
-    """Check eval_criteria.yaml for required keys. Full schema validation via check-jsonschema if available."""
+    """Check eval_criteria.yaml required keys, then validate the instance
+    against the installed schema via check-jsonschema.
+
+    WARN (None) when no schema is installed for this project type or the
+    binary is unavailable — visible gaps, not silent green.
+    """
     path = feature_dir / _EVAL_CRITERIA_YAML
     if not path.exists():
         return False, f"{_EVAL_CRITERIA_YAML} not found"
@@ -194,16 +213,24 @@ def check_eval_criteria(feature_dir: Path) -> tuple[bool | None, str]:
     if issues:
         return False, f"{_EVAL_CRITERIA_YAML}: {'; '.join(issues)}"
 
+    schema = _resolve_eval_schema(feature_dir)
+    if schema is None:
+        return None, (
+            f"{_EVAL_CRITERIA_YAML} structure OK — no eval_criteria schema "
+            "installed for this project type; instance validation skipped"
+        )
     try:
         result = subprocess.run(
-            ["check-jsonschema", "--check-metaschema", str(path)],
+            ["check-jsonschema", "--schemafile", str(schema), str(path)],
             capture_output=True, text=True, timeout=10,
         )
-        if result.returncode != 0:
-            return None, f"{_EVAL_CRITERIA_YAML} structure OK — full schema validation requires CI"
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None, f"{_EVAL_CRITERIA_YAML} structure OK — install check-jsonschema for full validation"
-    return True, f"{_EVAL_CRITERIA_YAML} is valid"
+    if result.returncode != 0:
+        detail = (result.stdout or result.stderr or "").strip().splitlines()
+        snippet = detail[-1] if detail else "schema validation failed"
+        return False, f"{_EVAL_CRITERIA_YAML} fails {schema.name}: {snippet}"
+    return True, f"{_EVAL_CRITERIA_YAML} valid against {schema.name}"
 
 
 def check_plan_eval_prediction(feature_dir: Path) -> tuple[bool, str]:

--- a/features/starter_data/acceptance.feature
+++ b/features/starter_data/acceptance.feature
@@ -75,3 +75,16 @@ Feature: customer_dim daily refresh
     When a daily refresh completes
     Then the credit usage SHALL be ≤ 2 × X
     And exceedances SHALL alert oncall (warn, not block)
+
+  @nfr-observability
+  Scenario: Pipeline failure alerts oncall
+    Given the customer_dim_daily pipeline fails a scheduled run
+    Then Slack #data-oncall SHALL receive a failure alert
+    And the run SHALL appear in the dbt_observability dashboard with its duration
+
+  @nfr-compliance
+  Scenario: Right-to-be-forgotten propagates through the mart
+    Given a customer exercises GDPR deletion in the source system
+    When the deletion lands in source.customers
+    Then the customer SHALL be absent from marts.customer_dim within 24 hours
+    And the deletion SHALL be recorded in the audit log for 1 year

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -2001,6 +2001,64 @@ class TestSmokeInit:
         content = (target / "features" / "new-feature" / "acceptance.feature").read_text(encoding="utf-8")
         assert content == "Feature: bundled", "Should use bundled starter, not stale target starter"
 
+    def test_init_defaults_starter_from_marker_type_data(self, tmp_path, monkeypatch):
+        """In a marker-typed data repo, `govkit init` with no --starter and an
+        empty prompt answer scaffolds the data starter — and the prompt shows
+        the detected default."""
+        fake_repo = self._bundled_repo(tmp_path, starter="starter_data")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", fake_repo)
+
+        target = tmp_path / "project"
+        (target / "features").mkdir(parents=True)
+        write_govkit_marker(target, "claude-code", "4", {"type": "data"})
+
+        prompts = []
+
+        def fake_input(prompt=""):
+            prompts.append(prompt)
+            return ""
+
+        monkeypatch.setattr("builtins.input", fake_input)
+
+        cmd_init(argparse.Namespace(
+            feature="my-pipeline", target=str(target), level=None, starter=None,
+        ))
+
+        feature_dir = target / "features" / "my-pipeline"
+        assert (feature_dir / "acceptance.feature").read_text(encoding="utf-8") == "Feature: bundled"
+        assert prompts and "default: data" in prompts[0]
+
+    def test_init_defaults_cli_marker_to_cli_starter(self, tmp_path, monkeypatch):
+        """A cli-typed repo defaults to the cli starter, not backend."""
+        fake_repo = self._bundled_repo(tmp_path, starter="starter_cli")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", fake_repo)
+
+        target = tmp_path / "project"
+        (target / "features").mkdir(parents=True)
+        write_govkit_marker(target, "claude-code", "4", {"type": "cli"})
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+        cmd_init(argparse.Namespace(
+            feature="my-tool", target=str(target), level=None, starter=None,
+        ))
+
+        assert (target / "features" / "my-tool" / "acceptance.feature").exists()
+
+    def test_init_explicit_starter_beats_marker_type(self, tmp_path, monkeypatch):
+        """--starter always wins over the marker-derived default."""
+        fake_repo = self._bundled_repo(tmp_path, starter="starter_backend")
+        monkeypatch.setattr("cli.paths.REPO_ROOT", fake_repo)
+
+        target = tmp_path / "project"
+        (target / "features").mkdir(parents=True)
+        write_govkit_marker(target, "claude-code", "4", {"type": "data"})
+
+        cmd_init(argparse.Namespace(
+            feature="my-feature", target=str(target), level=None, starter="backend",
+        ))
+
+        assert (target / "features" / "my-feature" / "acceptance.feature").exists()
+
     @pytest.mark.parametrize("ui_starter", ["ui-react", "ui-angular"])
     def test_init_ui_variants_resolve_to_starter_ui(self, tmp_path, monkeypatch, ui_starter):
         """ui-react and ui-angular both map to the framework-agnostic starter_ui dir."""

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -625,6 +625,30 @@ class TestCheckGherkinNfrCoverage:
         ok, msg = check_gherkin_nfr_coverage(starter)
         assert ok is True, msg
 
+
+# ---------------------------------------------------------------------------
+# STARTERS registry
+# ---------------------------------------------------------------------------
+
+
+class TestStartersRegistry:
+    def test_starters_covers_every_bundled_starter_dir(self):
+        """validate skips starter dirs by name when scanning a target's
+        features/; a bundled starter missing from STARTERS gets validated as
+        if it were a user feature (and fails — starters omit plan.md by
+        design). Guard so the next starter cannot repeat starter_data's
+        omission."""
+        from cli import paths
+        from cli.validate import STARTERS
+
+        bundled = {
+            p.name
+            for p in (paths.REPO_ROOT / "features").iterdir()
+            if p.is_dir() and p.name.startswith("starter_")
+        }
+        assert bundled, "no bundled starters found — REPO_ROOT misresolved?"
+        assert bundled <= STARTERS, f"STARTERS missing: {sorted(bundled - STARTERS)}"
+
     def test_missing_files(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -367,6 +367,73 @@ class TestCheckEvalCriteria:
         assert ok is False
         assert "not found" in msg
 
+    # -- honest schema validation (instance vs installed schema) -------------
+
+    def _install(self, tmp_path, with_schema=True):
+        """A target with features/feat/eval_criteria.yaml and (optionally) an
+        installed governance schema."""
+        feature_dir = tmp_path / "target" / "features" / "feat"
+        write(feature_dir / "eval_criteria.yaml", VALID_EVAL_CRITERIA)
+        schema = tmp_path / "target" / "governance" / "backend" / "schemas" / "eval_criteria.schema.json"
+        if with_schema:
+            write(schema, '{"type": "object"}')
+        return feature_dir, schema
+
+    def test_validates_instance_against_installed_schema(self, tmp_path, monkeypatch):
+        """The instance must be validated AGAINST the installed schema —
+        not --check-metaschema'd, which validates the YAML *as* a schema and
+        is meaningless for an instance file."""
+        feature_dir, schema = self._install(tmp_path)
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
+
+        ok, msg = check_eval_criteria(feature_dir)
+        assert ok is True
+        assert calls, "check-jsonschema was not invoked"
+        assert "--schemafile" in calls[0]
+        assert str(schema) in calls[0]
+        assert "--check-metaschema" not in calls[0]
+
+    def test_schema_validation_failure_fails(self, tmp_path, monkeypatch):
+        feature_dir, _ = self._install(tmp_path)
+
+        def fake_run(argv, **kwargs):
+            return type("R", (), {
+                "returncode": 1, "stdout": "", "stderr": "criteria[0]: 'threshold' is required",
+            })()
+
+        monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
+
+        ok, msg = check_eval_criteria(feature_dir)
+        assert ok is False
+        assert "eval_criteria.schema.json" in msg
+
+    def test_missing_binary_warns(self, tmp_path, monkeypatch):
+        feature_dir, _ = self._install(tmp_path)
+
+        def fake_run(argv, **kwargs):
+            raise FileNotFoundError("check-jsonschema not on PATH")
+
+        monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
+
+        ok, msg = check_eval_criteria(feature_dir)
+        assert ok is None
+        assert "check-jsonschema" in msg
+
+    def test_no_installed_schema_warns(self, tmp_path):
+        """A type whose install ships no eval schema (data, today) gets a
+        visible WARN instead of a silently green fake validation."""
+        feature_dir, _ = self._install(tmp_path, with_schema=False)
+
+        ok, msg = check_eval_criteria(feature_dir)
+        assert ok is None
+        assert "no eval_criteria schema installed" in msg
+
 
 # ---------------------------------------------------------------------------
 # check_plan_eval_prediction

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -489,6 +489,142 @@ class TestCheckGherkinNfrCoverage:
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
         assert ok is True  # no populated categories, so coverage not required
 
+    # -- data-shaped NFRs: @nfr-* headings, table-style sections -------------
+
+    def test_data_table_nfrs_missing_tag_fails(self, tmp_path):
+        """A data nfrs.md populates its categories with table rows under
+        `## @nfr-*` headings; a populated category with no matching tag in
+        acceptance.feature must fail."""
+        write(tmp_path / "nfrs.md", """\
+            ## @nfr-freshness
+
+            | Concern | Target |
+            |---|---|
+            | Schedule | Daily 06:00 UTC |
+
+            ## @nfr-pii
+
+            | Column | Treatment |
+            |---|---|
+            | customer_email | Hashed |
+        """)
+        write(tmp_path / "acceptance.feature", """\
+            Feature: Sample
+
+              @nfr-pii
+              Scenario: Masked outside prod
+                Given an analyst in staging
+                Then customer_email is masked
+        """)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is False
+        assert "@nfr-freshness" in msg
+        assert "@nfr-pii" not in msg
+
+    def test_data_table_nfrs_full_coverage_passes(self, tmp_path):
+        write(tmp_path / "nfrs.md", """\
+            ## @nfr-freshness
+
+            | Concern | Target |
+            |---|---|
+            | Schedule | Daily 06:00 UTC |
+
+            ## @nfr-lineage
+
+            | Concern | Target |
+            |---|---|
+            | Source-to-mart capture | Every prod run |
+        """)
+        write(tmp_path / "acceptance.feature", """\
+            Feature: Sample
+
+              @nfr-freshness
+              Scenario: Fresh by 07:00
+                Given the schedule
+                Then staleness <= 1 hour
+
+              @nfr-lineage
+              Scenario: Lineage captured
+                Given a prod run
+                Then lineage shows the upstream
+        """)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is True
+
+    def test_plain_heading_normalizes_to_category(self, tmp_path):
+        """`## Freshness` and `## @nfr-freshness` are the same category."""
+        write(tmp_path / "nfrs.md", """\
+            ## Freshness
+
+            | Concern | Target |
+            |---|---|
+            | Schedule | Hourly |
+        """)
+        write(tmp_path / "acceptance.feature", VALID_FEATURE)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is False
+        assert "@nfr-freshness" in msg
+
+    def test_new_categories_recognized_in_bullet_form(self, tmp_path):
+        """cost/quality (and the other data categories) are known regardless
+        of section style."""
+        write(tmp_path / "nfrs.md", """\
+            ## Cost
+            - Alert at 2x rolling median credit usage
+
+            ## Quality
+            - customer_id unique, severity error
+        """)
+        write(tmp_path / "acceptance.feature", VALID_FEATURE)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is False
+        assert "@nfr-cost" in msg
+        assert "@nfr-quality" in msg
+
+    def test_header_only_table_is_not_populated(self, tmp_path):
+        """A table with header + separator but no data rows is scaffolding,
+        like a lone TBD bullet — it demands no tag."""
+        write(tmp_path / "nfrs.md", """\
+            ## @nfr-freshness
+
+            | Concern | Target |
+            |---|---|
+        """)
+        write(tmp_path / "acceptance.feature", VALID_FEATURE)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is True
+
+    def test_table_rows_all_tbd_are_not_populated(self, tmp_path):
+        write(tmp_path / "nfrs.md", """\
+            ## @nfr-cost
+
+            | Concern | Target |
+            |---|---|
+            | Baseline | TBD |
+        """)
+        write(tmp_path / "acceptance.feature", VALID_FEATURE)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is True
+
+    def test_checkbox_line_populates_section(self, tmp_path):
+        write(tmp_path / "nfrs.md", """\
+            ## @nfr-compliance
+            - [x] GDPR deletion propagates within 24 hours
+        """)
+        write(tmp_path / "acceptance.feature", VALID_FEATURE)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is False
+        assert "@nfr-compliance" in msg
+
+    def test_bundled_data_starter_has_full_coverage(self):
+        """The worked example must satisfy the contract it demonstrates:
+        every category starter_data/nfrs.md populates has a tagged scenario."""
+        from cli import paths
+
+        starter = paths.REPO_ROOT / "features" / "starter_data"
+        ok, msg = check_gherkin_nfr_coverage(starter)
+        assert ok is True, msg
+
     def test_missing_files(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -369,14 +369,27 @@ class TestCheckEvalCriteria:
 
     # -- honest schema validation (instance vs installed schema) -------------
 
-    def _install(self, tmp_path, with_schema=True):
-        """A target with features/feat/eval_criteria.yaml and (optionally) an
-        installed governance schema."""
-        feature_dir = tmp_path / "target" / "features" / "feat"
+    def _install(self, tmp_path, with_schema=True, marker_type=None, extra_areas=()):
+        """A target with features/feat/eval_criteria.yaml, an installed
+        backend governance schema (optional), extra governance areas, and a
+        .govkit marker recording options.type (optional)."""
+        target = tmp_path / "target"
+        feature_dir = target / "features" / "feat"
         write(feature_dir / "eval_criteria.yaml", VALID_EVAL_CRITERIA)
-        schema = tmp_path / "target" / "governance" / "backend" / "schemas" / "eval_criteria.schema.json"
+        schema = target / "governance" / "backend" / "schemas" / "eval_criteria.schema.json"
         if with_schema:
             write(schema, '{"type": "object"}')
+        for area in extra_areas:
+            write(
+                target / "governance" / area / "schemas" / "eval_criteria.schema.json",
+                '{"type": "object"}',
+            )
+        if marker_type:
+            (target / ".govkit").mkdir(parents=True, exist_ok=True)
+            (target / ".govkit" / "marker.json").write_text(json.dumps({
+                "version": "0.14.0", "level": "4", "agent": "claude-code",
+                "options": {"type": marker_type, "ci": "github"},
+            }), encoding="utf-8")
         return feature_dir, schema
 
     def test_validates_instance_against_installed_schema(self, tmp_path, monkeypatch):
@@ -433,6 +446,66 @@ class TestCheckEvalCriteria:
         ok, msg = check_eval_criteria(feature_dir)
         assert ok is None
         assert "no eval_criteria schema installed" in msg
+
+    # -- marker-type-aware schema resolution ---------------------------------
+
+    def _capture_run(self, monkeypatch, returncode=0):
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return type("R", (), {"returncode": returncode, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
+        return calls
+
+    def test_marker_type_selects_matching_schema(self, tmp_path, monkeypatch):
+        """When multiple governance areas ship schemas (stale tree from a
+        previous --type), the marker's options.type decides — not
+        lexicographic order."""
+        feature_dir, _ = self._install(tmp_path, marker_type="ui-react", extra_areas=("ui",))
+        calls = self._capture_run(monkeypatch)
+
+        ok, msg = check_eval_criteria(feature_dir)
+
+        assert ok is True
+        ui_schema = tmp_path / "target" / "governance" / "ui" / "schemas" / "eval_criteria.schema.json"
+        assert str(ui_schema) in calls[0]
+
+    def test_backend_marker_selects_backend_schema(self, tmp_path, monkeypatch):
+        feature_dir, backend_schema = self._install(
+            tmp_path, marker_type="api", extra_areas=("ui",),
+        )
+        calls = self._capture_run(monkeypatch)
+
+        ok, msg = check_eval_criteria(feature_dir)
+
+        assert ok is True
+        assert str(backend_schema) in calls[0]
+
+    def test_data_marker_warns_despite_stale_schema_tree(self, tmp_path, monkeypatch):
+        """A data install has no eval schema today; a stale backend
+        governance tree must not be validated against."""
+        feature_dir, _ = self._install(tmp_path, marker_type="data")
+        calls = self._capture_run(monkeypatch)
+
+        ok, msg = check_eval_criteria(feature_dir)
+
+        assert ok is None
+        assert "no eval_criteria schema installed" in msg
+        assert not calls
+
+    def test_ambiguous_schemas_without_marker_warn(self, tmp_path, monkeypatch):
+        """No marker to choose by + multiple schemas installed: refuse to
+        guess, warn instead."""
+        feature_dir, _ = self._install(tmp_path, extra_areas=("ui",))
+        calls = self._capture_run(monkeypatch)
+
+        ok, msg = check_eval_criteria(feature_dir)
+
+        assert ok is None
+        assert "ambiguous" in msg
+        assert not calls
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Makes `govkit validate` and `govkit init` deliver what they promise for `--type data` installs: data NFR categories are actually cross-checked against Gherkin tags, the installed data starter is no longer misread as a user feature, init defaults follow the recorded project type, and eval-criteria schema validation validates the instance against the real installed schema.

## Why

Phase B of `plans/DATA_ENFORCEMENT_HARDENING_PLAN.md` (increments 2-4). The 2026-07-23 data-teams review found the validation layer was silently vacuous for data repos: the NFR tag check knew no data categories and could not see table-style sections, `starter_data` was missing from the validate skip-list, `init` always suggested the backend starter in data repos, and `check_eval_criteria` ran `--check-metaschema` against the instance file — validating the YAML *as a schema*, which proved nothing for any project type.

## Changes

**NFR coverage (increment 2)**
- `check_gherkin_nfr_coverage` knows the data categories (`freshness`, `quality`, `pii`, `lineage`, `cost`), normalizes `## @nfr-<category>` headings to the same category as plain headings, and counts non-TBD table data rows as populating a section (header+delimiter-only tables are scaffolding)
- The data starter gains the `@nfr-observability` and `@nfr-compliance` scenarios it was missing under its own contract; a guard test pins the bundled starter against the check

**Starter/init hygiene (increment 3)**
- `starter_data` added to `validate.STARTERS`; guard test asserts the skip-list covers every bundled `features/starter_*` dir
- `cmd_init` derives the prompt default from the marker's `options.type` (data→data, cli→cli, ui-*→matching UI, api/unknown→backend); prompt shows the detected default; explicit `--starter` still wins

**Schema validation (increment 4)**
- `check_eval_criteria` resolves `governance/*/schemas/eval_criteria.schema.json` from the install and runs `check-jsonschema --schemafile <schema> <instance>`; non-conforming files FAIL with the validator message; a type with no installed schema (data, until the data schema ships in increment 7) WARNs visibly instead of passing

## Testing

- `pytest` — 1104 passed, 1 skipped (pre-existing); 16 new tests, each increment written failing-first
- Real-binary smoke: bundled backend starter passes genuine instance validation against the backend schema
- `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)