### PR TITLE
feat(govkit): data enforcement hardening, phases C-F (increments 5-11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- Data installs ship an eval-criteria schema
+  (`governance/data/schemas/eval_criteria.schema.json`): integer `version`,
+  `mode: deterministic | none` (no `llm`), and criteria of
+  `id`/`description`/`measurement`/`threshold`/`severity` where thresholds
+  are query predicates — deliberately not the backend evaluator-tool shape.
+  The data starter conforms, all 3 agents install the schema at data L4, and
+  local `govkit validate` on a data repo goes from WARN to real instance
+  validation.
+- The dbt CI gate (`dbt-gate`, github + azure) now statically blocks a PR
+  when a model under `models/marts/` lacks an enforced model contract
+  (`contract: {enforced: true}`) or appears in no `exposures:` entry. On
+  dbt-core < 1.5 the contract check downgrades to a warning with an upgrade
+  pointer. `dbt-project-evaluator` layer-boundary enforcement is documented
+  as an opt-in, and the python-dbt overlay docs (v0.11.0) document model
+  contracts, `deprecation_date`, and model versions as the mart
+  change-control mechanism.
+- Stack overlays can ship agent rules (`rules:` in `overlay.yaml`),
+  replacing the type defaults for the entries they name.
+  `databricks-lakehouse` (v0.11.0) ships medallion-worded bronze/silver/gold
+  layer rules for all three agents — byte-identical bodies, `**/bronze/**`
+  style globs still templated via `layers.*` — while `python-dbt` keeps the
+  dbt rules. `govkit stack apply` now also refreshes the agent rule files
+  and runs the full post-install finalize, so swapped rules are re-templated
+  (previously stack apply never re-templated rules).
+- The architecture-preflight skill gains a `3.7 Data Impact` block —
+  Pipeline / Contract / PII / Lineage Impact sections a data report adds
+  (backend/UI reports skip them) — and spec-planning gains a `Data projects`
+  note covering the data NFR categories and deterministic eval-criteria
+  shape. Both blocks are byte-identical across the three agents and the
+  data starter's worked preflight example mirrors the skill's report
+  sections by construction.
+
 ### Changed
 
 - The planning skills (`adr-author`, `spec-planning`, `architecture-preflight`,
@@ -20,6 +54,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   cite `docs/data/architecture/`; backend and UI installs are unchanged. When
   the marker type is missing or unknown the token is left in place and the
   new doctor check D015 flags it (identical for all three agents).
+- Team-tunable values left the rule bodies. The PII keyword list lives in
+  `.govkit/skill_context.yaml` (`pii.keyword_list`, seeded with the default
+  seven keywords; a team-tuned list survives the regeneration upgrades
+  perform) and is rendered into installed rules at install time; the
+  dbt-gate's PII regex is documented as mirroring the same seed.
+  Materialization and naming defaults moved from the layer rule bodies to a
+  `MODEL_LAYERING.md` citation — the doc is editable, the rules are not.
+- Data features no longer require a `plan.md` `evaluation_prediction` block
+  (ADR-0001, shipped under `docs/data/architecture/ADR/`): the FIRST/Virtue
+  rubrics score application code, and the data starter's copy had drifted
+  into an uncalibrated vocabulary. `govkit validate` skips the prediction
+  check when the marker records `type: data`; backend and UI are unchanged.
+  The data starter's plan drops the forked block.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed
+
+- The planning skills (`adr-author`, `spec-planning`, `architecture-preflight`,
+  `implementation-plan`) now resolve the docs tree from the install instead of
+  hardcoding `docs/backend/`. Skill sources reference
+  `docs/{{docs_area}}/...`, and the token is expanded at install time —
+  mirroring rule-glob templating — from a new `docs_area` fact in
+  `.govkit/skill_context.yaml` derived from the marker's `options.type`
+  (api/cli → backend, ui-* → ui, data → data). A data install's skills now
+  cite `docs/data/architecture/`; backend and UI installs are unchanged. When
+  the marker type is missing or unknown the token is left in place and the
+  new doctor check D015 flags it (identical for all three agents).
+
 ### Fixed
 
 - Edit-protection for governed and shared docs is now content-based. The

--- a/PARITY_TEST.md
+++ b/PARITY_TEST.md
@@ -114,6 +114,29 @@ For high-confidence verification of the loader behavior, open a UI sandbox in ea
 
 ---
 
+## Data-native skill block parity (hardening plan Increments 5–6)
+
+The backend planning skills are the ones a `--type data` install receives, so
+they carry data-awareness in two enforced-identical blocks per agent:
+
+- `## 3.7 Data Impact` in `skills/backend/architecture-preflight/SKILL.md` —
+  the Pipeline / Contract / PII / Lineage Impact sections a data preflight
+  report adds (backend/UI reports skip them). Byte-identical across the 3
+  agents: `tests/test_agent_skills.py::test_data_impact_block_parity_across_agents`.
+- `### Data projects` in `skills/backend/spec-planning/SKILL.md` — data NFR
+  categories + deterministic eval-criteria guidance. Byte-identical across
+  the 3 agents:
+  `tests/test_agent_skills.py::test_spec_planning_data_note_parity_across_agents`.
+
+Doc paths in these skills are tokenized (`docs/{{docs_area}}/...`) and
+expanded at install time from the marker's `options.type`
+(`tests/test_skill_templating.py` pins sources and installs in both
+directions). `features/starter_data/architecture_preflight.md` mirrors the
+skill's report sections by construction
+(`tests/test_agent_skills.py::test_starter_data_preflight_mirrors_skill_sections`).
+
+---
+
 ## v0.7 Language-Agnostic Parity (still in force)
 
 The earlier v0.7 refactor moved language-specific content out of agent rules and into `docs/backend/architecture/`. Rules reference docs; rules don't embed FastAPI / .NET / Java / Go specifics. The default docs ship FastAPI-by-default; switch stacks by copying from `docs/stacks/<stack>/` into `docs/backend/architecture/` (see README "Switching Tech Stacks").

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -314,7 +314,9 @@
           "shared": [
             "features/starter_data/"
           ],
-          "governed": []
+          "governed": [
+            "governance/data/schemas/"
+          ]
         }
       }
     },

--- a/agents/claude-code/rules/data/intermediate.md
+++ b/agents/claude-code/rules/data/intermediate.md
@@ -18,8 +18,8 @@ This is WHERE business logic lives — not in staging, not in marts.
 
 - Reads from staging models OR other intermediate models, via `{{ ref(...) }}`
 - May NOT read from `marts/` (creates cycles + downstream dependencies)
-- Materialization: `ephemeral` (default) or `view`
-- Naming: `int_<business_concept>__<verb>.sql`
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay)
 - Cross-source joins go HERE, not in staging
 
 ## Required documentation

--- a/agents/claude-code/rules/data/marts.md
+++ b/agents/claude-code/rules/data/marts.md
@@ -19,10 +19,9 @@ the column list as a public API.
 
 - Reads from `intermediate/` or other `marts/` only — never staging, never
   raw warehouse, never sources directly
-- Materialization: `table` (small) or `incremental` (large; requires a
-  documented unique key + ADR if new)
-- Naming: `dim_*` (dimension), `fct_*` (fact), or domain-shaped
-  (`customer_360`)
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay); a new `incremental`
+  materialization requires a documented unique key + ADR
 - Primary key: `unique` + `not_null` tests required (per
   `DATA_QUALITY_CONTRACT.md`)
 - Every column described in `_<model>.yml`

--- a/agents/claude-code/rules/data/staging.md
+++ b/agents/claude-code/rules/data/staging.md
@@ -21,13 +21,13 @@ business logic happens.
 - Allowed transformations: renames, type casts, light value cleanup
   (`lower(email)`, `trim(name)`), filtering NULL primary keys
 - Forbidden: joins across sources, aggregations, business-logic conditionals
-- Model name pattern: `stg_<source>__<table>.sql`
-- Materialization: `view` (default)
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay)
 
 ## PII at the staging boundary
 
-Every column matching the team's PII keyword list (`email`, `phone`, `ssn`,
-`dob`, `name`, `address` by default) MUST be:
+Every column matching the team's PII keyword list ({{pii_keywords}} — tunable via
+`pii.keyword_list` in `.govkit/skill_context.yaml`) MUST be:
 1. Tagged with `meta.contains_pii: true` in the `_<model>.yml`
 2. Wrapped in the project's masking macro per
    `docs/data/architecture/PII_HANDLING.md` (stack overlay)

--- a/agents/claude-code/skills/backend/adr-author/SKILL.md
+++ b/agents/claude-code/skills/backend/adr-author/SKILL.md
@@ -7,7 +7,7 @@ description: Author an Architecture Decision Record for a new pattern, exception
 
 You are writing an Architecture Decision Record (ADR). Determine the ADR title from the user's request; if it is not provided, ask before proceeding.
 
-Follow the template at `docs/backend/architecture/ADR/TEMPLATE.md`. Produce a complete ADR using these sections:
+Follow the template at `docs/{{docs_area}}/architecture/ADR/TEMPLATE.md`. Produce a complete ADR using these sections:
 
 ## Title
 
@@ -52,4 +52,4 @@ Required reviewers (team lead, architect, or security lead based on scope) and l
 
 ---
 
-Write the ADR to `docs/backend/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.
+Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.

--- a/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
@@ -84,6 +84,43 @@ This is informational and does not block planning.
 
 ---
 
+## 3.7 Data Impact  (data projects only)
+
+When the project type is data (the marker records `type: data` and the
+architecture contracts live under `docs/data/architecture/`), the standards
+set for Section 2 is the data one — layering (`BOUNDARIES.md`), query
+conventions (`QUERY_CONVENTIONS.md`, stack overlay), data quality tiers
+(`DATA_QUALITY_CONTRACT.md`), PII handling (`PII_HANDLING_CONTRACT.md`),
+lineage (`LINEAGE_CONTRACT.md`), and environments (`ENVIRONMENTS.md`) —
+rather than API conventions and auth/security patterns. Add the four
+sections below to the report. Backend and UI reports skip this section.
+
+### Pipeline Impact
+
+- Schedule or SLA changes: run cadence, freshness targets, alert/block
+  thresholds affected by this feature
+- Backfill: required? Window strategy and idempotency expectations
+- Orchestration dependencies: upstream sources and downstream jobs affected
+
+### Contract Impact
+
+- Mart schema changes: added, renamed, or removed columns — renames and
+  removals are breaking per the mart layer rule's breaking-change table;
+  they require a deprecation notice and consumer coordination
+- Downstream exposures affected (check the exposures file for consumers)
+
+### PII Impact
+
+- New or reclassified PII columns and their categories
+- Masking treatment per `PII_HANDLING_CONTRACT.md`, including non-prod
+  environments
+
+### Lineage Impact
+
+- Source-to-mart lineage changes introduced by this feature
+- Column-level lineage entries required for PII-tagged columns
+- Exposure or lineage-tool entries to add or update
+
 ## 4. ADR Decision
 
 Choose one:

--- a/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
@@ -19,10 +19,10 @@ Before generating any code or detailed plan, produce an Architecture Preflight R
 
 For each of the following, state which architectural rules apply (cite file and section):
 
-- Layering (from `docs/backend/architecture/ARCH_CONTRACT.md`)
-- API conventions (from `docs/backend/architecture/API_CONVENTIONS.md`)
-- Auth/security patterns (from `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`)
-- NFR section contract (from `docs/backend/architecture/NFRS_CONVENTIONS.md`)
+- Layering (from `docs/{{docs_area}}/architecture/ARCH_CONTRACT.md`)
+- API conventions (from `docs/{{docs_area}}/architecture/API_CONVENTIONS.md`)
+- Auth/security patterns (from `docs/{{docs_area}}/architecture/SECURITY_AUTH_PATTERNS.md`)
+- NFR section contract (from `docs/{{docs_area}}/architecture/NFRS_CONVENTIONS.md`)
 - Error model and response shape
 - Logging and observability expectations
 
@@ -47,7 +47,7 @@ For each of the following, state which architectural rules apply (cite file and 
 ## 3. Boundary Analysis
 
 - What modules or services will this code touch?
-- Are any boundary rules at risk of violation? (from `docs/backend/architecture/BOUNDARIES.md`)
+- Are any boundary rules at risk of violation? (from `docs/{{docs_area}}/architecture/BOUNDARIES.md`)
 - Does this require a new interface between services?
 
 ## 3.5 Repository Scope Analysis

--- a/agents/claude-code/skills/backend/implementation-plan/SKILL.md
+++ b/agents/claude-code/skills/backend/implementation-plan/SKILL.md
@@ -15,8 +15,8 @@ Read these artifacts before planning:
 - `features/<feature_name>/acceptance.feature`
 - `features/<feature_name>/eval_criteria.yaml`
 - `features/<feature_name>/architecture_preflight.md`
-- `docs/backend/evaluation/eval_criteria.md`
-- `docs/backend/architecture/` (all files)
+- `docs/{{docs_area}}/evaluation/eval_criteria.md`
+- `docs/{{docs_area}}/architecture/` (all files)
 
 ## Planning Requirements
 
@@ -24,7 +24,7 @@ The plan must:
 
 - Follow **this project's architecture** — read `.govkit/skill_context.yaml`
   for `architecture.style` and the layer-to-folder mapping under
-  `architecture.layers`. Cite `docs/backend/architecture/BOUNDARIES.md` for
+  `architecture.layers`. Cite `docs/{{docs_area}}/architecture/BOUNDARIES.md` for
   the canonical layer contract.
 - Enforce FIRST principles for unit tests
 - Enforce 7 Code Virtues for implementation
@@ -42,7 +42,7 @@ The plan must:
 Map the work to the layers in `.govkit/skill_context.yaml` under
 `architecture.layers` (inbound / outbound / domain). Cite the actual
 folder names this project uses (per `skill_context.architecture.layers.*`
-and `docs/backend/architecture/BOUNDARIES.md`). Explicitly confirm no
+and `docs/{{docs_area}}/architecture/BOUNDARIES.md`). Explicitly confirm no
 boundary violations.
 
 ### Task Breakdown (Ordered Checklist)

--- a/agents/claude-code/skills/backend/spec-planning/SKILL.md
+++ b/agents/claude-code/skills/backend/spec-planning/SKILL.md
@@ -65,3 +65,17 @@ Write or update `features/<feature_name>/eval_criteria.yaml` conforming to `docs
 - Fail-on-regression behavior
 
 Output A first, then Output B. No implementation code in this step.
+
+### Data projects
+
+For data projects (marker `type: data`), adjust the spec outputs:
+
+- NFR categories are `freshness`, `quality`, `pii`, `lineage`, `cost`
+  (plus `reliability`, `observability`, `compliance` where relevant).
+  Tag scenarios `@nfr-<category>` — the eval gate cross-checks every
+  populated category against the tags.
+- `eval_criteria.yaml` uses the data schema: `mode: deterministic` (or
+  `none`), and each criterion's `measurement` names a query or CI check
+  with `threshold` as a predicate string. No LLM evaluator tools.
+- Cite the data quality, freshness, and lineage contracts under
+  `docs/data/architecture/` instead of API conventions and auth patterns.

--- a/agents/claude-code/skills/backend/spec-planning/SKILL.md
+++ b/agents/claude-code/skills/backend/spec-planning/SKILL.md
@@ -14,10 +14,10 @@ Feature specs:
 - Acceptance: `features/<feature_name>/acceptance.feature`
 
 Architecture standards:
-- `docs/backend/architecture/` (all files)
+- `docs/{{docs_area}}/architecture/` (all files)
 
 Evaluation standards:
-- `docs/backend/evaluation/eval_criteria.md`
+- `docs/{{docs_area}}/evaluation/eval_criteria.md`
 
 Existing artifacts (read if present, update if needed):
 - `features/<feature_name>/eval_criteria.yaml`
@@ -34,7 +34,7 @@ Existing artifacts (read if present, update if needed):
 3. Identify required design elements per **this project's architecture**:
    - Read `.govkit/skill_context.yaml` for the architecture style and the
      folder hints under `architecture.layers` (inbound / outbound / domain).
-   - Read `docs/backend/architecture/BOUNDARIES.md` for the canonical layer
+   - Read `docs/{{docs_area}}/architecture/BOUNDARIES.md` for the canonical layer
      contract and `LAYER_IMPLEMENTATION.md` for the layer-by-layer guidance.
    - List the inbound entry points, domain logic modules, outbound
      dependencies, and any infrastructure adapters the feature needs —
@@ -57,7 +57,7 @@ Write `features/<feature_name>/plan.md` with:
 
 ## Output B: Feature Eval Criteria
 
-Write or update `features/<feature_name>/eval_criteria.yaml` conforming to `docs/backend/evaluation/eval_criteria.md`. Include at minimum:
+Write or update `features/<feature_name>/eval_criteria.yaml` conforming to `docs/{{docs_area}}/evaluation/eval_criteria.md`. Include at minimum:
 - FIRST enforcement settings
 - 7 Virtues enforcement settings
 - Any LLM-specific dimensions required by this feature

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -52,7 +52,9 @@
           "shared": [
             "features/starter_data/"
           ],
-          "governed": []
+          "governed": [
+            "governance/data/schemas/"
+          ]
         }
       },
       "api": {

--- a/agents/codex/rules/data/intermediate.md
+++ b/agents/codex/rules/data/intermediate.md
@@ -11,8 +11,8 @@ This is WHERE business logic lives — not in staging, not in marts.
 
 - Reads from staging models OR other intermediate models, via `{{ ref(...) }}`
 - May NOT read from `marts/` (creates cycles + downstream dependencies)
-- Materialization: `ephemeral` (default) or `view`
-- Naming: `int_<business_concept>__<verb>.sql`
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay)
 - Cross-source joins go HERE, not in staging
 
 ## Required documentation

--- a/agents/codex/rules/data/marts.md
+++ b/agents/codex/rules/data/marts.md
@@ -12,10 +12,9 @@ the column list as a public API.
 
 - Reads from `intermediate/` or other `marts/` only — never staging, never
   raw warehouse, never sources directly
-- Materialization: `table` (small) or `incremental` (large; requires a
-  documented unique key + ADR if new)
-- Naming: `dim_*` (dimension), `fct_*` (fact), or domain-shaped
-  (`customer_360`)
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay); a new `incremental`
+  materialization requires a documented unique key + ADR
 - Primary key: `unique` + `not_null` tests required (per
   `DATA_QUALITY_CONTRACT.md`)
 - Every column described in `_<model>.yml`

--- a/agents/codex/rules/data/staging.md
+++ b/agents/codex/rules/data/staging.md
@@ -14,13 +14,13 @@ business logic happens.
 - Allowed transformations: renames, type casts, light value cleanup
   (`lower(email)`, `trim(name)`), filtering NULL primary keys
 - Forbidden: joins across sources, aggregations, business-logic conditionals
-- Model name pattern: `stg_<source>__<table>.sql`
-- Materialization: `view` (default)
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay)
 
 ## PII at the staging boundary
 
-Every column matching the team's PII keyword list (`email`, `phone`, `ssn`,
-`dob`, `name`, `address` by default) MUST be:
+Every column matching the team's PII keyword list ({{pii_keywords}} — tunable via
+`pii.keyword_list` in `.govkit/skill_context.yaml`) MUST be:
 1. Tagged with `meta.contains_pii: true` in the `_<model>.yml`
 2. Wrapped in the project's masking macro per
    `docs/data/architecture/PII_HANDLING.md` (stack overlay)

--- a/agents/codex/skills/backend/adr-author/SKILL.md
+++ b/agents/codex/skills/backend/adr-author/SKILL.md
@@ -7,7 +7,7 @@ description: Author an Architecture Decision Record for a new pattern, exception
 
 You are writing an Architecture Decision Record (ADR). Determine the ADR title from the user's request; if it is not provided, ask before proceeding.
 
-Follow the template at `docs/backend/architecture/ADR/TEMPLATE.md`. Produce a complete ADR using these sections:
+Follow the template at `docs/{{docs_area}}/architecture/ADR/TEMPLATE.md`. Produce a complete ADR using these sections:
 
 ## Title
 
@@ -52,4 +52,4 @@ Required reviewers (team lead, architect, or security lead based on scope) and l
 
 ---
 
-Write the ADR to `docs/backend/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.
+Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.

--- a/agents/codex/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/codex/skills/backend/architecture-preflight/SKILL.md
@@ -84,6 +84,43 @@ This is informational and does not block planning.
 
 ---
 
+## 3.7 Data Impact  (data projects only)
+
+When the project type is data (the marker records `type: data` and the
+architecture contracts live under `docs/data/architecture/`), the standards
+set for Section 2 is the data one — layering (`BOUNDARIES.md`), query
+conventions (`QUERY_CONVENTIONS.md`, stack overlay), data quality tiers
+(`DATA_QUALITY_CONTRACT.md`), PII handling (`PII_HANDLING_CONTRACT.md`),
+lineage (`LINEAGE_CONTRACT.md`), and environments (`ENVIRONMENTS.md`) —
+rather than API conventions and auth/security patterns. Add the four
+sections below to the report. Backend and UI reports skip this section.
+
+### Pipeline Impact
+
+- Schedule or SLA changes: run cadence, freshness targets, alert/block
+  thresholds affected by this feature
+- Backfill: required? Window strategy and idempotency expectations
+- Orchestration dependencies: upstream sources and downstream jobs affected
+
+### Contract Impact
+
+- Mart schema changes: added, renamed, or removed columns — renames and
+  removals are breaking per the mart layer rule's breaking-change table;
+  they require a deprecation notice and consumer coordination
+- Downstream exposures affected (check the exposures file for consumers)
+
+### PII Impact
+
+- New or reclassified PII columns and their categories
+- Masking treatment per `PII_HANDLING_CONTRACT.md`, including non-prod
+  environments
+
+### Lineage Impact
+
+- Source-to-mart lineage changes introduced by this feature
+- Column-level lineage entries required for PII-tagged columns
+- Exposure or lineage-tool entries to add or update
+
 ## 4. ADR Decision
 
 Choose one:

--- a/agents/codex/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/codex/skills/backend/architecture-preflight/SKILL.md
@@ -19,10 +19,10 @@ Before generating any code or detailed plan, produce an Architecture Preflight R
 
 For each of the following, state which architectural rules apply (cite file and section):
 
-- Layering (from `docs/backend/architecture/ARCH_CONTRACT.md`)
-- API conventions (from `docs/backend/architecture/API_CONVENTIONS.md`)
-- Auth/security patterns (from `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`)
-- NFR section contract (from `docs/backend/architecture/NFRS_CONVENTIONS.md`)
+- Layering (from `docs/{{docs_area}}/architecture/ARCH_CONTRACT.md`)
+- API conventions (from `docs/{{docs_area}}/architecture/API_CONVENTIONS.md`)
+- Auth/security patterns (from `docs/{{docs_area}}/architecture/SECURITY_AUTH_PATTERNS.md`)
+- NFR section contract (from `docs/{{docs_area}}/architecture/NFRS_CONVENTIONS.md`)
 - Error model and response shape
 - Logging and observability expectations
 
@@ -47,7 +47,7 @@ For each of the following, state which architectural rules apply (cite file and 
 ## 3. Boundary Analysis
 
 - What modules or services will this code touch?
-- Are any boundary rules at risk of violation? (from `docs/backend/architecture/BOUNDARIES.md`)
+- Are any boundary rules at risk of violation? (from `docs/{{docs_area}}/architecture/BOUNDARIES.md`)
 - Does this require a new interface between services?
 
 ## 3.5 Repository Scope Analysis

--- a/agents/codex/skills/backend/implementation-plan/SKILL.md
+++ b/agents/codex/skills/backend/implementation-plan/SKILL.md
@@ -15,8 +15,8 @@ Read these artifacts before planning:
 - `features/<feature_name>/acceptance.feature`
 - `features/<feature_name>/eval_criteria.yaml`
 - `features/<feature_name>/architecture_preflight.md`
-- `docs/backend/evaluation/eval_criteria.md`
-- `docs/backend/architecture/` (all files)
+- `docs/{{docs_area}}/evaluation/eval_criteria.md`
+- `docs/{{docs_area}}/architecture/` (all files)
 
 ## Planning Requirements
 

--- a/agents/codex/skills/backend/spec-planning/SKILL.md
+++ b/agents/codex/skills/backend/spec-planning/SKILL.md
@@ -14,10 +14,10 @@ Feature specs:
 - Acceptance: `features/<feature_name>/acceptance.feature`
 
 Architecture standards:
-- `docs/backend/architecture/` (all files)
+- `docs/{{docs_area}}/architecture/` (all files)
 
 Evaluation standards:
-- `docs/backend/evaluation/eval_criteria.md`
+- `docs/{{docs_area}}/evaluation/eval_criteria.md`
 
 Existing artifacts (read if present, update if needed):
 - `features/<feature_name>/eval_criteria.yaml`
@@ -55,7 +55,7 @@ Write `features/<feature_name>/plan.md` with:
 
 ## Output B: Feature Eval Criteria
 
-Write or update `features/<feature_name>/eval_criteria.yaml` conforming to `docs/backend/evaluation/eval_criteria.md`. Include at minimum:
+Write or update `features/<feature_name>/eval_criteria.yaml` conforming to `docs/{{docs_area}}/evaluation/eval_criteria.md`. Include at minimum:
 - FIRST enforcement settings
 - 7 Virtues enforcement settings
 - Any LLM-specific dimensions required by this feature

--- a/agents/codex/skills/backend/spec-planning/SKILL.md
+++ b/agents/codex/skills/backend/spec-planning/SKILL.md
@@ -63,3 +63,17 @@ Write or update `features/<feature_name>/eval_criteria.yaml` conforming to `docs
 - Fail-on-regression behavior
 
 Output A first, then Output B. No implementation code in this step.
+
+### Data projects
+
+For data projects (marker `type: data`), adjust the spec outputs:
+
+- NFR categories are `freshness`, `quality`, `pii`, `lineage`, `cost`
+  (plus `reliability`, `observability`, `compliance` where relevant).
+  Tag scenarios `@nfr-<category>` — the eval gate cross-checks every
+  populated category against the tags.
+- `eval_criteria.yaml` uses the data schema: `mode: deterministic` (or
+  `none`), and each criterion's `measurement` names a query or CI check
+  with `threshold` as a predicate string. No LLM evaluator tools.
+- Cite the data quality, freshness, and lineage contracts under
+  `docs/data/architecture/` instead of API conventions and auth patterns.

--- a/agents/copilot/instructions/data/intermediate.instructions.md
+++ b/agents/copilot/instructions/data/intermediate.instructions.md
@@ -16,8 +16,8 @@ This is WHERE business logic lives — not in staging, not in marts.
 
 - Reads from staging models OR other intermediate models, via `{{ ref(...) }}`
 - May NOT read from `marts/` (creates cycles + downstream dependencies)
-- Materialization: `ephemeral` (default) or `view`
-- Naming: `int_<business_concept>__<verb>.sql`
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay)
 - Cross-source joins go HERE, not in staging
 
 ## Required documentation

--- a/agents/copilot/instructions/data/marts.instructions.md
+++ b/agents/copilot/instructions/data/marts.instructions.md
@@ -17,10 +17,9 @@ the column list as a public API.
 
 - Reads from `intermediate/` or other `marts/` only — never staging, never
   raw warehouse, never sources directly
-- Materialization: `table` (small) or `incremental` (large; requires a
-  documented unique key + ADR if new)
-- Naming: `dim_*` (dimension), `fct_*` (fact), or domain-shaped
-  (`customer_360`)
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay); a new `incremental`
+  materialization requires a documented unique key + ADR
 - Primary key: `unique` + `not_null` tests required (per
   `DATA_QUALITY_CONTRACT.md`)
 - Every column described in `_<model>.yml`

--- a/agents/copilot/instructions/data/staging.instructions.md
+++ b/agents/copilot/instructions/data/staging.instructions.md
@@ -19,13 +19,13 @@ business logic happens.
 - Allowed transformations: renames, type casts, light value cleanup
   (`lower(email)`, `trim(name)`), filtering NULL primary keys
 - Forbidden: joins across sources, aggregations, business-logic conditionals
-- Model name pattern: `stg_<source>__<table>.sql`
-- Materialization: `view` (default)
+- Naming and materialization follow
+  `docs/data/architecture/MODEL_LAYERING.md` (stack overlay)
 
 ## PII at the staging boundary
 
-Every column matching the team's PII keyword list (`email`, `phone`, `ssn`,
-`dob`, `name`, `address` by default) MUST be:
+Every column matching the team's PII keyword list ({{pii_keywords}} — tunable via
+`pii.keyword_list` in `.govkit/skill_context.yaml`) MUST be:
 1. Tagged with `meta.contains_pii: true` in the `_<model>.yml`
 2. Wrapped in the project's masking macro per
    `docs/data/architecture/PII_HANDLING.md` (stack overlay)

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -52,7 +52,9 @@
           "shared": [
             "features/starter_data/"
           ],
-          "governed": []
+          "governed": [
+            "governance/data/schemas/"
+          ]
         }
       },
       "api": {

--- a/agents/copilot/skills/backend/adr-author/SKILL.md
+++ b/agents/copilot/skills/backend/adr-author/SKILL.md
@@ -7,7 +7,7 @@ description: Author an Architecture Decision Record for a new pattern, exception
 
 You are writing an Architecture Decision Record (ADR). Determine the ADR title from the user's request; if it is not provided, ask before proceeding.
 
-Follow the template at `docs/backend/architecture/ADR/TEMPLATE.md`. Produce a complete ADR using these sections:
+Follow the template at `docs/{{docs_area}}/architecture/ADR/TEMPLATE.md`. Produce a complete ADR using these sections:
 
 ## Title
 
@@ -52,4 +52,4 @@ Required reviewers (team lead, architect, or security lead based on scope) and l
 
 ---
 
-Write the ADR to `docs/backend/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.
+Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.

--- a/agents/copilot/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/copilot/skills/backend/architecture-preflight/SKILL.md
@@ -84,6 +84,43 @@ This is informational and does not block planning.
 
 ---
 
+## 3.7 Data Impact  (data projects only)
+
+When the project type is data (the marker records `type: data` and the
+architecture contracts live under `docs/data/architecture/`), the standards
+set for Section 2 is the data one — layering (`BOUNDARIES.md`), query
+conventions (`QUERY_CONVENTIONS.md`, stack overlay), data quality tiers
+(`DATA_QUALITY_CONTRACT.md`), PII handling (`PII_HANDLING_CONTRACT.md`),
+lineage (`LINEAGE_CONTRACT.md`), and environments (`ENVIRONMENTS.md`) —
+rather than API conventions and auth/security patterns. Add the four
+sections below to the report. Backend and UI reports skip this section.
+
+### Pipeline Impact
+
+- Schedule or SLA changes: run cadence, freshness targets, alert/block
+  thresholds affected by this feature
+- Backfill: required? Window strategy and idempotency expectations
+- Orchestration dependencies: upstream sources and downstream jobs affected
+
+### Contract Impact
+
+- Mart schema changes: added, renamed, or removed columns — renames and
+  removals are breaking per the mart layer rule's breaking-change table;
+  they require a deprecation notice and consumer coordination
+- Downstream exposures affected (check the exposures file for consumers)
+
+### PII Impact
+
+- New or reclassified PII columns and their categories
+- Masking treatment per `PII_HANDLING_CONTRACT.md`, including non-prod
+  environments
+
+### Lineage Impact
+
+- Source-to-mart lineage changes introduced by this feature
+- Column-level lineage entries required for PII-tagged columns
+- Exposure or lineage-tool entries to add or update
+
 ## 4. ADR Decision
 
 Choose one:

--- a/agents/copilot/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/copilot/skills/backend/architecture-preflight/SKILL.md
@@ -19,10 +19,10 @@ Before generating any code or detailed plan, produce an Architecture Preflight R
 
 For each of the following, state which architectural rules apply (cite file and section):
 
-- Layering (from `docs/backend/architecture/ARCH_CONTRACT.md`)
-- API conventions (from `docs/backend/architecture/API_CONVENTIONS.md`)
-- Auth/security patterns (from `docs/backend/architecture/SECURITY_AUTH_PATTERNS.md`)
-- NFR section contract (from `docs/backend/architecture/NFRS_CONVENTIONS.md`)
+- Layering (from `docs/{{docs_area}}/architecture/ARCH_CONTRACT.md`)
+- API conventions (from `docs/{{docs_area}}/architecture/API_CONVENTIONS.md`)
+- Auth/security patterns (from `docs/{{docs_area}}/architecture/SECURITY_AUTH_PATTERNS.md`)
+- NFR section contract (from `docs/{{docs_area}}/architecture/NFRS_CONVENTIONS.md`)
 - Error model and response shape
 - Logging and observability expectations
 
@@ -47,7 +47,7 @@ For each of the following, state which architectural rules apply (cite file and 
 ## 3. Boundary Analysis
 
 - What modules or services will this code touch?
-- Are any boundary rules at risk of violation? (from `docs/backend/architecture/BOUNDARIES.md`)
+- Are any boundary rules at risk of violation? (from `docs/{{docs_area}}/architecture/BOUNDARIES.md`)
 - Does this require a new interface between services?
 
 ## 3.5 Repository Scope Analysis

--- a/agents/copilot/skills/backend/implementation-plan/SKILL.md
+++ b/agents/copilot/skills/backend/implementation-plan/SKILL.md
@@ -15,8 +15,8 @@ Read these artifacts before planning:
 - `features/<feature_name>/acceptance.feature`
 - `features/<feature_name>/eval_criteria.yaml`
 - `features/<feature_name>/architecture_preflight.md`
-- `docs/backend/evaluation/eval_criteria.md`
-- `docs/backend/architecture/` (all files)
+- `docs/{{docs_area}}/evaluation/eval_criteria.md`
+- `docs/{{docs_area}}/architecture/` (all files)
 
 ## Planning Requirements
 

--- a/agents/copilot/skills/backend/spec-planning/SKILL.md
+++ b/agents/copilot/skills/backend/spec-planning/SKILL.md
@@ -12,10 +12,10 @@ Feature specs:
 - Acceptance: `features/<feature_name>/acceptance.feature`
 
 Architecture standards:
-- `docs/backend/architecture/**`
+- `docs/{{docs_area}}/architecture/**`
 
 Evaluation standards:
-- Global evaluation contract: `docs/backend/evaluation/eval_criteria.md`
+- Global evaluation contract: `docs/{{docs_area}}/evaluation/eval_criteria.md`
 
 Existing artifacts (read if present, update if needed):
 - Feature eval config: `features/<feature_name>/eval_criteria.yaml`
@@ -56,7 +56,7 @@ Create `features/<feature_name>/plan.md` content with:
 
 ### Output B: Feature Eval Criteria (YAML)
 Create or update `features/<feature_name>/eval_criteria.yaml` to conform to:
-- `docs/backend/evaluation/eval_criteria.md` schema and thresholds
+- `docs/{{docs_area}}/evaluation/eval_criteria.md` schema and thresholds
 Include, at minimum:
 - FIRST enforcement settings
 - 7 virtues enforcement settings
@@ -68,8 +68,8 @@ Include, at minimum:
 
 plan.md must include an Evaluation Compliance Summary with predicted FIRST and Virtue scores. Use the scoring rubrics for reference:
 
-- FIRST rubric: `docs/backend/evaluation/FIRST_SCORING_RUBRIC.md`
-- Virtue rubric: `docs/backend/evaluation/VIRTUE_SCORING_RUBRIC.md`
+- FIRST rubric: `docs/{{docs_area}}/evaluation/FIRST_SCORING_RUBRIC.md`
+- Virtue rubric: `docs/{{docs_area}}/evaluation/VIRTUE_SCORING_RUBRIC.md`
 
 Do not proceed if predicted FIRST average or Virtue average is below 4.0.
 

--- a/agents/copilot/skills/backend/spec-planning/SKILL.md
+++ b/agents/copilot/skills/backend/spec-planning/SKILL.md
@@ -80,3 +80,17 @@ Do not proceed if predicted FIRST average or Virtue average is below 4.0.
 - No implementation code in this step.
 
 This output will feed `/govkit-implementation-plan`.
+
+### Data projects
+
+For data projects (marker `type: data`), adjust the spec outputs:
+
+- NFR categories are `freshness`, `quality`, `pii`, `lineage`, `cost`
+  (plus `reliability`, `observability`, `compliance` where relevant).
+  Tag scenarios `@nfr-<category>` — the eval gate cross-checks every
+  populated category against the tags.
+- `eval_criteria.yaml` uses the data schema: `mode: deterministic` (or
+  `none`), and each criterion's `measurement` names a query or CI check
+  with `threshold` as a predicate string. No LLM evaluator tools.
+- Cite the data quality, freshness, and lineage contracts under
+  `docs/data/architecture/` instead of API conventions and auth patterns.

--- a/ci/azure/dbt-gate.yml
+++ b/ci/azure/dbt-gate.yml
@@ -11,6 +11,8 @@
 # - dbt compile
 # - SQLFluff lint when SQLFluff is configured
 # - static model YAML checks for descriptions, primary-key tests, and PII meta
+# - mart model contract enforcement (contract: {enforced: true}) and
+#   exposure coverage for every model under models/marts/
 #
 # Opt-in only:
 # - dbt test --select state:modified+
@@ -177,6 +179,83 @@ stages:
                                 f"{path}: model {model_name} needs one primary key column with unique and not_null tests"
                             )
 
+                # Mart contract + exposure enforcement (MODEL_LAYERING.md): marts are the
+                # public API. Every mart model must declare an enforced dbt model contract
+                # and appear in at least one exposure - no exposure means dead code or an
+                # undocumented consumer. Contract enforcement needs dbt-core >= 1.5; older
+                # projects get a warning with an upgrade pointer, not a failure.
+                marts_sql = sorted(pathlib.Path("models/marts").rglob("*.sql"))
+                if marts_sql:
+                    mart_names = sorted({p.stem for p in marts_sql})
+
+                    try:
+                        project = yaml.safe_load(
+                            pathlib.Path("dbt_project.yml").read_text(encoding="utf-8")
+                        ) or {}
+                    except (OSError, yaml.YAMLError):
+                        project = {}
+
+                    yaml_docs = []
+                    for path in model_files:
+                        try:
+                            yaml_docs.append((path, yaml.safe_load(path.read_text(encoding="utf-8")) or {}))
+                        except yaml.YAMLError:
+                            continue
+
+                    def _supports_contracts() -> bool:
+                        for _, data in yaml_docs:
+                            for model in data.get("models") or []:
+                                if "contract" in (model.get("config") or {}) or "contract" in model:
+                                    return True
+                        req = project.get("require-dbt-version")
+                        for entry in req if isinstance(req, list) else [req] if req else []:
+                            match = re.search(r"(\d+)\.(\d+)", str(entry))
+                            if match and (int(match.group(1)), int(match.group(2))) >= (1, 5):
+                                return True
+                        return False
+
+                    mart_entries = {}
+                    for path, data in yaml_docs:
+                        if "marts" not in path.parts:
+                            continue
+                        for model in data.get("models") or []:
+                            mart_entries[str(model.get("name"))] = (path, model)
+
+                    if _supports_contracts():
+                        for name in mart_names:
+                            entry = mart_entries.get(name)
+                            if entry is None:
+                                errors.append(
+                                    f"models/marts: mart {name} has no model YAML entry - "
+                                    "declare it with contract: {enforced: true}"
+                                )
+                                continue
+                            entry_path, model = entry
+                            contract = (model.get("config") or {}).get("contract") or model.get("contract") or {}
+                            if not (isinstance(contract, dict) and contract.get("enforced") is True):
+                                errors.append(
+                                    f"{entry_path}: mart {name} must declare contract: "
+                                    "{enforced: true} - marts are the public API"
+                                )
+                    else:
+                        print(
+                            "WARN: mart model contracts not checked - dbt-core >= 1.5 required. "
+                            "Pin require-dbt-version: '>=1.5' in dbt_project.yml (and upgrade "
+                            "dbt-core) to enforce mart column contracts."
+                        )
+
+                    exposure_refs = set()
+                    for _, data in yaml_docs:
+                        for exposure in data.get("exposures") or []:
+                            for dep in exposure.get("depends_on") or []:
+                                exposure_refs.add(str(dep))
+                    for name in mart_names:
+                        if not any(name in ref for ref in exposure_refs):
+                            errors.append(
+                                f"models/marts: mart {name} appears in no exposures: entry - "
+                                "no exposure means dead code or an undocumented consumer"
+                            )
+
                 if errors:
                     print("dbt static model checks failed:")
                     for error in errors:
@@ -196,6 +275,8 @@ stages:
                 - dbt test --select state:modified+
                 - dbt source freshness
                 - warehouse-backed model build and warehouse-backed data-quality checks
+                - dbt-project-evaluator for layer-boundary enforcement
+                  (machine-checks BOUNDARIES.md section 1's allowed-reads table)
 
                 Enable these only after CI has a safe profile, secrets, target schema,
                 cost controls, and warehouse isolation.

--- a/ci/azure/dbt-gate.yml
+++ b/ci/azure/dbt-gate.yml
@@ -130,6 +130,9 @@ stages:
                     print("FAIL: no model YAML files found under models/.")
                     sys.exit(1)
 
+                # Single source: this keyword list mirrors the default seed of
+                # pii.keyword_list in .govkit/skill_context.yaml. Teams tuning the
+                # list edit skill_context and update this regex to match.
                 pii_name = re.compile(r"(email|phone|ssn|dob|birth|address|name)", re.I)
                 errors: list[str] = []
 

--- a/ci/github/dbt-gate.yml
+++ b/ci/github/dbt-gate.yml
@@ -118,6 +118,9 @@ jobs:
               print("FAIL: no model YAML files found under models/.")
               sys.exit(1)
 
+          # Single source: this keyword list mirrors the default seed of
+          # pii.keyword_list in .govkit/skill_context.yaml. Teams tuning the
+          # list edit skill_context and update this regex to match.
           pii_name = re.compile(r"(email|phone|ssn|dob|birth|address|name)", re.I)
           errors: list[str] = []
 

--- a/ci/github/dbt-gate.yml
+++ b/ci/github/dbt-gate.yml
@@ -10,6 +10,8 @@
 # - dbt compile
 # - SQLFluff lint when SQLFluff is configured
 # - static model YAML checks for descriptions, primary-key tests, and PII meta
+# - mart model contract enforcement (contract: {enforced: true}) and
+#   exposure coverage for every model under models/marts/
 #
 # Opt-in only:
 # - dbt test --select state:modified+
@@ -165,6 +167,83 @@ jobs:
                           f"{path}: model {model_name} needs one primary key column with unique and not_null tests"
                       )
 
+          # Mart contract + exposure enforcement (MODEL_LAYERING.md): marts are the
+          # public API. Every mart model must declare an enforced dbt model contract
+          # and appear in at least one exposure - no exposure means dead code or an
+          # undocumented consumer. Contract enforcement needs dbt-core >= 1.5; older
+          # projects get a warning with an upgrade pointer, not a failure.
+          marts_sql = sorted(pathlib.Path("models/marts").rglob("*.sql"))
+          if marts_sql:
+              mart_names = sorted({p.stem for p in marts_sql})
+
+              try:
+                  project = yaml.safe_load(
+                      pathlib.Path("dbt_project.yml").read_text(encoding="utf-8")
+                  ) or {}
+              except (OSError, yaml.YAMLError):
+                  project = {}
+
+              yaml_docs = []
+              for path in model_files:
+                  try:
+                      yaml_docs.append((path, yaml.safe_load(path.read_text(encoding="utf-8")) or {}))
+                  except yaml.YAMLError:
+                      continue
+
+              def _supports_contracts() -> bool:
+                  for _, data in yaml_docs:
+                      for model in data.get("models") or []:
+                          if "contract" in (model.get("config") or {}) or "contract" in model:
+                              return True
+                  req = project.get("require-dbt-version")
+                  for entry in req if isinstance(req, list) else [req] if req else []:
+                      match = re.search(r"(\d+)\.(\d+)", str(entry))
+                      if match and (int(match.group(1)), int(match.group(2))) >= (1, 5):
+                          return True
+                  return False
+
+              mart_entries = {}
+              for path, data in yaml_docs:
+                  if "marts" not in path.parts:
+                      continue
+                  for model in data.get("models") or []:
+                      mart_entries[str(model.get("name"))] = (path, model)
+
+              if _supports_contracts():
+                  for name in mart_names:
+                      entry = mart_entries.get(name)
+                      if entry is None:
+                          errors.append(
+                              f"models/marts: mart {name} has no model YAML entry - "
+                              "declare it with contract: {enforced: true}"
+                          )
+                          continue
+                      entry_path, model = entry
+                      contract = (model.get("config") or {}).get("contract") or model.get("contract") or {}
+                      if not (isinstance(contract, dict) and contract.get("enforced") is True):
+                          errors.append(
+                              f"{entry_path}: mart {name} must declare contract: "
+                              "{enforced: true} - marts are the public API"
+                          )
+              else:
+                  print(
+                      "WARN: mart model contracts not checked - dbt-core >= 1.5 required. "
+                      "Pin require-dbt-version: '>=1.5' in dbt_project.yml (and upgrade "
+                      "dbt-core) to enforce mart column contracts."
+                  )
+
+              exposure_refs = set()
+              for _, data in yaml_docs:
+                  for exposure in data.get("exposures") or []:
+                      for dep in exposure.get("depends_on") or []:
+                          exposure_refs.add(str(dep))
+              for name in mart_names:
+                  if not any(name in ref for ref in exposure_refs):
+                      errors.append(
+                          f"models/marts: mart {name} appears in no exposures: entry - "
+                          "no exposure means dead code or an undocumented consumer"
+                      )
+
           if errors:
               print("dbt static model checks failed:")
               for error in errors:
@@ -181,6 +260,8 @@ jobs:
           - dbt test --select state:modified+
           - dbt source freshness
           - warehouse-backed model build and warehouse-backed data-quality checks
+          - dbt-project-evaluator for layer-boundary enforcement
+            (machine-checks BOUNDARIES.md section 1's allowed-reads table)
 
           Enable these only after CI has a safe profile, secrets, target schema,
           cost controls, and warehouse isolation.

--- a/cli/agent_layout.py
+++ b/cli/agent_layout.py
@@ -34,6 +34,7 @@ class AgentLayout:
     rules_glob: str | None
     frontmatter_glob_key: str | None
     glob_value_shape: Literal["list", "comma-string"] | None
+    skills_dir: str | None = None
 
 
 AGENT_LAYOUTS: dict[str, AgentLayout] = {
@@ -43,6 +44,7 @@ AGENT_LAYOUTS: dict[str, AgentLayout] = {
         rules_glob=".claude/rules/*.md",
         frontmatter_glob_key="paths",
         glob_value_shape="list",
+        skills_dir=".claude/skills",
     ),
     "copilot": AgentLayout(
         instruction_file=".github/copilot-instructions.md",
@@ -50,6 +52,7 @@ AGENT_LAYOUTS: dict[str, AgentLayout] = {
         rules_glob=".github/instructions/*.instructions.md",
         frontmatter_glob_key="applyTo",
         glob_value_shape="comma-string",
+        skills_dir=".github/skills",
     ),
     "codex": AgentLayout(
         instruction_file="AGENTS.md",
@@ -57,5 +60,6 @@ AGENT_LAYOUTS: dict[str, AgentLayout] = {
         rules_glob=None,
         frontmatter_glob_key=None,
         glob_value_shape=None,
+        skills_dir=".agents/skills",
     ),
 }

--- a/cli/cmd_apply.py
+++ b/cli/cmd_apply.py
@@ -21,6 +21,7 @@ from .install_common import (
 )
 from .manifest import load_manifest, resolve_options, resolve_variant_files
 from .marker import read_govkit_marker, write_govkit_marker
+from .overlay import apply_rule_overrides, load_overlay
 from .stack_select import apply_stack_overlay, print_detection_summary, resolve_stack_choice
 
 if TYPE_CHECKING:
@@ -108,6 +109,11 @@ def _apply_variant_install(
 
     print(f"\n  Configuration: {options}\n")
     files, shared, governed = resolve_variant_files(manifest, options)
+
+    # Stack rule overrides: when the active overlay ships rules, they
+    # replace the type defaults for the overlapping entries before install.
+    stack_overlay = load_overlay((stack_meta or {}).get("id", "")) if stack_meta else None
+    files = apply_rule_overrides(files, stack_overlay, args.agent)
 
     print("Agent files:")
     for entry in files:

--- a/cli/cmd_stack.py
+++ b/cli/cmd_stack.py
@@ -11,10 +11,11 @@ import argparse
 import sys
 from pathlib import Path
 
+from . import paths
+from .install_common import install_agent_file, post_install_finalize
+from .manifest import load_manifest, resolve_variant_files
 from .marker import read_govkit_marker, write_govkit_marker
-from .overlay import apply_overlay, list_overlays, load_overlay
-from .setup_review import print_review_checklist, write_setup_review
-from .skill_context import write_skill_context
+from .overlay import apply_overlay, apply_rule_overrides, list_overlays, load_overlay
 from .stack_select import STACK_ID_ASSUMPTION, build_stack_assumption, build_stack_meta
 
 
@@ -82,6 +83,18 @@ def cmd_stack_apply(args: argparse.Namespace) -> None:
     print(f"  {overlay.display_name}\n")
     apply_overlay(overlay, target, applied_at=prior_applied_at, force=args.force)
 
+    # Agent rule files are govkit-owned and stack-scoped: the swap reinstalls
+    # the resolved set — the new stack's rule overrides, or the type defaults
+    # when it declares none — so rules always match the active stack.
+    manifest = load_manifest(agent)
+    if "variants" in manifest:
+        files, _, _ = resolve_variant_files(manifest, options)
+        files = apply_rule_overrides(files, overlay, agent)
+        agent_dir = paths.AGENTS_DIR / agent
+        print("\nAgent files (refreshed for the stack):")
+        for entry in files:
+            install_agent_file(agent_dir, entry, target, prior_applied_at)
+
     stack_meta = build_stack_meta(overlay)
     # Replace any prior stack.id assumption; keep the rest. The stack id is
     # an explicit CLI argument here, so source/confidence mirror the --stack
@@ -98,11 +111,10 @@ def cmd_stack_apply(args: argparse.Namespace) -> None:
         calibration=stored.get("calibration"),
     )
 
-    new_marker = read_govkit_marker(target)
-    if new_marker is not None:
-        write_setup_review(target, new_marker)
-        write_skill_context(target, new_marker)
-        print_review_checklist(target, new_marker)
+    # Full finalize (setup review, skill_context, rule + skill templating,
+    # checklist) — the reinstalled rule files carry template frontmatter that
+    # must be expanded for the new stack's layers.
+    post_install_finalize(target, agent)
 
     print(f"\nDone. Stack '{overlay.id}' applied to {target}")
 

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -17,6 +17,7 @@ directories under cwd so monorepos get checked per-app.
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -607,6 +608,53 @@ def _classify_extension_message(message: str) -> tuple[str, Severity]:
     if "relates_to" in message:
         return "D014", "warning"
     return "D013", "error"
+
+
+@_register_check("D015")
+def _check_unexpanded_skill_tokens(target: Path, marker: dict) -> list[ValidationFinding]:
+    """D015 — installed skill files must not carry unexpanded {{...}} tokens.
+
+    Skill templating (cli/skill_templating.py) expands `{{docs_area}}` at
+    install time and degrades by leaving the token in place when the marker
+    type is missing/unknown. A leftover token means the skill cites a docs
+    path no agent can follow — surface it rather than let it fail silently
+    at skill runtime.
+    """
+    agent = marker.get("agent", "claude-code")
+    layout = AGENT_LAYOUTS.get(agent)
+    if layout is None or layout.skills_dir is None:
+        return []
+    skills_root = target / layout.skills_dir
+    if not skills_root.is_dir():
+        return []
+
+    findings: list[ValidationFinding] = []
+    for skill_file in sorted(skills_root.rglob("*.md")):
+        try:
+            text = skill_file.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        tokens = sorted(set(re.findall(r"\{\{[a-z_.]+\}\}", text)))
+        if not tokens:
+            continue
+        try:
+            rel_file = skill_file.relative_to(target)
+        except ValueError:
+            rel_file = skill_file
+        findings.append(ValidationFinding(
+            id="D015",
+            severity="warning",
+            category="skill-token",
+            file=str(rel_file).replace("\\", "/"),
+            message=f"unexpanded skill token(s) {', '.join(tokens)} — the marker's "
+                    "options.type could not be mapped to a docs area at install time",
+            suggested_action=(
+                "re-run `govkit apply` with a valid --type (or fix options.type in "
+                ".govkit/marker.json and run `govkit upgrade --force`) so skill "
+                "templating can resolve the token"
+            ),
+        ))
+    return findings
 
 
 @_register_check("D013")

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -352,11 +352,12 @@ def post_install_finalize(
     from .rule_templating import template_installed_rules
     from .setup_review import print_review_checklist, write_setup_review
     from .skill_context import load_skill_context, write_skill_context
-    from .skill_templating import template_installed_skills
+    from .skill_templating import template_installed_rule_bodies, template_installed_skills
     write_setup_review(target, marker)
     write_skill_context(target, marker, profile=profile)
     sc = load_skill_context(target)
     if sc is not None:
         template_installed_rules(target, agent, sc.layers)
         template_installed_skills(target, agent, sc.docs_area)
+        template_installed_rule_bodies(target, agent, sc.pii_keywords)
     print_review_checklist(target, marker)

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -346,9 +346,11 @@ def post_install_finalize(
     from .rule_templating import template_installed_rules
     from .setup_review import print_review_checklist, write_setup_review
     from .skill_context import load_skill_context, write_skill_context
+    from .skill_templating import template_installed_skills
     write_setup_review(target, marker)
     write_skill_context(target, marker, profile=profile)
     sc = load_skill_context(target)
     if sc is not None:
         template_installed_rules(target, agent, sc.layers)
+        template_installed_skills(target, agent, sc.docs_area)
     print_review_checklist(target, marker)

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -100,8 +100,14 @@ def install_agent_file(
     agent_dir: Path, entry: dict, target: Path, applied_at: str | None = None,
 ) -> None:
     """Install one agent-file manifest entry: a managed block when the entry
-    opts in (`managed_block`), otherwise a plain overwrite copy."""
-    src = agent_dir / entry["src"]
+    opts in (`managed_block`), otherwise a plain overwrite copy.
+
+    `src_root` (in-memory only — stack rule overrides set it, manifests
+    never do) points the src at a different bundle root, e.g. the active
+    stack overlay's directory.
+    """
+    src_root = Path(entry["src_root"]) if entry.get("src_root") else agent_dir
+    src = src_root / entry["src"]
     dest = target / entry["dest"]
     if entry.get("managed_block"):
         write_managed_agent_block(dest, src.read_text(encoding="utf-8"), applied_at)

--- a/cli/marker.py
+++ b/cli/marker.py
@@ -28,6 +28,18 @@ from . import version
 MARKER_DIRNAME = ".govkit"
 MARKER_FILENAME = "marker.json"
 
+# The docs/governance area implied by each marker options.type — the <area>
+# in docs/<area>/architecture/ and governance/<area>/schemas/. Shared by
+# validate (schema resolution) and skill_context (docs_area fact) so the two
+# interpretations of options.type cannot drift.
+TYPE_AREA = {
+    "api": "backend",
+    "cli": "backend",
+    "ui-react": "ui",
+    "ui-angular": "ui",
+    "data": "data",
+}
+
 
 # ---------------------------------------------------------------------------
 # Version comparison + one-time migration warnings (v0.7.0 swap onward)

--- a/cli/overlay.py
+++ b/cli/overlay.py
@@ -42,6 +42,7 @@ class Overlay:
     supported_types: list = field(default_factory=list)
     default_assumptions: list = field(default_factory=list)
     docs: list = field(default_factory=list)
+    rules: list = field(default_factory=list)
     skill_context: dict = field(default_factory=dict)
     review_checklist: list = field(default_factory=list)
 
@@ -82,6 +83,7 @@ def _build_overlay(stack_dir: Path) -> Overlay | None:
         supported_types=data.get("supported_types") or [],
         default_assumptions=data.get("default_assumptions") or [],
         docs=data.get("docs") or [],
+        rules=data.get("rules") or [],
         skill_context=data.get("skill_context") or {},
         review_checklist=data.get("review_checklist") or [],
     )
@@ -109,6 +111,39 @@ def list_overlays() -> list[Overlay]:
         if ov is not None:
             overlays.append(ov)
     return overlays
+
+
+def apply_rule_overrides(files: list, overlay: Overlay | None, agent: str) -> list:
+    """Replace type-default agent rule entries with the stack's own.
+
+    An overlay `rules:` entry for `agent` drops the resolved files entry
+    whose src equals its `replaces` and appends itself with `src_root`
+    pointing into the stack bundle, so install_agent_file reads the rule
+    from the overlay instead of the agent dir. Entries whose src is missing
+    from the bundle are skipped entirely — the type default then stays
+    installed rather than leaving the slot empty. Rule files are
+    govkit-owned (no editable header), so unconditional refresh on
+    apply/upgrade/stack apply is the intended semantics.
+    """
+    if overlay is None or not overlay.rules:
+        return files
+    out = list(files)
+    for rule in overlay.rules:
+        if not isinstance(rule, dict) or rule.get("agent") != agent:
+            continue
+        src, dest = rule.get("src"), rule.get("dest")
+        if not (isinstance(src, str) and isinstance(dest, str)):
+            continue
+        if not (overlay.root / src).is_file():
+            continue
+        replaces = rule.get("replaces")
+        if replaces:
+            out = [e for e in out if e.get("src") != replaces]
+        entry: dict = {"src": src, "dest": dest, "src_root": str(overlay.root)}
+        if rule.get("managed_block"):
+            entry["managed_block"] = True
+        out.append(entry)
+    return out
 
 
 def apply_overlay(

--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -72,6 +72,12 @@ _STYLE_LAYERS = {
 # CI option in marker → friendlier CI id used in skill_context.
 _CI_NAME = {"github": "github-actions", "azure": "azure-pipelines"}
 
+# Default PII keyword list — the single source the data rules and the
+# dbt-gate's PII regex are seeded from. Teams tune it by editing
+# pii.keyword_list in .govkit/skill_context.yaml; the edited list survives
+# re-writes (see _pii_facts).
+_DEFAULT_PII_KEYWORDS = ["email", "phone", "ssn", "dob", "birth", "address", "name"]
+
 
 @dataclass
 class SkillContext:
@@ -97,6 +103,7 @@ class SkillContext:
     ci: str | None
     docs_area: str
     llm: bool
+    pii_keywords: list[str] = field(default_factory=list)
     extensions: list[dict] = field(default_factory=list)
 
 
@@ -144,6 +151,28 @@ def _extension_facts(target: Path) -> list[dict]:
             "contract_paths": _extract_contract_paths(manifest),
         })
     return out
+
+
+def _pii_facts(target: Path) -> dict:
+    """Seed the tunable PII keyword list, preserving a team's edited list.
+
+    write_skill_context regenerates the file on every apply/upgrade/stack
+    apply; a non-empty keyword_list the team tuned must survive that, so the
+    existing value wins over the default seed.
+    """
+    path = target / ".govkit" / "skill_context.yaml"
+    if path.is_file():
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, yaml.YAMLError):
+            data = None
+        if isinstance(data, dict) and isinstance(data.get("pii"), dict):
+            keywords = data["pii"].get("keyword_list")
+            if isinstance(keywords, list):
+                cleaned = [k for k in keywords if isinstance(k, str) and k]
+                if cleaned:
+                    return {"keyword_list": cleaned}
+    return {"keyword_list": list(_DEFAULT_PII_KEYWORDS)}
 
 
 def _stack_facts(marker: dict) -> dict:
@@ -201,6 +230,7 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
         # leaves its tokens unexpanded and doctor flags them.
         "docs_area": TYPE_AREA.get(options.get("type"), ""),
         "llm": level == "5",
+        "pii": _pii_facts(target),
         "extensions": _extension_facts(target),
     }
 
@@ -306,5 +336,6 @@ def load_skill_context(target: Path) -> SkillContext | None:
         ci=data.get("ci") if isinstance(data.get("ci"), str) else None,
         docs_area=data.get("docs_area") if isinstance(data.get("docs_area"), str) else "",
         llm=bool(data.get("llm")),
+        pii_keywords=_safe_str_list(_safe_dict(data.get("pii")).get("keyword_list")),
         extensions=[e for e in extensions if isinstance(e, dict)] if isinstance(extensions, list) else [],
     )

--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from .marker import TYPE_AREA
+
 if TYPE_CHECKING:
     from .detect import RepoProfile
 
@@ -93,6 +95,7 @@ class SkillContext:
     unit_test: str | None
     bdd_test: str | None
     ci: str | None
+    docs_area: str
     llm: bool
     extensions: list[dict] = field(default_factory=list)
 
@@ -193,6 +196,10 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
         },
         "stack": _stack_facts(marker),
         "ci": _CI_NAME.get(options.get("ci"), options.get("ci")),
+        # The docs tree this install's type reads (docs/<area>/architecture/).
+        # Empty when the type is missing/unknown — skill templating then
+        # leaves its tokens unexpanded and doctor flags them.
+        "docs_area": TYPE_AREA.get(options.get("type"), ""),
         "llm": level == "5",
         "extensions": _extension_facts(target),
     }
@@ -297,6 +304,7 @@ def load_skill_context(target: Path) -> SkillContext | None:
         unit_test=stack.get("unit_test") if isinstance(stack.get("unit_test"), str) else None,
         bdd_test=stack.get("bdd_test") if isinstance(stack.get("bdd_test"), str) else None,
         ci=data.get("ci") if isinstance(data.get("ci"), str) else None,
+        docs_area=data.get("docs_area") if isinstance(data.get("docs_area"), str) else "",
         llm=bool(data.get("llm")),
         extensions=[e for e in extensions if isinstance(e, dict)] if isinstance(extensions, list) else [],
     )

--- a/cli/skill_templating.py
+++ b/cli/skill_templating.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from .agent_layout import AGENT_LAYOUTS
 
 _DOCS_AREA_TOKEN = "{{docs_area}}"
+_PII_KEYWORDS_TOKEN = "{{pii_keywords}}"
 
 
 def expand_skill_tokens(text: str, docs_area: str) -> str:
@@ -39,6 +40,51 @@ def expand_skill_tokens(text: str, docs_area: str) -> str:
     if not docs_area:
         return text
     return text.replace(_DOCS_AREA_TOKEN, docs_area)
+
+
+def render_pii_keywords(keywords: list[str]) -> str:
+    """Render the PII keyword list for prose insertion: `email`, `phone`, ..."""
+    return ", ".join(f"`{k}`" for k in keywords)
+
+
+def template_installed_rule_bodies(target: Path, agent: str, pii_keywords: list[str]) -> int:
+    """Expand `{{pii_keywords}}` in installed rule bodies.
+
+    Rule bodies embed no team-tunable literals — the tunables live in
+    skill_context (`pii.keyword_list`) and are rendered in at install time,
+    so the rules and the CI gate's PII check share one source. Walks the
+    agent's rules dir; codex additionally gets `.agents/rules` plus any
+    AGENTS.md carrying the token (its dbt layer rules install as nested
+    managed blocks). An empty list leaves tokens in place (doctor's skill
+    token check pattern: unknown context stays visible).
+    """
+    if not pii_keywords:
+        return 0
+    layout = AGENT_LAYOUTS.get(agent)
+    if layout is None:
+        return 0
+    rendered = render_pii_keywords(pii_keywords)
+
+    candidates: list[Path] = []
+    if layout.rules_dir and (target / layout.rules_dir).is_dir():
+        candidates.extend(sorted((target / layout.rules_dir).rglob("*.md")))
+    if agent == "codex":
+        agents_rules = target / ".agents" / "rules"
+        if agents_rules.is_dir():
+            candidates.extend(sorted(agents_rules.rglob("*.md")))
+        candidates.extend(sorted(target.rglob("AGENTS.md")))
+
+    modified = 0
+    for path in candidates:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if _PII_KEYWORDS_TOKEN not in text:
+            continue
+        path.write_text(text.replace(_PII_KEYWORDS_TOKEN, rendered), encoding="utf-8")
+        modified += 1
+    return modified
 
 
 def template_installed_skills(target: Path, agent: str, docs_area: str) -> int:

--- a/cli/skill_templating.py
+++ b/cli/skill_templating.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Install-time token expansion for installed skill files.
+
+Skill sources reference the type's docs tree as `docs/{{docs_area}}/...`
+instead of hardcoding `docs/backend/`. Agents cannot resolve skill_context at
+runtime, so — like rule glob templating (cli/rule_templating.py) — the token
+is expanded once at install time, in `post_install_finalize`, after
+skill_context.yaml is written.
+
+Unlike rule templating (a frontmatter directive), this is inline body
+substitution: skills cite doc paths in prose. Degradation matches the rule
+pass: an unresolvable token (empty docs_area from a missing/unknown marker
+type) is left in the text — doctor flags it — never guessed.
+
+Installed skills are govkit-owned (no editable header, unconditionally
+refreshed on apply/upgrade), so rewriting them in place clobbers nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .agent_layout import AGENT_LAYOUTS
+
+_DOCS_AREA_TOKEN = "{{docs_area}}"
+
+
+def expand_skill_tokens(text: str, docs_area: str) -> str:
+    """Expand skill tokens in `text` for the install's docs area.
+
+    Empty `docs_area` leaves the token in place (unknown context must stay
+    visible, not be guessed away). Tokens other than `{{docs_area}}` are not
+    recognized and pass through untouched.
+    """
+    if not docs_area:
+        return text
+    return text.replace(_DOCS_AREA_TOKEN, docs_area)
+
+
+def template_installed_skills(target: Path, agent: str, docs_area: str) -> int:
+    """Expand tokens in every installed skill file for `agent` under `target`.
+
+    Walks the agent's skills dir (AGENT_LAYOUTS), rewrites files in place,
+    and returns the number of files modified. No-op (0) for unknown agents,
+    layouts without a skills dir, a missing directory, or empty docs_area.
+    """
+    layout = AGENT_LAYOUTS.get(agent)
+    if layout is None or layout.skills_dir is None or not docs_area:
+        return 0
+    skills_root = target / layout.skills_dir
+    if not skills_root.is_dir():
+        return 0
+
+    modified = 0
+    for path in sorted(skills_root.rglob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        expanded = expand_skill_tokens(text, docs_area)
+        if expanded != text:
+            path.write_text(expanded, encoding="utf-8")
+            modified += 1
+    return modified

--- a/cli/stacks/databricks-lakehouse/overlay.yaml
+++ b/cli/stacks/databricks-lakehouse/overlay.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../governance/schemas/stack-overlay.schema.json
 id: databricks-lakehouse
-version: "0.10.0"
+version: "0.11.0"
 display_name: "Databricks Lakehouse (Unity Catalog / Delta / Asset Bundles)"
 summary: "Databricks-native data delivery with Unity Catalog, Delta tables, Asset Bundles, Jobs, Lakeflow Pipelines, PySpark, SQL, and notebooks"
 supported_types: [data]
@@ -37,6 +37,49 @@ docs:
   - src: LINEAGE_OBSERVABILITY.md
     dest: docs/data/architecture/LINEAGE_OBSERVABILITY.md
     editable: true
+rules:
+  # Medallion-worded layer rules replace the dbt-worded type defaults for
+  # the overlapping layer slots. claude-code/copilot keep the default dest
+  # filenames (the layer *slot*), so `stack apply` swaps content in place.
+  # codex's dbt defaults are folder-scoped nested AGENTS.md blocks under
+  # models/, which a medallion repo does not have — its medallion rules
+  # install as plain .agents/rules files instead.
+  - agent: claude-code
+    src: rules/claude-code/bronze.md
+    dest: .claude/rules/govkit/staging.md
+    replaces: rules/data/staging.md
+  - agent: claude-code
+    src: rules/claude-code/silver.md
+    dest: .claude/rules/govkit/intermediate.md
+    replaces: rules/data/intermediate.md
+  - agent: claude-code
+    src: rules/claude-code/gold.md
+    dest: .claude/rules/govkit/marts.md
+    replaces: rules/data/marts.md
+  - agent: copilot
+    src: rules/copilot/bronze.instructions.md
+    dest: .github/instructions/govkit/staging.instructions.md
+    replaces: instructions/data/staging.instructions.md
+  - agent: copilot
+    src: rules/copilot/silver.instructions.md
+    dest: .github/instructions/govkit/intermediate.instructions.md
+    replaces: instructions/data/intermediate.instructions.md
+  - agent: copilot
+    src: rules/copilot/gold.instructions.md
+    dest: .github/instructions/govkit/marts.instructions.md
+    replaces: instructions/data/marts.instructions.md
+  - agent: codex
+    src: rules/codex/bronze.md
+    dest: .agents/rules/bronze.md
+    replaces: rules/data/staging.md
+  - agent: codex
+    src: rules/codex/silver.md
+    dest: .agents/rules/silver.md
+    replaces: rules/data/intermediate.md
+  - agent: codex
+    src: rules/codex/gold.md
+    dest: .agents/rules/gold.md
+    replaces: rules/data/marts.md
 skill_context:
   language: python
   framework: databricks-lakehouse

--- a/cli/stacks/databricks-lakehouse/rules/claude-code/bronze.md
+++ b/cli/stacks/databricks-lakehouse/rules/claude-code/bronze.md
@@ -1,0 +1,48 @@
+---
+paths_template: layers.inbound
+paths:
+  - "**/bronze/**"
+---
+
+# Bronze Layer — Source-Shaped Ingest
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what bronze may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — medallion naming + storage
+
+Bronze assets land source data as Delta tables with light normalization.
+They are NOT where business logic happens.
+
+## Rules
+
+- A bronze asset reads from exactly one external source (Auto Loader,
+  `read_files`, or a declared ingest job) — never from another lakehouse
+  layer
+- Allowed transformations: renames, type casts, light value cleanup
+  (`lower(email)`, `trim(name)`), filtering NULL primary keys
+- Forbidden: joins across sources, aggregations, business-logic conditionals
+- Write as Delta with schema evolution handled explicitly — no silent
+  `mergeSchema` in production paths
+- Asset naming and catalog placement follow
+  `docs/data/architecture/MODEL_LAYERING.md`
+
+## PII at the bronze boundary
+
+Every column matching the team's PII keyword list MUST be tagged and masked
+per `docs/data/architecture/PII_HANDLING.md` (stack overlay) before the data
+is readable outside the ingest schema. Generating a bronze asset that
+exposes raw PII fails the PII check in CI.
+
+## When in doubt
+
+- If the transformation crosses sources → it belongs in silver, not bronze
+- If the transformation aggregates → it belongs in silver or gold
+- If the source layout is unusual → flag in the PR, don't invent a new
+  ingest convention
+
+## Anti-patterns
+
+- A bronze asset that joins two sources
+- A bronze asset whose name doesn't mirror the source (misleading)
+- A bronze asset that filters business-relevant rows (e.g., excludes test
+  accounts) — that's a silver concern

--- a/cli/stacks/databricks-lakehouse/rules/claude-code/bronze.md
+++ b/cli/stacks/databricks-lakehouse/rules/claude-code/bronze.md
@@ -28,7 +28,9 @@ They are NOT where business logic happens.
 
 ## PII at the bronze boundary
 
-Every column matching the team's PII keyword list MUST be tagged and masked
+Every column matching the team's PII keyword list ({{pii_keywords}} —
+tunable via `pii.keyword_list` in `.govkit/skill_context.yaml`) MUST be
+tagged and masked
 per `docs/data/architecture/PII_HANDLING.md` (stack overlay) before the data
 is readable outside the ingest schema. Generating a bronze asset that
 exposes raw PII fails the PII check in CI.

--- a/cli/stacks/databricks-lakehouse/rules/claude-code/gold.md
+++ b/cli/stacks/databricks-lakehouse/rules/claude-code/gold.md
@@ -1,0 +1,40 @@
+---
+paths_template: layers.outbound
+paths:
+  - "**/gold/**"
+---
+
+# Gold Layer — Serving Contracts
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what gold may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — consumer contracts + change control
+
+Gold assets are the public API of the lakehouse: BI, ML, operational
+consumers, and published data products read gold only.
+
+## Rules
+
+- Gold reads from silver (and other gold) — reading bronze directly
+  requires an ADR
+- Treat every gold column list as a public contract: renames and removals
+  are breaking changes requiring a deprecation notice, consumer
+  coordination, and an ADR (per `MODEL_LAYERING.md` change control)
+- Every gold asset declares its downstream consumers (exposure/lineage
+  registration per `docs/data/architecture/LINEAGE_OBSERVABILITY.md`)
+- Metric definitions live in gold, defined once — two gold assets must not
+  redefine the same metric
+
+## When in doubt
+
+- If no consumer is known → don't ship the asset (no exposure means dead
+  code or an undocumented consumer)
+- If the change alters a served column → treat it as breaking until proven
+  otherwise
+
+## Anti-patterns
+
+- A gold asset that is never queried (delete it)
+- Two gold assets with overlapping concepts (consolidate)
+- Consumer-specific one-off shapes proliferating instead of a shared
+  contract + view

--- a/cli/stacks/databricks-lakehouse/rules/claude-code/silver.md
+++ b/cli/stacks/databricks-lakehouse/rules/claude-code/silver.md
@@ -1,0 +1,41 @@
+---
+paths_template: layers.domain
+paths:
+  - "**/silver/**"
+---
+
+# Silver Layer — Conformed Business Entities
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what silver may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — medallion layering
+
+Silver assets own standardization, deduplication, and entity conformance.
+This is where business transformations live.
+
+## Rules
+
+- Silver reads from bronze and other silver assets — never directly from
+  external sources, never from gold
+- Deduplicate and conform entities here: one silver asset per business
+  concept, not per consumer
+- Enforce data-quality expectations at silver (per
+  `docs/data/architecture/DATA_QUALITY_CONTRACT.md`) — quality-checked data
+  is this layer's contract
+- Prefer PySpark/SQL transformations tracked in source control; notebooks
+  follow the team's notebook policy in
+  `docs/data/architecture/TECH_STACK.md`
+
+## When in doubt
+
+- If it is consumer- or serving-shaped → it belongs in gold
+- If it reads an external source → the ingest belongs in bronze
+- If two silver assets overlap conceptually → consolidate before adding a
+  third
+
+## Anti-patterns
+
+- A silver asset referenced by exactly one gold asset that only renames
+  columns (inline it)
+- Bypassing bronze to "save a hop" (breaks lineage + replayability)
+- Quality checks deferred to gold (consumers see unchecked data)

--- a/cli/stacks/databricks-lakehouse/rules/codex/bronze.md
+++ b/cli/stacks/databricks-lakehouse/rules/codex/bronze.md
@@ -1,0 +1,42 @@
+# Bronze Layer — Source-Shaped Ingest
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what bronze may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — medallion naming + storage
+
+Bronze assets land source data as Delta tables with light normalization.
+They are NOT where business logic happens.
+
+## Rules
+
+- A bronze asset reads from exactly one external source (Auto Loader,
+  `read_files`, or a declared ingest job) — never from another lakehouse
+  layer
+- Allowed transformations: renames, type casts, light value cleanup
+  (`lower(email)`, `trim(name)`), filtering NULL primary keys
+- Forbidden: joins across sources, aggregations, business-logic conditionals
+- Write as Delta with schema evolution handled explicitly — no silent
+  `mergeSchema` in production paths
+- Asset naming and catalog placement follow
+  `docs/data/architecture/MODEL_LAYERING.md`
+
+## PII at the bronze boundary
+
+Every column matching the team's PII keyword list MUST be tagged and masked
+per `docs/data/architecture/PII_HANDLING.md` (stack overlay) before the data
+is readable outside the ingest schema. Generating a bronze asset that
+exposes raw PII fails the PII check in CI.
+
+## When in doubt
+
+- If the transformation crosses sources → it belongs in silver, not bronze
+- If the transformation aggregates → it belongs in silver or gold
+- If the source layout is unusual → flag in the PR, don't invent a new
+  ingest convention
+
+## Anti-patterns
+
+- A bronze asset that joins two sources
+- A bronze asset whose name doesn't mirror the source (misleading)
+- A bronze asset that filters business-relevant rows (e.g., excludes test
+  accounts) — that's a silver concern

--- a/cli/stacks/databricks-lakehouse/rules/codex/bronze.md
+++ b/cli/stacks/databricks-lakehouse/rules/codex/bronze.md
@@ -22,7 +22,9 @@ They are NOT where business logic happens.
 
 ## PII at the bronze boundary
 
-Every column matching the team's PII keyword list MUST be tagged and masked
+Every column matching the team's PII keyword list ({{pii_keywords}} —
+tunable via `pii.keyword_list` in `.govkit/skill_context.yaml`) MUST be
+tagged and masked
 per `docs/data/architecture/PII_HANDLING.md` (stack overlay) before the data
 is readable outside the ingest schema. Generating a bronze asset that
 exposes raw PII fails the PII check in CI.

--- a/cli/stacks/databricks-lakehouse/rules/codex/gold.md
+++ b/cli/stacks/databricks-lakehouse/rules/codex/gold.md
@@ -1,0 +1,34 @@
+# Gold Layer — Serving Contracts
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what gold may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — consumer contracts + change control
+
+Gold assets are the public API of the lakehouse: BI, ML, operational
+consumers, and published data products read gold only.
+
+## Rules
+
+- Gold reads from silver (and other gold) — reading bronze directly
+  requires an ADR
+- Treat every gold column list as a public contract: renames and removals
+  are breaking changes requiring a deprecation notice, consumer
+  coordination, and an ADR (per `MODEL_LAYERING.md` change control)
+- Every gold asset declares its downstream consumers (exposure/lineage
+  registration per `docs/data/architecture/LINEAGE_OBSERVABILITY.md`)
+- Metric definitions live in gold, defined once — two gold assets must not
+  redefine the same metric
+
+## When in doubt
+
+- If no consumer is known → don't ship the asset (no exposure means dead
+  code or an undocumented consumer)
+- If the change alters a served column → treat it as breaking until proven
+  otherwise
+
+## Anti-patterns
+
+- A gold asset that is never queried (delete it)
+- Two gold assets with overlapping concepts (consolidate)
+- Consumer-specific one-off shapes proliferating instead of a shared
+  contract + view

--- a/cli/stacks/databricks-lakehouse/rules/codex/silver.md
+++ b/cli/stacks/databricks-lakehouse/rules/codex/silver.md
@@ -1,0 +1,35 @@
+# Silver Layer — Conformed Business Entities
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what silver may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — medallion layering
+
+Silver assets own standardization, deduplication, and entity conformance.
+This is where business transformations live.
+
+## Rules
+
+- Silver reads from bronze and other silver assets — never directly from
+  external sources, never from gold
+- Deduplicate and conform entities here: one silver asset per business
+  concept, not per consumer
+- Enforce data-quality expectations at silver (per
+  `docs/data/architecture/DATA_QUALITY_CONTRACT.md`) — quality-checked data
+  is this layer's contract
+- Prefer PySpark/SQL transformations tracked in source control; notebooks
+  follow the team's notebook policy in
+  `docs/data/architecture/TECH_STACK.md`
+
+## When in doubt
+
+- If it is consumer- or serving-shaped → it belongs in gold
+- If it reads an external source → the ingest belongs in bronze
+- If two silver assets overlap conceptually → consolidate before adding a
+  third
+
+## Anti-patterns
+
+- A silver asset referenced by exactly one gold asset that only renames
+  columns (inline it)
+- Bypassing bronze to "save a hop" (breaks lineage + replayability)
+- Quality checks deferred to gold (consumers see unchecked data)

--- a/cli/stacks/databricks-lakehouse/rules/copilot/bronze.instructions.md
+++ b/cli/stacks/databricks-lakehouse/rules/copilot/bronze.instructions.md
@@ -1,0 +1,47 @@
+---
+applyTo_template: layers.inbound
+applyTo: "**/bronze/**"
+---
+
+# Bronze Layer — Source-Shaped Ingest
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what bronze may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — medallion naming + storage
+
+Bronze assets land source data as Delta tables with light normalization.
+They are NOT where business logic happens.
+
+## Rules
+
+- A bronze asset reads from exactly one external source (Auto Loader,
+  `read_files`, or a declared ingest job) — never from another lakehouse
+  layer
+- Allowed transformations: renames, type casts, light value cleanup
+  (`lower(email)`, `trim(name)`), filtering NULL primary keys
+- Forbidden: joins across sources, aggregations, business-logic conditionals
+- Write as Delta with schema evolution handled explicitly — no silent
+  `mergeSchema` in production paths
+- Asset naming and catalog placement follow
+  `docs/data/architecture/MODEL_LAYERING.md`
+
+## PII at the bronze boundary
+
+Every column matching the team's PII keyword list MUST be tagged and masked
+per `docs/data/architecture/PII_HANDLING.md` (stack overlay) before the data
+is readable outside the ingest schema. Generating a bronze asset that
+exposes raw PII fails the PII check in CI.
+
+## When in doubt
+
+- If the transformation crosses sources → it belongs in silver, not bronze
+- If the transformation aggregates → it belongs in silver or gold
+- If the source layout is unusual → flag in the PR, don't invent a new
+  ingest convention
+
+## Anti-patterns
+
+- A bronze asset that joins two sources
+- A bronze asset whose name doesn't mirror the source (misleading)
+- A bronze asset that filters business-relevant rows (e.g., excludes test
+  accounts) — that's a silver concern

--- a/cli/stacks/databricks-lakehouse/rules/copilot/bronze.instructions.md
+++ b/cli/stacks/databricks-lakehouse/rules/copilot/bronze.instructions.md
@@ -27,7 +27,9 @@ They are NOT where business logic happens.
 
 ## PII at the bronze boundary
 
-Every column matching the team's PII keyword list MUST be tagged and masked
+Every column matching the team's PII keyword list ({{pii_keywords}} —
+tunable via `pii.keyword_list` in `.govkit/skill_context.yaml`) MUST be
+tagged and masked
 per `docs/data/architecture/PII_HANDLING.md` (stack overlay) before the data
 is readable outside the ingest schema. Generating a bronze asset that
 exposes raw PII fails the PII check in CI.

--- a/cli/stacks/databricks-lakehouse/rules/copilot/gold.instructions.md
+++ b/cli/stacks/databricks-lakehouse/rules/copilot/gold.instructions.md
@@ -1,0 +1,39 @@
+---
+applyTo_template: layers.outbound
+applyTo: "**/gold/**"
+---
+
+# Gold Layer — Serving Contracts
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what gold may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — consumer contracts + change control
+
+Gold assets are the public API of the lakehouse: BI, ML, operational
+consumers, and published data products read gold only.
+
+## Rules
+
+- Gold reads from silver (and other gold) — reading bronze directly
+  requires an ADR
+- Treat every gold column list as a public contract: renames and removals
+  are breaking changes requiring a deprecation notice, consumer
+  coordination, and an ADR (per `MODEL_LAYERING.md` change control)
+- Every gold asset declares its downstream consumers (exposure/lineage
+  registration per `docs/data/architecture/LINEAGE_OBSERVABILITY.md`)
+- Metric definitions live in gold, defined once — two gold assets must not
+  redefine the same metric
+
+## When in doubt
+
+- If no consumer is known → don't ship the asset (no exposure means dead
+  code or an undocumented consumer)
+- If the change alters a served column → treat it as breaking until proven
+  otherwise
+
+## Anti-patterns
+
+- A gold asset that is never queried (delete it)
+- Two gold assets with overlapping concepts (consolidate)
+- Consumer-specific one-off shapes proliferating instead of a shared
+  contract + view

--- a/cli/stacks/databricks-lakehouse/rules/copilot/silver.instructions.md
+++ b/cli/stacks/databricks-lakehouse/rules/copilot/silver.instructions.md
@@ -1,0 +1,40 @@
+---
+applyTo_template: layers.domain
+applyTo: "**/silver/**"
+---
+
+# Silver Layer — Conformed Business Entities
+
+**Authority:**
+- `docs/data/architecture/BOUNDARIES.md` — what silver may read + write
+- `docs/data/architecture/MODEL_LAYERING.md` (stack overlay) — medallion layering
+
+Silver assets own standardization, deduplication, and entity conformance.
+This is where business transformations live.
+
+## Rules
+
+- Silver reads from bronze and other silver assets — never directly from
+  external sources, never from gold
+- Deduplicate and conform entities here: one silver asset per business
+  concept, not per consumer
+- Enforce data-quality expectations at silver (per
+  `docs/data/architecture/DATA_QUALITY_CONTRACT.md`) — quality-checked data
+  is this layer's contract
+- Prefer PySpark/SQL transformations tracked in source control; notebooks
+  follow the team's notebook policy in
+  `docs/data/architecture/TECH_STACK.md`
+
+## When in doubt
+
+- If it is consumer- or serving-shaped → it belongs in gold
+- If it reads an external source → the ingest belongs in bronze
+- If two silver assets overlap conceptually → consolidate before adding a
+  third
+
+## Anti-patterns
+
+- A silver asset referenced by exactly one gold asset that only renames
+  columns (inline it)
+- Bypassing bronze to "save a hop" (breaks lineage + replayability)
+- Quality checks deferred to gold (consumers see unchecked data)

--- a/cli/stacks/python-dbt/MODEL_LAYERING.md
+++ b/cli/stacks/python-dbt/MODEL_LAYERING.md
@@ -121,6 +121,37 @@ exposures:
 
 `dbt docs` then surfaces "what breaks if I change this mart" automatically.
 
+## Model contracts are the machine form of this section
+
+Every mart model declares an enforced dbt model contract (dbt-core >= 1.5)
+so the column list is checked at build time, not by convention:
+
+```yaml
+models:
+  - name: dim_customers
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: customer_id
+        data_type: string
+```
+
+The CI gate (`dbt-gate`) blocks a PR when a model under `models/marts/`
+lacks `contract: {enforced: true}` or appears in no `exposures:` entry —
+no exposure means dead code or an undocumented consumer. (On dbt-core
+< 1.5 the contract check downgrades to a warning with an upgrade pointer.)
+
+## Change control: deprecation and model versions
+
+- **Deprecating a mart or column**: set `deprecation_date:` on the model
+  and keep the deprecation notice in `description:` for one release cycle;
+  coordinate with the consumers listed in `_exposures.yml`.
+- **Breaking change** (rename/removal/type change): ship it as a new model
+  version (`versions:` with `latest_version:`) so existing consumers keep
+  resolving the old shape while they migrate, and record the migration
+  plan in an ADR. Retire the old version at its `deprecation_date`.
+
 ---
 
 # 5. Snapshots (SCD2)

--- a/cli/stacks/python-dbt/TESTING.md
+++ b/cli/stacks/python-dbt/TESTING.md
@@ -151,6 +151,23 @@ worked example.
 
 ---
 
+# 7.5 Static Mart Checks the CI Gate Runs
+
+Independent of warehouse execution, the `dbt-gate` CI workflow statically
+blocks a PR when a model under `models/marts/` either:
+
+- lacks an enforced model contract (`contract: {enforced: true}` — the
+  machine form of "marts are the public API"; see `MODEL_LAYERING.md` §4),
+  or
+- appears in no `exposures:` entry (no exposure means dead code or an
+  undocumented consumer).
+
+On dbt-core < 1.5 (no model contracts) the contract check downgrades to a
+warning with an upgrade pointer. Layer-boundary enforcement via
+`dbt-project-evaluator` is available as a documented opt-in in the gate.
+
+---
+
 # 8. What NOT to Test
 
 - Source data quality (that's the upstream owner's responsibility — flag via

--- a/cli/stacks/python-dbt/overlay.yaml
+++ b/cli/stacks/python-dbt/overlay.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../governance/schemas/stack-overlay.schema.json
 id: python-dbt
-version: "0.10.0"
+version: "0.11.0"
 display_name: "Python 3.11+ / dbt-core (staging / intermediate / marts)"
 summary: "dbt-core + a warehouse adapter (Snowflake / BigQuery / Redshift / Postgres); SQLfluff + dbt schema tests + optional dbt-expectations for L4"
 supported_types: [data]

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -29,7 +29,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from .marker import read_govkit_level, read_govkit_marker
+from .marker import TYPE_AREA, read_govkit_level, read_govkit_marker
 
 # ---------------------------------------------------------------------------
 # Artifact file name constants
@@ -180,17 +180,9 @@ def check_nfrs_sections(feature_dir: Path) -> tuple[bool | None, str]:
     return True, f"{_NFRS_MD} section contract OK (Repository Scope + Out of scope populated)"
 
 
-# Governance area whose schemas govern each marker options.type. data maps to
-# its own area, which ships no schema yet — the resolver then reports the gap
+# marker.TYPE_AREA maps options.type to its governance area. data maps to its
+# own area, which ships no schema yet — the resolver then reports the gap
 # instead of consulting another type's (possibly stale) governance tree.
-_TYPE_TO_GOVERNANCE_AREA = {
-    "api": "backend",
-    "cli": "backend",
-    "ui-react": "ui",
-    "ui-angular": "ui",
-    "data": "data",
-}
-
 _NO_SCHEMA_REASON = "no eval_criteria schema installed for this project type"
 
 
@@ -213,7 +205,7 @@ def _resolve_eval_schema(feature_dir: Path) -> tuple[Path | None, str]:
         marker = read_govkit_marker(ancestor)
         if not marker:
             continue
-        area = _TYPE_TO_GOVERNANCE_AREA.get((marker.get("options") or {}).get("type"))
+        area = TYPE_AREA.get((marker.get("options") or {}).get("type"))
         if area is None:
             break  # marker present but type unknown — fall back to scanning
         schema = ancestor / "governance" / area / "schemas" / "eval_criteria.schema.json"

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -29,7 +29,7 @@ import re
 import subprocess
 from pathlib import Path
 
-from .marker import TYPE_AREA, read_govkit_level, read_govkit_marker
+from .marker import TYPE_AREA, read_govkit_marker
 
 # ---------------------------------------------------------------------------
 # Artifact file name constants
@@ -511,13 +511,27 @@ def check_l5_preflight_sections(feature_dir: Path) -> tuple[bool, str]:
 # Runner
 # ---------------------------------------------------------------------------
 
-def _build_checks(level: str) -> tuple[list[str], list]:
+def _data_prediction_not_required(feature_dir: Path) -> tuple[bool, str]:
+    """Data features carry no FIRST/Virtue self-prediction (ADR-0001 under
+    docs/data/architecture/ADR/): enforcement is artifact completeness, the
+    data eval-criteria schema, NFR tag coverage, and the mart-contract gate."""
+    return True, (
+        "evaluation prediction not required for data features "
+        "(docs/data/architecture/ADR/0001-data-features-skip-prediction-gate.md)"
+    )
+
+
+def _build_checks(level: str, marker_type: str | None = None) -> tuple[list[str], list]:
     """Return the artifact list and check functions for a given level.
 
     L3 is handled by an early no-op return in run_validation() and never reaches
     this function. L4 enforces the 5-artifact governed contract; L5 layers in
-    LLM-specific checks on top.
+    LLM-specific checks on top. `marker_type` swaps the type-specific checks —
+    data features skip the evaluation-prediction gate (ADR-0001).
     """
+    prediction_check = (
+        _data_prediction_not_required if marker_type == "data" else check_plan_eval_prediction
+    )
     artifacts = L4_REQUIRED_ARTIFACTS
     if level == "5":
         checks = [
@@ -526,7 +540,7 @@ def _build_checks(level: str) -> tuple[list[str], list]:
             check_nfrs_no_tbd,
             check_nfrs_sections,
             check_eval_criteria,
-            check_plan_eval_prediction,
+            prediction_check,
             check_gherkin_nfr_coverage,
             check_llm_nfrs,
             check_l5_eval_criteria,
@@ -542,7 +556,7 @@ def _build_checks(level: str) -> tuple[list[str], list]:
             check_nfrs_no_tbd,
             check_nfrs_sections,
             check_eval_criteria,
-            check_plan_eval_prediction,
+            prediction_check,
             check_gherkin_nfr_coverage,
         ]
     return artifacts, checks
@@ -597,8 +611,9 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
         print(f"Error: target directory '{target}' does not exist.")
         return 1
 
+    marker = read_govkit_marker(target) or {}
     if level is None:
-        level = read_govkit_level(target) or "3"
+        level = marker.get("level") or "3"
 
     ext_exit = _run_extension_checks(target, strict)
 
@@ -619,7 +634,7 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
         print(f"Error: no features/ directory found in '{target}'.")
         return 1
 
-    _, checks = _build_checks(level)
+    _, checks = _build_checks(level, (marker.get("options") or {}).get("type"))
 
     feature_dirs = sorted(
         d for d in features_dir.iterdir()

--- a/docs/data/architecture/ADR/0001-data-features-skip-prediction-gate.md
+++ b/docs/data/architecture/ADR/0001-data-features-skip-prediction-gate.md
@@ -1,0 +1,59 @@
+# ADR-0001: Data features carry no FIRST/Virtue evaluation prediction
+
+## Status
+Accepted
+
+## Date
+2026-07-24
+
+## Authors
+- govkit maintainers
+
+---
+
+## 1. Context
+
+Backend and UI features at L4 require an `evaluation_prediction` block in
+`plan.md`: a self-predicted FIRST (test quality) and 7-Virtue (code quality)
+score, each averaging ≥ 4.0, checked by `govkit validate`.
+
+For data features the block never fit:
+
+- The FIRST rubric scores unit-test design; data features are verified by
+  schema tests, singular tests, and query predicates — a different surface
+  with its own contract (`DATA_QUALITY_CONTRACT.md`, `eval_criteria.yaml`).
+- The 7 Virtues rubric (Working / Unique / Simple / Clear / Easy /
+  Developed / Tested) was written for application code. The data starter's
+  copy drifted into an undocumented vocabulary
+  (correctness/clarity/composability/…), which no rubric doc defines and no
+  team has calibrated.
+- A self-predicted ≥ 4.0 average is ceremony either way: the prediction is
+  authored by the same agent that authors the plan, against a rubric the
+  data team has no calibration history for.
+
+## 2. Decision
+
+Drop the `evaluation_prediction` requirement for `--type data` features.
+`govkit validate` skips the prediction check when the marker records
+`type: data`. Enforcement for data features is carried by:
+
+- artifact completeness (the 5-artifact L4 contract still applies),
+- `eval_criteria.yaml` validated against the data schema
+  (`governance/data/schemas/eval_criteria.schema.json`) — deterministic
+  criteria measured by queries and CI outcomes,
+- the mart-contract CI gate (enforced model contracts + exposure coverage),
+- the data NFR tag coverage check.
+
+A data-native scored rubric (contract completeness, test-tier coverage,
+lineage coverage) is deliberately **not** introduced now: inventing a
+rubric nobody has calibrated recreates the ceremony this ADR removes. If a
+team asks for a scored gate, that becomes a new ADR superseding this one.
+
+## 3. Consequences
+
+- `features/<name>/plan.md` for data features contains no
+  `evaluation_prediction` block; the starter ships without one.
+- Backend and UI features are unchanged — the prediction gate still
+  applies there.
+- Teams that want a prediction anyway may keep the block in their plans;
+  validate simply does not require or score it for data features.

--- a/features/starter_data/architecture_preflight.md
+++ b/features/starter_data/architecture_preflight.md
@@ -21,17 +21,17 @@
 
 ## 2. Standards Check
 
-For each, cite the contract file + section:
+Data project — the standards set is the data one (see §3.7):
 
 - **Layering** — `docs/data/architecture/BOUNDARIES.md` §1 (staging may
   read sources only; marts may read intermediate + other marts; no
   cross-layer shortcuts)
 - **Query conventions** — `docs/data/architecture/QUERY_CONVENTIONS.md`
   (stack overlay; CTE skeleton, naming `stg_<source>__<table>`)
-- **Test discipline** — `docs/data/architecture/DATA_QUALITY_CONTRACT.md`
+- **Data quality tiers** — `docs/data/architecture/DATA_QUALITY_CONTRACT.md`
   §1 (schema tests `error`; distribution tests start `warn`)
-- **PII** — `docs/data/architecture/PII_HANDLING_CONTRACT.md` §1-4 (tag
-  + mask via `mask_pii()` macro per overlay's `PII_HANDLING.md`)
+- **PII handling** — `docs/data/architecture/PII_HANDLING_CONTRACT.md` §1-4
+  (tag + mask via `mask_pii()` macro per overlay's `PII_HANDLING.md`)
 - **Lineage** — `docs/data/architecture/LINEAGE_CONTRACT.md` §3 (column
   lineage required for PII-tagged columns)
 - **Environments** — `docs/data/architecture/ENVIRONMENTS.md` §3-4 (PII
@@ -75,6 +75,56 @@ side, monitored on ours.)
 
 ---
 
+## 3.6 Scope Boundary Source Check
+
+- [x] `nfrs.md` has a non-empty `## Out of scope` section
+
+Out-of-scope is author-declared — spec planning carries it into the plan
+verbatim.
+
+---
+
+## 3.7 Data Impact
+
+### Pipeline Impact
+
+- **Schedule / SLA:** new daily 06:00 UTC run; freshness target 1 hour
+  after scheduled completion, alert at 2×, block at 4× (per `nfrs.md`
+  `@nfr-freshness`).
+- **Backfill:** required for the initial load; re-runs of the same date
+  range must be idempotent (identical output row counts).
+- **Orchestration dependencies:** upstream `stripe.customers` source
+  freshness (24 h SLA, owned by stripe-sync); downstream Looker refresh
+  and the Hightouch reverse-ETL job consume `dim_customers`.
+
+### Contract Impact
+
+- **Mart schema changes:** new mart — no renames or removals of existing
+  columns, so no breaking change under the mart layer rule's
+  breaking-change table. Future column removals require deprecation
+  notice + consumer coordination.
+- **Exposures affected:** add `dim_customers` entries for Looker and
+  Hightouch to `models/marts/_exposures.yml`.
+
+### PII Impact
+
+- **Columns:** `customer_email`, `customer_phone` (contact),
+  `billing_address` (identity), `tax_id_last4` (sensitive) — categories
+  per `nfrs.md` `@nfr-pii`; no new PII category introduced.
+- **Masking:** `mask_pii()` macro per
+  `docs/data/architecture/PII_HANDLING_CONTRACT.md`; hashed/synthetic in
+  all non-prod environments.
+
+### Lineage Impact
+
+- **Source-to-mart:** new edges `stripe.customers → stg → int →
+  dim_customers`, captured on every prod run.
+- **Column-level lineage:** required for the four PII-tagged columns.
+- **Tool entries:** register the two exposures; lineage destination TBD
+  (Datahub / OpenLineage / dbt Cloud — pick one).
+
+---
+
 ## 4. ADR Decision
 
 - TBD: ADR required if `dim_customers` materialization is **incremental**
@@ -101,34 +151,12 @@ Per `eval_criteria.yaml`:
 
 ---
 
-## 6. Evaluation Impact
+## 6. Risks & Unknowns
 
-The mart is downstream-facing — every change carries breaking-change risk
-for Looker + Hightouch consumers. Per `MODEL_LAYERING.md` (overlay) §4:
-"removing or renaming mart columns requires deprecation notice + consumer
-coordination."
-
-No L5 LLM evaluation applies (no generated text in this feature).
-
----
-
-## 7. ADR Determination
-
-See §4. Default: no ADR.
-
----
-
-## 8. Shared Contract Analysis
-
-- `source('stripe', 'customers')` — owned by the stripe-sync team; we
-  inherit their freshness contract. Document the dependency.
-- `mask_pii()` macro — shared across the project; no change needed.
-
----
-
-## 9. Preflight Conclusion
-
-Proceed with the plan in `plan.md`. No new contracts needed; no ADR
-required (assuming default `table` materialization). Confirm lineage
-tool choice with leadership before the lineage capture step (item 10 in
-the plan).
+- Lineage tool choice is open (Datahub / OpenLineage / dbt Cloud) —
+  confirm with leadership before the lineage capture step.
+- `stripe.customers` freshness SLA is inherited, not controlled here; a
+  breach upstream shows as our staleness alert.
+- Every `dim_customers` change is downstream-facing (Looker + Hightouch)
+  — breaking-change risk is carried by the Contract Impact checklist
+  above, not by an API review.

--- a/features/starter_data/eval_criteria.yaml
+++ b/features/starter_data/eval_criteria.yaml
@@ -11,7 +11,7 @@
 #   threshold   — pass/fail boundary
 #   severity    — error blocks merge; warn surfaces in PR summary
 
-version: "1"
+version: 1
 mode: deterministic
 
 criteria:

--- a/features/starter_data/plan.md
+++ b/features/starter_data/plan.md
@@ -81,35 +81,6 @@ marts). No cross-layer shortcuts.
 
 ---
 
-## Predicted FIRST + Virtue scoring
-
-This section is required at L4+ before implementation begins. Replace TBD
-with predictions calibrated to your team's scoring rubric.
-
-```yaml
-evaluation_prediction:
-  first:
-    fast: TBD       # dbt test runtime
-    independent: TBD # test isolation (per-model schemas in CI)
-    repeatable: TBD
-    self-checking: TBD
-    timely: TBD
-    average: TBD    # must be >= 4.0 to proceed
-  virtues:
-    correctness: TBD
-    clarity: TBD
-    composability: TBD
-    coverage: TBD
-    consistency: TBD
-    cost: TBD
-    care: TBD
-    average: TBD    # must be >= 4.0 to proceed
-```
-
-If either average is below 4.0, revise the plan before writing code.
-
----
-
 ## Risks + Open Questions
 
 - **Source schema drift** — Stripe occasionally renames columns silently;

--- a/governance/data/schemas/eval_criteria.schema.json
+++ b/governance/data/schemas/eval_criteria.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:governed-ai-delivery:schemas:data-eval_criteria",
+  "title": "Data Eval Criteria Schema",
+  "description": "Evaluation criteria for data (--type data) features. Deliberately not the backend criterion shape: data criteria are checked by query results and CI test outcomes, so thresholds are predicate strings and there are no evaluator tools or LLM modes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "mode"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "description": "Schema version for the eval_criteria.yaml instance.",
+      "minimum": 1
+    },
+    "mode": {
+      "type": "string",
+      "description": "deterministic: criteria checked by queries + CI outcomes. none: no evaluation applies (requires rationale). LLM evaluation is not a data mode.",
+      "enum": ["deterministic", "none"]
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Required when mode is none. Explains why evaluation is not applicable."
+    },
+    "feature": {
+      "type": "string",
+      "description": "Optional. The feature name this eval_criteria.yaml belongs to."
+    },
+    "owner": {
+      "type": "string",
+      "description": "Optional. Team or role responsible for keeping criteria accurate."
+    },
+    "criteria": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/criterion" }
+    }
+  },
+
+  "allOf": [
+    {
+      "if": {
+        "properties": { "mode": { "const": "none" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "required": ["rationale"],
+        "properties": { "criteria": { "maxItems": 0 } }
+      }
+    },
+    {
+      "if": {
+        "properties": { "mode": { "const": "deterministic" } },
+        "required": ["mode"]
+      },
+      "then": {
+        "required": ["criteria"],
+        "properties": { "criteria": { "minItems": 1 } }
+      }
+    }
+  ],
+
+  "$defs": {
+    "criterion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "measurement", "threshold", "severity"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "Kebab-case identifier for the criterion."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "One sentence: what is being checked."
+        },
+        "measurement": {
+          "type": "string",
+          "minLength": 1,
+          "description": "How it is measured — a query, dbt test, CI script, or metric."
+        },
+        "threshold": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Pass/fail boundary as a predicate string (data thresholds are query predicates, not 0-1 floats)."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warn"],
+          "description": "error blocks merge; warn surfaces in the PR summary."
+        },
+        "tags": { "type": "array", "items": { "type": "string" } },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/governance/schemas/stack-overlay.schema.json
+++ b/governance/schemas/stack-overlay.schema.json
@@ -61,6 +61,22 @@
         }
       }
     },
+    "rules": {
+      "type": "array",
+      "description": "Agent rule sources this stack ships. Each entry replaces the type-default rule entry whose manifest src equals `replaces` (when present) and installs `src` (relative to the overlay dir) at `dest` (relative to the target). Rule files are govkit-owned: refreshed unconditionally on apply/upgrade/stack apply.",
+      "items": {
+        "type": "object",
+        "required": ["agent", "src", "dest"],
+        "additionalProperties": false,
+        "properties": {
+          "agent": {"type": "string", "minLength": 1},
+          "src": {"type": "string", "minLength": 1},
+          "dest": {"type": "string", "minLength": 1},
+          "replaces": {"type": "string", "minLength": 1},
+          "managed_block": {"type": "boolean"}
+        }
+      }
+    },
     "skill_context": {
       "type": "object",
       "description": "Stack facts merged into .govkit/skill_context.yaml under `stack` for skill consumers. Keys vary per stack (language, api_framework, unit_test, bdd_test, package_files, source_folder_hint, ...)."

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -84,3 +84,94 @@ def test_section_25_parity_across_all_skills():
     assert not mismatches, (
         f"Section 2.5 must be identical across all SKILL.md files; mismatches: {mismatches}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Data-native preflight sections (hardening plan Increment 6)
+# ---------------------------------------------------------------------------
+
+BACKEND_PREFLIGHT_PATHS = [
+    REPO_ROOT / "agents" / agent / "skills" / "backend" / "architecture-preflight" / "SKILL.md"
+    for agent in ("claude-code", "codex", "copilot")
+]
+BACKEND_SPEC_PLANNING_PATHS = [
+    REPO_ROOT / "agents" / agent / "skills" / "backend" / "spec-planning" / "SKILL.md"
+    for agent in ("claude-code", "codex", "copilot")
+]
+
+DATA_IMPACT_HEADING = "## 3.7 Data Impact"
+DATA_IMPACT_SUBSECTIONS = [
+    "### Pipeline Impact",
+    "### Contract Impact",
+    "### PII Impact",
+    "### Lineage Impact",
+]
+SPEC_PLANNING_DATA_HEADING = "### Data projects"
+
+
+@pytest.mark.parametrize(
+    "skill_path", BACKEND_PREFLIGHT_PATHS, ids=lambda p: p.parent.parent.parent.parent.name,
+)
+def test_preflight_has_data_impact_block(skill_path: Path):
+    """Data installs receive the backend preflight source; it must carry the
+    data-native impact sections (backend/UI reports skip them)."""
+    text = skill_path.read_text(encoding="utf-8")
+    assert DATA_IMPACT_HEADING in text
+    section = _extract_section(text, DATA_IMPACT_HEADING)
+    missing = [s for s in DATA_IMPACT_SUBSECTIONS if s not in section]
+    assert not missing, f"{skill_path.relative_to(REPO_ROOT)} missing: {missing}"
+
+
+def test_data_impact_block_parity_across_agents():
+    sections = {
+        p: _extract_section(p.read_text(encoding="utf-8"), DATA_IMPACT_HEADING)
+        for p in BACKEND_PREFLIGHT_PATHS
+    }
+    canonical = sections[BACKEND_PREFLIGHT_PATHS[0]]
+    mismatches = [
+        str(p.relative_to(REPO_ROOT)) for p, s in sections.items() if s != canonical
+    ]
+    assert not mismatches, f"Data Impact block must be identical: {mismatches}"
+
+
+@pytest.mark.parametrize(
+    "skill_path", BACKEND_SPEC_PLANNING_PATHS, ids=lambda p: p.parent.parent.parent.parent.name,
+)
+def test_spec_planning_has_data_projects_note(skill_path: Path):
+    """spec-planning must tell data projects which NFR categories to tag and
+    that data eval criteria are deterministic (no LLM evaluator tools)."""
+    text = skill_path.read_text(encoding="utf-8")
+    assert SPEC_PLANNING_DATA_HEADING in text
+    section = _extract_section(text, SPEC_PLANNING_DATA_HEADING)
+    for phrase in ("freshness", "quality", "pii", "lineage", "cost", "deterministic"):
+        assert phrase in section, (skill_path.relative_to(REPO_ROOT), phrase)
+
+
+def test_spec_planning_data_note_parity_across_agents():
+    sections = {
+        p: _extract_section(p.read_text(encoding="utf-8"), SPEC_PLANNING_DATA_HEADING)
+        for p in BACKEND_SPEC_PLANNING_PATHS
+    }
+    canonical = sections[BACKEND_SPEC_PLANNING_PATHS[0]]
+    mismatches = [
+        str(p.relative_to(REPO_ROOT)) for p, s in sections.items() if s != canonical
+    ]
+    assert not mismatches, f"Data projects note must be identical: {mismatches}"
+
+
+def test_starter_data_preflight_mirrors_skill_sections():
+    """The worked example must be exactly what the shipped skill produces:
+    every data-impact section the skill prescribes appears in the starter,
+    and the starter uses the skill's report section set."""
+    starter = (
+        REPO_ROOT / "features" / "starter_data" / "architecture_preflight.md"
+    ).read_text(encoding="utf-8")
+    for heading in DATA_IMPACT_SUBSECTIONS:
+        assert heading in starter, heading
+    for heading in (
+        "## 1. Summary", "## 2. Standards Check", "## 2.6 Extension Discovery",
+        "## 3. Boundary Analysis", "## 3.5 Repository Scope Analysis",
+        "## 3.7 Data Impact", "## 4. ADR Decision", "## 5. Tests Required",
+        "## 6. Risks & Unknowns",
+    ):
+        assert heading in starter, heading

--- a/tests/test_dbt_gate_checks.py
+++ b/tests/test_dbt_gate_checks.py
@@ -1,0 +1,177 @@
+"""Behavior tests for the dbt-gate embedded static checker.
+
+Increment 8 of the data-enforcement hardening plan: the gate converts the
+mart docs teams edit into checks the build runs — every mart model must
+declare an enforced dbt model contract and appear in at least one exposure.
+The pure-python checker is embedded in both platform gates via a heredoc;
+these tests extract it and execute it against fixtures, and pin the two
+embeddings identical so the platforms cannot drift.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_PATHS = {
+    "github": REPO_ROOT / "ci" / "github" / "dbt-gate.yml",
+    "azure": REPO_ROOT / "ci" / "azure" / "dbt-gate.yml",
+}
+
+
+def _extract_embedded_python(gate_path: Path) -> str:
+    """Pull the python heredoc body out of the gate's raw text, de-indented."""
+    raw = gate_path.read_text(encoding="utf-8")
+    start_marker = "python - <<'PY'\n"
+    start = raw.index(start_marker) + len(start_marker)
+    body_lines = []
+    for line in raw[start:].splitlines():
+        if line.strip() == "PY":
+            break
+        body_lines.append(line)
+    indent = min(
+        (len(line) - len(line.lstrip()) for line in body_lines if line.strip()),
+        default=0,
+    )
+    return "\n".join(line[indent:] for line in body_lines) + "\n"
+
+
+def _run_checker(tmp_path: Path) -> subprocess.CompletedProcess:
+    script = _extract_embedded_python(GATE_PATHS["github"])
+    return subprocess.run(
+        [sys.executable, "-"],
+        input=script,
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+
+
+def _write_fixture(
+    tmp_path: Path,
+    *,
+    contract: bool = True,
+    exposure: bool = True,
+    dbt_version: str | None = ">=1.5.0",
+) -> None:
+    project: dict = {"name": "fixture"}
+    if dbt_version:
+        project["require-dbt-version"] = dbt_version
+    (tmp_path / "dbt_project.yml").write_text(
+        yaml.safe_dump(project),
+        encoding="utf-8",
+    )
+    marts = tmp_path / "models" / "marts"
+    marts.mkdir(parents=True)
+    (marts / "dim_customers.sql").write_text(
+        "select 1 as customer_id\n",
+        encoding="utf-8",
+    )
+    model: dict = {
+        "name": "dim_customers",
+        "description": "Customer dimension",
+        "columns": [
+            {
+                "name": "customer_id",
+                "description": "Primary key",
+                "tests": ["unique", "not_null"],
+            }
+        ],
+    }
+    if contract:
+        model["config"] = {"contract": {"enforced": True}}
+    doc: dict = {"models": [model]}
+    if exposure:
+        doc["exposures"] = [
+            {
+                "name": "looker_customers",
+                "type": "dashboard",
+                "owner": {"name": "analytics"},
+                "depends_on": ["ref('dim_customers')"],
+            }
+        ]
+    (marts / "_customers.yml").write_text(yaml.safe_dump(doc), encoding="utf-8")
+
+
+def test_embedded_checker_identical_across_platforms():
+    scripts = {k: _extract_embedded_python(p) for k, p in GATE_PATHS.items()}
+    assert scripts["github"] == scripts["azure"]
+
+
+class TestMartContractChecks:
+    def test_contracted_and_exposed_mart_passes(self, tmp_path):
+        _write_fixture(tmp_path)
+        result = _run_checker(tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_mart_without_contract_fails(self, tmp_path):
+        _write_fixture(tmp_path, contract=False)
+        result = _run_checker(tmp_path)
+        assert result.returncode == 1
+        assert "contract" in result.stdout
+        assert "dim_customers" in result.stdout
+
+    def test_mart_without_exposure_fails(self, tmp_path):
+        _write_fixture(tmp_path, exposure=False)
+        result = _run_checker(tmp_path)
+        assert result.returncode == 1
+        assert "exposure" in result.stdout
+        assert "dim_customers" in result.stdout
+
+    def test_old_dbt_downgrades_contract_check_to_warning(self, tmp_path):
+        """Pre-1.5 dbt has no model contracts: the contract check warns with
+        an upgrade pointer instead of failing (conservative-gate philosophy).
+        The exposure check still applies."""
+        _write_fixture(tmp_path, contract=False, dbt_version=None)
+        result = _run_checker(tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "1.5" in result.stdout
+
+    def test_no_marts_dir_adds_no_mart_errors(self, tmp_path):
+        """Projects without models/marts/ (staging-only repos) see no mart
+        findings; the existing model checks still run."""
+        (tmp_path / "dbt_project.yml").write_text("name: fixture\n", encoding="utf-8")
+        staging = tmp_path / "models" / "staging"
+        staging.mkdir(parents=True)
+        (staging / "_stg.yml").write_text(
+            yaml.safe_dump(
+                {
+                    "models": [
+                        {
+                            "name": "stg_customers",
+                            "description": "staging",
+                            "columns": [
+                                {
+                                    "name": "customer_id",
+                                    "description": "pk",
+                                    "tests": ["unique", "not_null"],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = _run_checker(tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize("platform", sorted(GATE_PATHS))
+def test_gate_documents_project_evaluator_opt_in(platform):
+    text = GATE_PATHS[platform].read_text(encoding="utf-8")
+    assert "dbt-project-evaluator" in text
+
+
+@pytest.mark.parametrize("platform", sorted(GATE_PATHS))
+def test_gate_header_lists_mart_checks_as_blocking(platform):
+    text = GATE_PATHS[platform].read_text(encoding="utf-8")
+    assert "contract" in text
+    assert "exposure" in text

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -94,6 +94,48 @@ class TestRunDoctor:
 
 
 # ---------------------------------------------------------------------------
+# D015 — unexpanded skill tokens
+# ---------------------------------------------------------------------------
+
+
+class TestUnexpandedSkillTokens:
+    def test_flags_unexpanded_docs_area_token_in_installed_skill(self, tmp_path):
+        """Skill templating degrades by leaving {{docs_area}} in place when
+        the marker type is unknown; doctor must surface the leftover."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path)
+        skill = tmp_path / ".claude" / "skills" / "govkit-spec-planning"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: govkit-spec-planning\ndescription: x\n---\n"
+            "Read docs/{{docs_area}}/architecture/ first.\n",
+            encoding="utf-8",
+        )
+
+        findings = run_doctor(tmp_path)
+        hits = [f for f in findings if f.id == "D015"]
+        assert hits
+        assert hits[0].severity == "warning"
+        assert "{{docs_area}}" in hits[0].message
+
+    def test_expanded_skill_files_are_clean(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path)
+        skill = tmp_path / ".claude" / "skills" / "govkit-spec-planning"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: govkit-spec-planning\ndescription: x\n---\n"
+            "Read docs/backend/architecture/ first.\n",
+            encoding="utf-8",
+        )
+
+        findings = run_doctor(tmp_path)
+        assert [f for f in findings if f.id == "D015"] == []
+
+
+# ---------------------------------------------------------------------------
 # cmd_doctor — CLI dispatch + exit codes + monorepo discovery (A9)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -742,3 +742,93 @@ def test_overlay_has_yaml_language_server_modeline(stack_id):
     first_line = overlay_path.read_text(encoding="utf-8").splitlines()[0]
     assert first_line.startswith("# yaml-language-server: $schema=")
     assert "stack-overlay.schema.json" in first_line
+
+
+# ---------------------------------------------------------------------------
+# Data eval_criteria schema (hardening plan Increment 7)
+# ---------------------------------------------------------------------------
+
+DATA_EVAL_SCHEMA_PATH = REPO_ROOT / "governance" / "data" / "schemas" / "eval_criteria.schema.json"
+BACKEND_EVAL_SCHEMA_PATH = REPO_ROOT / "governance" / "backend" / "schemas" / "eval_criteria.schema.json"
+
+
+class TestDataEvalCriteriaSchema:
+    """Data eval criteria are checked by queries and CI outcomes, not
+    evaluator tools — deliberately not the backend criterion shape."""
+
+    def _schema(self) -> dict:
+        return json.loads(DATA_EVAL_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def _valid_criterion(self) -> dict:
+        return {
+            "id": "pk-uniqueness",
+            "description": "customer_id is unique",
+            "measurement": "dbt schema test (unique)",
+            "threshold": "zero rows with duplicate customer_id",
+            "severity": "error",
+        }
+
+    def test_schema_is_valid_json_schema(self):
+        Draft202012Validator.check_schema(self._schema())
+
+    def test_data_starter_validates(self):
+        import yaml
+
+        instance = yaml.safe_load(
+            (REPO_ROOT / "features" / "starter_data" / "eval_criteria.yaml")
+            .read_text(encoding="utf-8"),
+        )
+        errors = list(Draft202012Validator(self._schema()).iter_errors(instance))
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_backend_starter_still_validates_against_backend_schema(self):
+        import yaml
+
+        schema = json.loads(BACKEND_EVAL_SCHEMA_PATH.read_text(encoding="utf-8"))
+        instance = yaml.safe_load(
+            (REPO_ROOT / "features" / "starter_backend" / "eval_criteria.yaml")
+            .read_text(encoding="utf-8"),
+        )
+        errors = list(Draft202012Validator(schema).iter_errors(instance))
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_rejects_llm_mode(self):
+        instance = {"version": 1, "mode": "llm", "criteria": [self._valid_criterion()]}
+        assert list(Draft202012Validator(self._schema()).iter_errors(instance))
+
+    def test_rejects_string_version(self):
+        instance = {"version": "1", "mode": "deterministic", "criteria": [self._valid_criterion()]}
+        assert list(Draft202012Validator(self._schema()).iter_errors(instance))
+
+    def test_rejects_numeric_threshold(self):
+        crit = self._valid_criterion()
+        crit["threshold"] = 0.9
+        instance = {"version": 1, "mode": "deterministic", "criteria": [crit]}
+        assert list(Draft202012Validator(self._schema()).iter_errors(instance))
+
+    def test_rejects_backend_criterion_shape(self):
+        instance = {
+            "version": 1, "mode": "deterministic",
+            "criteria": [{
+                "name": "output_structure", "eval_class": "structure_validator",
+                "threshold": 0.9, "fail_on": "below_threshold",
+            }],
+        }
+        assert list(Draft202012Validator(self._schema()).iter_errors(instance))
+
+    def test_mode_none_requires_rationale(self):
+        validator = Draft202012Validator(self._schema())
+        assert list(validator.iter_errors({"version": 1, "mode": "none"}))
+        assert not list(validator.iter_errors(
+            {"version": 1, "mode": "none", "rationale": "no data outputs in this feature"},
+        ))
+
+    @pytest.mark.parametrize("agent", _all_agents())
+    def test_data_variant_installs_schema_dir(self, agent):
+        """The data L4 install must ship the schema so local validate goes
+        from WARN to real instance validation."""
+        manifest = _load_manifest(agent)
+        governed = (
+            manifest["variants"]["type"]["data"].get("level_4", {}).get("governed", [])
+        )
+        assert "governance/data/schemas/" in governed, agent

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -56,8 +56,43 @@ class TestWriteSkillContext:
         assert "architecture" in data
         assert "stack" in data
         assert "ci" in data
+        assert "docs_area" in data
         assert "llm" in data
         assert "extensions" in data
+
+    def test_docs_area_derived_from_marker_type(self, tmp_path):
+        """docs_area follows options.type so installed skills can be
+        templated to the type's docs tree (docs/<area>/architecture/)."""
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        for marker_type, expected in [
+            ("api", "backend"), ("cli", "backend"),
+            ("ui-react", "ui"), ("ui-angular", "ui"),
+            ("data", "data"),
+        ]:
+            marker = _write_marker(
+                tmp_path, options={"type": marker_type, "ci": "github"},
+            )
+            write_skill_context(tmp_path, marker)
+            data = yaml.safe_load(
+                (tmp_path / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+            )
+            assert data["docs_area"] == expected, marker_type
+
+    def test_docs_area_empty_when_type_missing_or_unknown(self, tmp_path):
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        for options in ({"ci": "github"}, {"type": "mainframe", "ci": "github"}):
+            marker = _write_marker(tmp_path, options=options)
+            write_skill_context(tmp_path, marker)
+            data = yaml.safe_load(
+                (tmp_path / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+            )
+            assert data["docs_area"] == "", options
 
     def test_stack_section_pulls_from_marker_and_overlay(self, tmp_path):
         import yaml
@@ -396,3 +431,27 @@ class TestLoadSkillContextMalformedBlocks:
         assert isinstance(ctx.extensions, list)
         # Same anti-splat rule: characters are not extensions.
         assert all(isinstance(e, dict) for e in ctx.extensions)
+
+
+class TestLoadSkillContextDocsArea:
+    def _write(self, target: Path, text: str) -> None:
+        (target / ".govkit").mkdir(parents=True, exist_ok=True)
+        (target / ".govkit" / "skill_context.yaml").write_text(text, encoding="utf-8")
+
+    def test_docs_area_round_trips(self, tmp_path):
+        from cli.skill_context import load_skill_context
+        self._write(tmp_path, "architecture:\n  style: hexagonal\nstack: {}\ndocs_area: data\n")
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.docs_area == "data"
+
+    def test_docs_area_missing_or_malformed_is_empty(self, tmp_path):
+        from cli.skill_context import load_skill_context
+        for body in (
+            "architecture:\n  style: hexagonal\nstack: {}\n",
+            "architecture:\n  style: hexagonal\nstack: {}\ndocs_area: [data]\n",
+        ):
+            self._write(tmp_path, body)
+            ctx = load_skill_context(tmp_path)
+            assert ctx is not None
+            assert ctx.docs_area == ""

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -455,3 +455,50 @@ class TestLoadSkillContextDocsArea:
             ctx = load_skill_context(tmp_path)
             assert ctx is not None
             assert ctx.docs_area == ""
+
+
+class TestPiiKeywordList:
+    def test_write_seeds_default_keyword_list(self, tmp_path):
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        write_skill_context(tmp_path, marker)
+        data = yaml.safe_load(
+            (tmp_path / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+        )
+        assert data["pii"]["keyword_list"] == [
+            "email", "phone", "ssn", "dob", "birth", "address", "name",
+        ]
+
+    def test_rewrite_preserves_team_tuned_list(self, tmp_path):
+        """upgrade/stack apply regenerate skill_context.yaml; a tuned
+        keyword_list must survive the rewrite."""
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        write_skill_context(tmp_path, marker)
+        path = tmp_path / ".govkit" / "skill_context.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data["pii"]["keyword_list"] = ["email", "iban", "national_id"]
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+        write_skill_context(tmp_path, marker)
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        assert data["pii"]["keyword_list"] == ["email", "iban", "national_id"]
+
+    def test_load_returns_pii_keywords(self, tmp_path):
+        from cli.skill_context import load_skill_context
+
+        (tmp_path / ".govkit").mkdir(parents=True)
+        (tmp_path / ".govkit" / "skill_context.yaml").write_text(
+            "architecture: {}\nstack: {}\npii:\n  keyword_list: [email, iban]\n",
+            encoding="utf-8",
+        )
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.pii_keywords == ["email", "iban"]

--- a/tests/test_skill_templating.py
+++ b/tests/test_skill_templating.py
@@ -1,0 +1,199 @@
+"""Tests for cli/skill_templating.py — install-time {{docs_area}} expansion.
+
+Increment 5 of the data-enforcement hardening plan: skill sources reference
+docs/{{docs_area}}/... instead of hardcoding docs/backend/, and the token is
+expanded at install time from skill_context (agents cannot resolve it at
+runtime). Degradation mirrors rule templating: an unresolvable token is left
+in the text for doctor to flag, never guessed.
+"""
+
+import pytest
+
+
+class TestExpandSkillTokens:
+    def test_replaces_docs_area_token(self):
+        from cli.skill_templating import expand_skill_tokens
+
+        text = "Read docs/{{docs_area}}/architecture/BOUNDARIES.md first."
+        out = expand_skill_tokens(text, "data")
+        assert out == "Read docs/data/architecture/BOUNDARIES.md first."
+
+    def test_replaces_every_occurrence(self):
+        from cli.skill_templating import expand_skill_tokens
+
+        text = "docs/{{docs_area}}/architecture/ and docs/{{docs_area}}/evaluation/"
+        out = expand_skill_tokens(text, "backend")
+        assert out == "docs/backend/architecture/ and docs/backend/evaluation/"
+
+    def test_empty_docs_area_leaves_token_in_place(self):
+        from cli.skill_templating import expand_skill_tokens
+
+        text = "Read docs/{{docs_area}}/architecture/."
+        assert expand_skill_tokens(text, "") == text
+
+    def test_unknown_tokens_are_left_untouched(self):
+        from cli.skill_templating import expand_skill_tokens
+
+        text = "docs/{{docs_area}}/x and {{other_token}} stays"
+        out = expand_skill_tokens(text, "ui")
+        assert "docs/ui/x" in out
+        assert "{{other_token}}" in out
+
+    def test_text_without_tokens_unchanged(self):
+        from cli.skill_templating import expand_skill_tokens
+
+        assert expand_skill_tokens("plain text\n", "backend") == "plain text\n"
+
+
+AGENT_SKILLS_DIRS = [
+    ("claude-code", ".claude/skills"),
+    ("codex", ".agents/skills"),
+    ("copilot", ".github/skills"),
+]
+
+
+class TestAgentLayoutSkillsDir:
+    def test_layouts_declare_skills_dirs(self):
+        from cli.agent_layout import AGENT_LAYOUTS
+
+        for agent, skills_dir in AGENT_SKILLS_DIRS:
+            assert AGENT_LAYOUTS[agent].skills_dir == skills_dir
+
+
+class TestTemplateInstalledSkills:
+    def _install_skill(self, target, skills_dir, name="govkit-spec-planning"):
+        d = target / skills_dir / name
+        d.mkdir(parents=True, exist_ok=True)
+        f = d / "SKILL.md"
+        f.write_text(
+            "---\nname: govkit-spec-planning\ndescription: plan a spec\n---\n"
+            "Read docs/{{docs_area}}/architecture/BOUNDARIES.md\n",
+            encoding="utf-8",
+        )
+        return f
+
+    @pytest.mark.parametrize("agent,skills_dir", AGENT_SKILLS_DIRS)
+    def test_rewrites_installed_skill_files(self, tmp_path, agent, skills_dir):
+        from cli.skill_templating import template_installed_skills
+
+        f = self._install_skill(tmp_path, skills_dir)
+        count = template_installed_skills(tmp_path, agent, "data")
+
+        assert count == 1
+        text = f.read_text(encoding="utf-8")
+        assert "docs/data/architecture/BOUNDARIES.md" in text
+        assert "{{docs_area}}" not in text
+
+    def test_empty_docs_area_is_noop(self, tmp_path):
+        from cli.skill_templating import template_installed_skills
+
+        f = self._install_skill(tmp_path, ".claude/skills")
+        count = template_installed_skills(tmp_path, "claude-code", "")
+
+        assert count == 0
+        assert "{{docs_area}}" in f.read_text(encoding="utf-8")
+
+    def test_unknown_agent_is_noop(self, tmp_path):
+        from cli.skill_templating import template_installed_skills
+
+        self._install_skill(tmp_path, ".claude/skills")
+        assert template_installed_skills(tmp_path, "custom-agent", "data") == 0
+
+    def test_missing_skills_dir_is_noop(self, tmp_path):
+        from cli.skill_templating import template_installed_skills
+
+        assert template_installed_skills(tmp_path, "claude-code", "data") == 0
+
+    def test_files_without_tokens_are_not_counted(self, tmp_path):
+        from cli.skill_templating import template_installed_skills
+
+        d = tmp_path / ".claude" / "skills" / "govkit-adr-author"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text("---\nname: x\n---\nNo tokens here.\n", encoding="utf-8")
+
+        assert template_installed_skills(tmp_path, "claude-code", "data") == 0
+
+
+# The four backend skill sources that install for non-backend types (data L4
+# installs all of them). L5-only skills keep literal docs/backend/ — their
+# extension contract paths are backend-real, and data has no L5.
+TOKENIZED_SKILLS = [
+    "adr-author",
+    "spec-planning",
+    "architecture-preflight",
+    "implementation-plan",
+]
+
+
+class TestSkillSourcesTokenized:
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    def test_planning_skill_sources_carry_token_not_literal(self, agent):
+        """Source-level parity guard: the tokenized skills must reference
+        docs/{{docs_area}}/ in every agent, never a hardcoded docs/backend/."""
+        from cli import paths
+
+        for skill in TOKENIZED_SKILLS:
+            src = paths.AGENTS_DIR / agent / "skills" / "backend" / skill / "SKILL.md"
+            text = src.read_text(encoding="utf-8")
+            assert "docs/backend/" not in text, (agent, skill)
+            assert "{{docs_area}}" in text, (agent, skill)
+
+
+class TestApplyExpandsSkillDocsArea:
+    @pytest.mark.parametrize("agent,skills_dir", AGENT_SKILLS_DIRS)
+    def test_data_install_skills_cite_data_docs(self, tmp_path, agent, skills_dir):
+        """The increment's guard: after apply --type data, no installed skill
+        file contains the literal docs/backend/ and no token survives."""
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "project"
+        target.mkdir()
+        cmd_apply(
+            argparse.Namespace(
+                agent=agent,
+                target=str(target),
+                level="4",
+                type="data",
+                ci="github",
+                stack="databricks-lakehouse",
+                force=False,
+                detect=False,
+            )
+        )
+
+        skill_files = sorted((target / skills_dir).rglob("*.md"))
+        assert skill_files
+        joined = ""
+        for f in skill_files:
+            text = f.read_text(encoding="utf-8")
+            assert "docs/backend/" not in text, f
+            assert "{{docs_area}}" not in text, f
+            joined += text
+        assert "docs/data/architecture" in joined
+
+    def test_api_install_skills_still_cite_backend_docs(self, tmp_path):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "project"
+        target.mkdir()
+        cmd_apply(
+            argparse.Namespace(
+                agent="claude-code",
+                target=str(target),
+                level="4",
+                type="api",
+                ci="github",
+                stack="python-fastapi",
+                force=False,
+                detect=False,
+            )
+        )
+
+        spec = target / ".claude" / "skills" / "govkit-spec-planning" / "SKILL.md"
+        text = spec.read_text(encoding="utf-8")
+        assert "docs/backend/architecture" in text
+        assert "{{docs_area}}" not in text

--- a/tests/test_skill_templating.py
+++ b/tests/test_skill_templating.py
@@ -139,6 +139,121 @@ class TestSkillSourcesTokenized:
             assert "{{docs_area}}" in text, (agent, skill)
 
 
+class TestPiiKeywordTemplating:
+    """Increment 10: the PII keyword list lives in skill_context, and rule
+    bodies carry {{pii_keywords}} rendered at install time."""
+
+    def test_render_pii_keywords(self):
+        from cli.skill_templating import render_pii_keywords
+
+        assert render_pii_keywords(["email", "ssn"]) == "`email`, `ssn`"
+
+    def test_expands_token_in_rules_dir(self, tmp_path):
+        from cli.skill_templating import template_installed_rule_bodies
+
+        rule = tmp_path / ".claude" / "rules" / "govkit" / "staging.md"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("PII list ({{pii_keywords}}) MUST be tagged\n", encoding="utf-8")
+
+        count = template_installed_rule_bodies(tmp_path, "claude-code", ["email", "dob"])
+
+        assert count == 1
+        text = rule.read_text(encoding="utf-8")
+        assert "`email`, `dob`" in text
+        assert "{{pii_keywords}}" not in text
+
+    def test_expands_codex_nested_blocks_and_plain_rules(self, tmp_path):
+        from cli.skill_templating import template_installed_rule_bodies
+
+        nested = tmp_path / "models" / "staging" / "AGENTS.md"
+        nested.parent.mkdir(parents=True)
+        nested.write_text("list ({{pii_keywords}})\n", encoding="utf-8")
+        plain = tmp_path / ".agents" / "rules" / "bronze.md"
+        plain.parent.mkdir(parents=True)
+        plain.write_text("list ({{pii_keywords}})\n", encoding="utf-8")
+
+        count = template_installed_rule_bodies(tmp_path, "codex", ["email"])
+
+        assert count == 2
+        assert "`email`" in nested.read_text(encoding="utf-8")
+        assert "`email`" in plain.read_text(encoding="utf-8")
+
+    def test_empty_keyword_list_leaves_token(self, tmp_path):
+        from cli.skill_templating import template_installed_rule_bodies
+
+        rule = tmp_path / ".claude" / "rules" / "govkit" / "staging.md"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("({{pii_keywords}})\n", encoding="utf-8")
+
+        assert template_installed_rule_bodies(tmp_path, "claude-code", []) == 0
+        assert "{{pii_keywords}}" in rule.read_text(encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "src",
+        [
+            "agents/claude-code/rules/data/staging.md",
+            "agents/codex/rules/data/staging.md",
+            "agents/copilot/instructions/data/staging.instructions.md",
+        ],
+    )
+    def test_staging_sources_carry_token_not_literal_list(self, src):
+        from cli import paths
+
+        text = (paths.REPO_ROOT / src).read_text(encoding="utf-8")
+        assert "{{pii_keywords}}" in text
+        assert "`ssn`,\n`dob`" not in text
+
+    def test_data_install_renders_pii_list_claude(self, tmp_path):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "p"
+        target.mkdir()
+        cmd_apply(
+            argparse.Namespace(
+                agent="claude-code",
+                target=str(target),
+                level="4",
+                type="data",
+                ci="github",
+                stack="python-dbt",
+                force=False,
+                detect=False,
+            )
+        )
+
+        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(
+            encoding="utf-8"
+        )
+        assert "`email`, `phone`, `ssn`, `dob`, `birth`, `address`, `name`" in staging
+        assert "{{pii_keywords}}" not in staging
+
+    def test_data_install_renders_pii_list_codex_nested_block(self, tmp_path):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "p"
+        target.mkdir()
+        cmd_apply(
+            argparse.Namespace(
+                agent="codex",
+                target=str(target),
+                level="4",
+                type="data",
+                ci="github",
+                stack="python-dbt",
+                force=False,
+                detect=False,
+            )
+        )
+
+        nested = (target / "models" / "staging" / "AGENTS.md").read_text(encoding="utf-8")
+        assert "`email`, `phone`, `ssn`" in nested
+        assert "{{pii_keywords}}" not in nested
+
+
 class TestApplyExpandsSkillDocsArea:
     @pytest.mark.parametrize("agent,skills_dir", AGENT_SKILLS_DIRS)
     def test_data_install_skills_cite_data_docs(self, tmp_path, agent, skills_dir):

--- a/tests/test_stack_rules.py
+++ b/tests/test_stack_rules.py
@@ -1,0 +1,212 @@
+"""Tests for stack-overlaid agent rules (hardening plan Increment 9).
+
+A stack overlay may ship `rules:` that replace the type-default rule set for
+the overlapping entries — databricks-lakehouse ships medallion-worded layer
+rules (bronze/silver/gold) while python-dbt keeps the dbt defaults.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+STACK_DIR = REPO_ROOT / "cli" / "stacks" / "databricks-lakehouse"
+
+
+def _apply(target: Path, agent: str, stack: str) -> None:
+    from cli.cmd_apply import cmd_apply
+
+    cmd_apply(argparse.Namespace(
+        agent=agent, target=str(target),
+        level="4", type="data", ci="github",
+        stack=stack, force=False, detect=False,
+    ))
+
+
+class TestApplyRuleOverrides:
+    def _overlay(self, tmp_path, rules):
+        from cli.overlay import Overlay
+
+        root = tmp_path / "stack"
+        root.mkdir(exist_ok=True)
+        return Overlay(
+            id="test-stack", root=root, version="0.1.0",
+            display_name="Test", summary="", rules=rules,
+        )
+
+    def test_replaces_matching_entry_and_points_at_overlay(self, tmp_path):
+        from cli.overlay import apply_rule_overrides
+
+        overlay = self._overlay(tmp_path, [{
+            "agent": "claude-code",
+            "src": "rules/bronze.md",
+            "dest": ".claude/rules/govkit/staging.md",
+            "replaces": "rules/data/staging.md",
+        }])
+        (overlay.root / "rules").mkdir()
+        (overlay.root / "rules" / "bronze.md").write_text("# Bronze\n", encoding="utf-8")
+
+        files = [
+            {"src": "rules/data/staging.md", "dest": ".claude/rules/govkit/staging.md"},
+            {"src": "rules/data/pii.md", "dest": ".claude/rules/govkit/pii.md"},
+        ]
+        out = apply_rule_overrides(files, overlay, "claude-code")
+
+        srcs = [e["src"] for e in out]
+        assert "rules/data/staging.md" not in srcs
+        assert "rules/data/pii.md" in srcs
+        override = next(e for e in out if e["src"] == "rules/bronze.md")
+        assert override["src_root"] == str(overlay.root)
+        assert override["dest"] == ".claude/rules/govkit/staging.md"
+
+    def test_missing_overlay_source_keeps_type_default(self, tmp_path):
+        from cli.overlay import apply_rule_overrides
+
+        overlay = self._overlay(tmp_path, [{
+            "agent": "claude-code",
+            "src": "rules/not-there.md",
+            "dest": ".claude/rules/govkit/staging.md",
+            "replaces": "rules/data/staging.md",
+        }])
+        files = [{"src": "rules/data/staging.md", "dest": ".claude/rules/govkit/staging.md"}]
+
+        out = apply_rule_overrides(files, overlay, "claude-code")
+        assert out == files
+
+    def test_other_agents_entries_are_ignored(self, tmp_path):
+        from cli.overlay import apply_rule_overrides
+
+        overlay = self._overlay(tmp_path, [{
+            "agent": "codex", "src": "rules/bronze.md", "dest": ".agents/rules/bronze.md",
+        }])
+        files = [{"src": "rules/data/staging.md", "dest": ".claude/rules/govkit/staging.md"}]
+
+        assert apply_rule_overrides(files, overlay, "claude-code") == files
+
+    def test_no_overlay_or_no_rules_is_noop(self, tmp_path):
+        from cli.overlay import apply_rule_overrides
+
+        files = [{"src": "a", "dest": "b"}]
+        assert apply_rule_overrides(files, None, "claude-code") == files
+        assert apply_rule_overrides(files, self._overlay(tmp_path, []), "claude-code") == files
+
+
+class TestMedallionSourcesParity:
+    LAYERS = ("bronze", "silver", "gold")
+
+    def _body(self, text: str) -> str:
+        if text.startswith("---"):
+            return text.split("---", 2)[2].lstrip("\n")
+        return text
+
+    @pytest.mark.parametrize("layer", LAYERS)
+    def test_bodies_identical_across_agents(self, layer):
+        texts = {
+            "claude-code": (STACK_DIR / "rules" / "claude-code" / f"{layer}.md").read_text(encoding="utf-8"),
+            "copilot": (STACK_DIR / "rules" / "copilot" / f"{layer}.instructions.md").read_text(encoding="utf-8"),
+            "codex": (STACK_DIR / "rules" / "codex" / f"{layer}.md").read_text(encoding="utf-8"),
+        }
+        bodies = {agent: self._body(t) for agent, t in texts.items()}
+        assert bodies["claude-code"] == bodies["copilot"] == bodies["codex"]
+
+    @pytest.mark.parametrize("layer", LAYERS)
+    def test_bodies_are_medallion_not_dbt_worded(self, layer):
+        body = (STACK_DIR / "rules" / "codex" / f"{layer}.md").read_text(encoding="utf-8")
+        assert "{{ source(" not in body
+        assert "stg_<source>" not in body
+
+
+class TestDataInstallStackRules:
+    def test_databricks_claude_rules_are_medallion(self, tmp_path):
+        target = tmp_path / "p"
+        target.mkdir()
+        _apply(target, "claude-code", "databricks-lakehouse")
+
+        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(encoding="utf-8")
+        assert "Bronze Layer" in staging
+        assert "{{ source(" not in staging
+        assert "**/bronze/**" in staging
+        marts = (target / ".claude" / "rules" / "govkit" / "marts.md").read_text(encoding="utf-8")
+        assert "Gold Layer" in marts
+
+    def test_databricks_codex_rules_are_plain_files_not_nested_blocks(self, tmp_path):
+        target = tmp_path / "p"
+        target.mkdir()
+        _apply(target, "codex", "databricks-lakehouse")
+
+        assert (target / ".agents" / "rules" / "bronze.md").is_file()
+        assert (target / ".agents" / "rules" / "gold.md").is_file()
+        # The dbt-specific nested AGENTS.md blocks must not be created in a
+        # medallion repo (there is no models/ tree to scope them to).
+        assert not (target / "models").exists()
+
+    def test_databricks_copilot_rules_are_medallion(self, tmp_path):
+        target = tmp_path / "p"
+        target.mkdir()
+        _apply(target, "copilot", "databricks-lakehouse")
+
+        staging = (
+            target / ".github" / "instructions" / "govkit" / "staging.instructions.md"
+        ).read_text(encoding="utf-8")
+        assert "Bronze Layer" in staging
+        assert "applyTo" in staging
+
+    def test_python_dbt_rules_stay_dbt_worded(self, tmp_path):
+        target = tmp_path / "p"
+        target.mkdir()
+        _apply(target, "claude-code", "python-dbt")
+
+        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(encoding="utf-8")
+        assert "{{ source(" in staging
+        assert "Bronze" not in staging
+
+
+class TestStackApplySwapsRules:
+    def test_swap_to_databricks_and_back(self, tmp_path):
+        from cli.cmd_stack import cmd_stack_apply
+
+        target = tmp_path / "p"
+        target.mkdir()
+        _apply(target, "claude-code", "python-dbt")
+        staging = target / ".claude" / "rules" / "govkit" / "staging.md"
+        assert "{{ source(" in staging.read_text(encoding="utf-8")
+
+        cmd_stack_apply(argparse.Namespace(
+            stack_id="databricks-lakehouse", target=str(target), force=False,
+        ))
+        assert "Bronze Layer" in staging.read_text(encoding="utf-8")
+
+        cmd_stack_apply(argparse.Namespace(
+            stack_id="python-dbt", target=str(target), force=False,
+        ))
+        text = staging.read_text(encoding="utf-8")
+        assert "{{ source(" in text
+        assert "Bronze Layer" not in text
+
+
+class TestMedallionGlobsResolve:
+    def test_doctor_d001_clean_when_bronze_dirs_exist(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        target = tmp_path / "p"
+        target.mkdir()
+        for layer in ("bronze", "silver", "gold"):
+            (target / "src" / layer).mkdir(parents=True)
+        _apply(target, "claude-code", "databricks-lakehouse")
+
+        findings = run_doctor(target)
+        d001 = [f for f in findings if f.id == "D001" and "bronze" in f.message]
+        assert d001 == [], [f.message for f in d001]
+
+    def test_doctor_d001_flags_missing_medallion_dirs(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        target = tmp_path / "p"
+        target.mkdir()
+        _apply(target, "claude-code", "databricks-lakehouse")
+
+        findings = run_doctor(target)
+        assert any(f.id == "D001" and "bronze" in f.message for f in findings)

--- a/tests/test_stack_rules.py
+++ b/tests/test_stack_rules.py
@@ -19,11 +19,18 @@ STACK_DIR = REPO_ROOT / "cli" / "stacks" / "databricks-lakehouse"
 def _apply(target: Path, agent: str, stack: str) -> None:
     from cli.cmd_apply import cmd_apply
 
-    cmd_apply(argparse.Namespace(
-        agent=agent, target=str(target),
-        level="4", type="data", ci="github",
-        stack=stack, force=False, detect=False,
-    ))
+    cmd_apply(
+        argparse.Namespace(
+            agent=agent,
+            target=str(target),
+            level="4",
+            type="data",
+            ci="github",
+            stack=stack,
+            force=False,
+            detect=False,
+        )
+    )
 
 
 class TestApplyRuleOverrides:
@@ -33,19 +40,28 @@ class TestApplyRuleOverrides:
         root = tmp_path / "stack"
         root.mkdir(exist_ok=True)
         return Overlay(
-            id="test-stack", root=root, version="0.1.0",
-            display_name="Test", summary="", rules=rules,
+            id="test-stack",
+            root=root,
+            version="0.1.0",
+            display_name="Test",
+            summary="",
+            rules=rules,
         )
 
     def test_replaces_matching_entry_and_points_at_overlay(self, tmp_path):
         from cli.overlay import apply_rule_overrides
 
-        overlay = self._overlay(tmp_path, [{
-            "agent": "claude-code",
-            "src": "rules/bronze.md",
-            "dest": ".claude/rules/govkit/staging.md",
-            "replaces": "rules/data/staging.md",
-        }])
+        overlay = self._overlay(
+            tmp_path,
+            [
+                {
+                    "agent": "claude-code",
+                    "src": "rules/bronze.md",
+                    "dest": ".claude/rules/govkit/staging.md",
+                    "replaces": "rules/data/staging.md",
+                }
+            ],
+        )
         (overlay.root / "rules").mkdir()
         (overlay.root / "rules" / "bronze.md").write_text("# Bronze\n", encoding="utf-8")
 
@@ -65,12 +81,17 @@ class TestApplyRuleOverrides:
     def test_missing_overlay_source_keeps_type_default(self, tmp_path):
         from cli.overlay import apply_rule_overrides
 
-        overlay = self._overlay(tmp_path, [{
-            "agent": "claude-code",
-            "src": "rules/not-there.md",
-            "dest": ".claude/rules/govkit/staging.md",
-            "replaces": "rules/data/staging.md",
-        }])
+        overlay = self._overlay(
+            tmp_path,
+            [
+                {
+                    "agent": "claude-code",
+                    "src": "rules/not-there.md",
+                    "dest": ".claude/rules/govkit/staging.md",
+                    "replaces": "rules/data/staging.md",
+                }
+            ],
+        )
         files = [{"src": "rules/data/staging.md", "dest": ".claude/rules/govkit/staging.md"}]
 
         out = apply_rule_overrides(files, overlay, "claude-code")
@@ -79,9 +100,16 @@ class TestApplyRuleOverrides:
     def test_other_agents_entries_are_ignored(self, tmp_path):
         from cli.overlay import apply_rule_overrides
 
-        overlay = self._overlay(tmp_path, [{
-            "agent": "codex", "src": "rules/bronze.md", "dest": ".agents/rules/bronze.md",
-        }])
+        overlay = self._overlay(
+            tmp_path,
+            [
+                {
+                    "agent": "codex",
+                    "src": "rules/bronze.md",
+                    "dest": ".agents/rules/bronze.md",
+                }
+            ],
+        )
         files = [{"src": "rules/data/staging.md", "dest": ".claude/rules/govkit/staging.md"}]
 
         assert apply_rule_overrides(files, overlay, "claude-code") == files
@@ -105,8 +133,12 @@ class TestMedallionSourcesParity:
     @pytest.mark.parametrize("layer", LAYERS)
     def test_bodies_identical_across_agents(self, layer):
         texts = {
-            "claude-code": (STACK_DIR / "rules" / "claude-code" / f"{layer}.md").read_text(encoding="utf-8"),
-            "copilot": (STACK_DIR / "rules" / "copilot" / f"{layer}.instructions.md").read_text(encoding="utf-8"),
+            "claude-code": (STACK_DIR / "rules" / "claude-code" / f"{layer}.md").read_text(
+                encoding="utf-8"
+            ),
+            "copilot": (STACK_DIR / "rules" / "copilot" / f"{layer}.instructions.md").read_text(
+                encoding="utf-8"
+            ),
             "codex": (STACK_DIR / "rules" / "codex" / f"{layer}.md").read_text(encoding="utf-8"),
         }
         bodies = {agent: self._body(t) for agent, t in texts.items()}
@@ -125,7 +157,9 @@ class TestDataInstallStackRules:
         target.mkdir()
         _apply(target, "claude-code", "databricks-lakehouse")
 
-        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(encoding="utf-8")
+        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(
+            encoding="utf-8"
+        )
         assert "Bronze Layer" in staging
         assert "{{ source(" not in staging
         assert "**/bronze/**" in staging
@@ -159,7 +193,9 @@ class TestDataInstallStackRules:
         target.mkdir()
         _apply(target, "claude-code", "python-dbt")
 
-        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(encoding="utf-8")
+        staging = (target / ".claude" / "rules" / "govkit" / "staging.md").read_text(
+            encoding="utf-8"
+        )
         assert "{{ source(" in staging
         assert "Bronze" not in staging
 
@@ -174,14 +210,22 @@ class TestStackApplySwapsRules:
         staging = target / ".claude" / "rules" / "govkit" / "staging.md"
         assert "{{ source(" in staging.read_text(encoding="utf-8")
 
-        cmd_stack_apply(argparse.Namespace(
-            stack_id="databricks-lakehouse", target=str(target), force=False,
-        ))
+        cmd_stack_apply(
+            argparse.Namespace(
+                stack_id="databricks-lakehouse",
+                target=str(target),
+                force=False,
+            )
+        )
         assert "Bronze Layer" in staging.read_text(encoding="utf-8")
 
-        cmd_stack_apply(argparse.Namespace(
-            stack_id="python-dbt", target=str(target), force=False,
-        ))
+        cmd_stack_apply(
+            argparse.Namespace(
+                stack_id="python-dbt",
+                target=str(target),
+                force=False,
+            )
+        )
         text = staging.read_text(encoding="utf-8")
         assert "{{ source(" in text
         assert "Bronze Layer" not in text

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -767,6 +767,71 @@ class TestCheckGherkinNfrCoverage:
 
 
 # ---------------------------------------------------------------------------
+# Data prediction gate (ADR-0001)
+# ---------------------------------------------------------------------------
+
+
+class TestDataPredictionGate:
+    def _data_target(self, tmp_path, marker_type="data"):
+        target = tmp_path / "target"
+        feature = target / "features" / "feat"
+        write(feature / "acceptance.feature", """\
+            Feature: Sample
+
+              @nfr-performance
+              Scenario: Fast
+                Given load
+                When request
+                Then fast
+
+              @nfr-security
+              Scenario: Secure
+                Given auth
+                When request
+                Then authorized
+        """)
+        write(feature / "nfrs.md", VALID_NFRS)
+        write(feature / "eval_criteria.yaml", VALID_EVAL_CRITERIA)
+        write(feature / "architecture_preflight.md", "# Preflight\n\nDone.\n")
+        write(feature / "plan.md", "# Plan\n\nSteps only — no prediction block.\n")
+        (target / ".govkit").mkdir(parents=True, exist_ok=True)
+        (target / ".govkit" / "marker.json").write_text(json.dumps({
+            "version": "0.14.0", "level": "4", "agent": "claude-code",
+            "options": {"type": marker_type, "ci": "github"},
+        }), encoding="utf-8")
+        return target
+
+    def test_data_feature_passes_without_prediction_block(self, tmp_path):
+        """ADR-0001: data features carry no FIRST/Virtue self-prediction."""
+        target = self._data_target(tmp_path)
+        assert run_validation(target, level="4") == 0
+
+    def test_backend_feature_still_requires_prediction(self, tmp_path):
+        target = self._data_target(tmp_path, marker_type="api")
+        assert run_validation(target, level="4") == 1
+
+    def test_starter_plan_has_no_prediction_block(self):
+        """The starter must not re-introduce the (drifted) prediction
+        vocabulary the ADR retired."""
+        from cli import paths
+
+        text = (paths.REPO_ROOT / "features" / "starter_data" / "plan.md").read_text(
+            encoding="utf-8",
+        )
+        assert "evaluation_prediction" not in text
+
+    def test_adr_ships_in_payload(self):
+        from cli import paths
+
+        adr = (
+            paths.REPO_ROOT / "docs" / "data" / "architecture" / "ADR"
+            / "0001-data-features-skip-prediction-gate.md"
+        )
+        assert adr.is_file()
+        assert "Accepted" in adr.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
 # STARTERS registry
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Completes the data-enforcement hardening plan: the spec machinery becomes type-aware, data evaluation criteria become schema-enforced, the dbt CI gate enforces mart contracts, the databricks stack ships medallion rules, team-tunable values leave rule bodies, and the prediction gate is retired for data features by ADR.

## Why

Phases C-F of `plans/DATA_ENFORCEMENT_HARDENING_PLAN.md` (increments 5-11). After Phase A (content-hash edit-protection, PR #64) and Phase B (honest validation, PR #65), the remaining gap was the payload itself: skills hardcoded `docs/backend/`, preflight vocabulary was API-flavored, data eval criteria had no schema, the mart contract lived only in editable docs, the databricks stack reused dbt-worded rules, tunable constants were baked into govkit-owned files, and data L4 demanded a self-scored prediction against a rubric the data flavor had forked and nobody calibrated.

## Changes

**Increment 5 — skills resolve the docs area from the install**
- `docs/{{docs_area}}/...` tokens in the 4 planning skills x 3 agents, expanded at install time from a new `docs_area` fact in skill_context (derived from the marker via a shared `TYPE_AREA` map in `marker.py` that the eval-schema resolver also uses); new `cli/skill_templating.py`; `AgentLayout.skills_dir`; doctor D015 flags unexpanded tokens

**Increment 6 — data-native preflight sections**
- architecture-preflight gains a `3.7 Data Impact` block (Pipeline / Contract / PII / Lineage Impact); spec-planning gains a `Data projects` note; both byte-identical across agents (parity tests); the data starter's preflight example mirrors the skill by construction

**Increment 7 — data eval-criteria schema**
- `governance/data/schemas/eval_criteria.schema.json` (deterministic/none modes, predicate-string thresholds); starter conforms; all 3 manifests ship it at data L4; local validate goes WARN -> real validation

**Increment 8 — dbt-gate enforces the mart contract**
- both platform gates block marts lacking `contract: {enforced: true}` or exposure coverage (warning + upgrade pointer on dbt < 1.5); `dbt-project-evaluator` documented opt-in; python-dbt overlay docs (v0.11.0) document contracts + model versions as change control; behavior tests execute the embedded checker and pin the two platform embeddings identical

**Increment 9 — stack-overlaid rules**
- overlays gain `rules:` (schema + loader + `apply_rule_overrides`); databricks-lakehouse (v0.11.0) ships medallion bronze/silver/gold rules x 3 agents (codex gets plain `.agents/rules` files since its dbt defaults are folder-scoped nested AGENTS.md blocks a medallion repo lacks); `stack apply` now refreshes rule files and runs full post-install finalize

**Increment 10 — tunables out of rule bodies**
- PII keyword list -> `skill_context pii.keyword_list` (team edits survive regeneration), rendered into rules via `{{pii_keywords}}`; gate PII regex documented as mirroring the same seed; materialization/naming literals -> `MODEL_LAYERING.md` citation

**Increment 11 — prediction gate ADR**
- ADR-0001 (shipped in the data payload): validate skips `evaluation_prediction` for `type: data`; starter plan drops its drifted virtue block with a guard test; backend/UI unchanged

## Testing

- `pytest` — 1197 passed, 1 skipped (pre-existing); +93 tests since PR #65, each increment committed separately with the suite green
- Parity pinned: skill blocks and medallion rule bodies byte-identical across the 3 agents; dbt-gate embedded checker byte-identical across platforms
- End-to-end: data installs cite `docs/data/`, medallion rules land for databricks and swap correctly via `govkit stack apply`, PII list renders into installed rules including codex nested AGENTS.md blocks
- `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)