### PR TITLE
refactor(govkit): representation cleanups — starter grammar, CheckStatus, shared safe read (0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ---
 
-## [Unreleased]
+## [0.15.0] — 2026-07-24
 
 ### Added
 
@@ -44,6 +44,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
+- `govkit validate` now skips any `features/` directory whose name matches
+  the starter grammar (`starter_*`), matching `upgrade`'s behavior. The
+  definition of "starter feature" has a single owner (`cli/features.py`);
+  previously validate excluded only a hard-coded list of known starters, so
+  a starter shipped by a newer govkit could be mis-validated as a user
+  feature.
+- Internal: validate's check outcomes are an explicit `CheckStatus`
+  (PASS/FAIL/WARN) instead of `bool | None` with `None` meaning warn, and
+  the skip-on-failure file read has a single owner (`fs.read_text_or_none`)
+  instead of 21 inline try/excepts. CLI output is unchanged.
 - The planning skills (`adr-author`, `spec-planning`, `architecture-preflight`,
   `implementation-plan`) now resolve the docs tree from the install instead of
   hardcoding `docs/backend/`. Skill sources reference

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 
 from . import paths, version
+from .features import list_user_features
 from .install_common import (
     copy_governed_or_shared,
     install_agent_file,
@@ -213,18 +214,6 @@ TBD
 """
 
 
-def _list_user_features(features_dir: Path) -> list[Path]:
-    """Return sorted feature directories, excluding starters and dotfiles."""
-    if not features_dir.exists():
-        return []
-    return sorted(
-        d for d in features_dir.iterdir()
-        if d.is_dir()
-        and not d.name.startswith("starter_")
-        and not d.name.startswith(".")
-    )
-
-
 def _cmd_upgrade_migrate_levels(
     target: Path, stored_version: str, stored_level: str,
     agent: str, stored_options: dict,
@@ -342,7 +331,7 @@ def _migrate_l3_interactive(
 ) -> int:
     """Interactive 4-option prompt for v0.6 L3 (3-artifact) projects."""
     features_dir = target / "features"
-    feature_dirs = _list_user_features(features_dir)
+    feature_dirs = list_user_features(features_dir)
 
     _print_l3_migration_menu(stored_version, feature_dirs)
     choice = input("  Choice [1-4]: ").strip()

--- a/cli/detect.py
+++ b/cli/detect.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from xml.etree import ElementTree as ET
 
+from .fs import read_text_or_none
 
 # ---------------------------------------------------------------------------
 # Signal definitions
@@ -147,10 +148,9 @@ def _find_recursive(target: Path, pattern: str, max_depth: int = 4) -> list[Path
 
 
 def _read_text(path: Path) -> str:
-    try:
-        return path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return ""
+    """read_text_or_none with detection's empty-string default: an unreadable
+    file simply contributes no signals."""
+    return read_text_or_none(path) or ""
 
 
 # ---------------------------------------------------------------------------

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -27,6 +27,7 @@ from typing import Literal
 # Finding model
 # ---------------------------------------------------------------------------
 from .agent_layout import AGENT_LAYOUTS
+from .fs import read_text_or_none
 from .marker import MARKER_DIRNAME, MARKER_FILENAME, read_govkit_marker
 
 Severity = Literal["error", "warning", "info"]
@@ -157,9 +158,8 @@ def _check_rule_globs_resolve(target: Path, marker: dict) -> list[ValidationFind
 
     findings: list[ValidationFinding] = []
     for rule_file in _iter_rule_files(target, rules_dir):
-        try:
-            text = rule_file.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(rule_file)
+        if text is None:
             continue
         fm = _parse_frontmatter(text)
         if not isinstance(fm, dict):
@@ -310,9 +310,8 @@ def _scan_baseline_headers(target: Path) -> list[tuple[Path, str, str]]:
         return []
     out: list[tuple[Path, str, str]] = []
     for md in docs_root.rglob("*.md"):
-        try:
-            text = md.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(md)
+        if text is None:
             continue
         fm = parse_editable_header(text)
         if not fm:
@@ -387,9 +386,8 @@ def _check_llm_leakage_in_non_l5(target: Path, marker: dict) -> list[ValidationF
         return []
     findings: list[ValidationFinding] = []
     for md in sorted(arch_dir.glob("*.md")):
-        try:
-            text = md.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(md)
+        if text is None:
             continue
         hits = [kw for kw in _LLM_LEAKAGE_KEYWORDS if kw in text]
         if not hits:
@@ -459,23 +457,16 @@ _DEP_MANIFESTS = (
 )
 
 
-def _read_lower(path: Path) -> str:
-    try:
-        return path.read_text(encoding="utf-8").lower()
-    except (OSError, UnicodeDecodeError):
-        return ""
-
-
 def _collect_dep_text(target: Path) -> str:
     """Concatenate every dep-manifest text we find under target's root."""
     chunks: list[str] = []
     for name in _DEP_MANIFESTS:
         for path in list(target.glob(name)) + list(target.rglob(name)):
             if path.is_file():
-                chunks.append(_read_lower(path))
+                chunks.append((read_text_or_none(path) or "").lower())
     for csproj in target.rglob("*.csproj"):
         if csproj.is_file():
-            chunks.append(_read_lower(csproj))
+            chunks.append((read_text_or_none(csproj) or "").lower())
     return "\n".join(c for c in chunks if c)
 
 
@@ -493,10 +484,10 @@ def _check_testing_framework_mismatch(target: Path, marker: dict) -> list[Valida
     testing_md = target / "docs" / "backend" / "architecture" / "TESTING.md"
     if not testing_md.is_file():
         return []
-    try:
-        testing_text = testing_md.read_text(encoding="utf-8").lower()
-    except (OSError, UnicodeDecodeError):
+    testing_text = read_text_or_none(testing_md)
+    if testing_text is None:
         return []
+    testing_text = testing_text.lower()
 
     dep_text = _collect_dep_text(target)
     if not dep_text.strip():
@@ -630,9 +621,8 @@ def _check_unexpanded_skill_tokens(target: Path, marker: dict) -> list[Validatio
 
     findings: list[ValidationFinding] = []
     for skill_file in sorted(skills_root.rglob("*.md")):
-        try:
-            text = skill_file.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(skill_file)
+        if text is None:
             continue
         tokens = sorted(set(re.findall(r"\{\{[a-z_.]+\}\}", text)))
         if not tokens:

--- a/cli/features.py
+++ b/cli/features.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Feature directories in a target project.
+
+The single definition of "starter feature": govkit's bundled starters follow
+the naming grammar `starter_{slug}` / `starter_{slug}_l5` (cmd_init derives
+names inside it), so any features/ entry matching the prefix is govkit's, not
+the team's. validate and upgrade both exclude starters through this module —
+a starter added later needs no edits here or at the call sites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_STARTER_PREFIX = "starter_"
+
+
+def is_starter_feature(name: str) -> bool:
+    """True when `name` is inside govkit's starter naming grammar."""
+    return name.startswith(_STARTER_PREFIX)
+
+
+def list_user_features(features_dir: Path) -> list[Path]:
+    """Sorted team-authored feature dirs under `features_dir` — starters and
+    dotdirs excluded. Empty when the dir is missing."""
+    if not features_dir.exists():
+        return []
+    return sorted(
+        d
+        for d in features_dir.iterdir()
+        if d.is_dir() and not is_starter_feature(d.name) and not d.name.startswith(".")
+    )

--- a/cli/fs.py
+++ b/cli/fs.py
@@ -27,6 +27,16 @@ from .headers import (
 )
 
 
+def read_text_or_none(path: Path) -> str | None:
+    """The file's UTF-8 text, or None when it cannot be read — missing,
+    unreadable, or not valid UTF-8. govkit's skip-on-failure read: callers
+    treat an unreadable file as absent rather than crash."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
 def is_user_edited(dest: Path, applied_at: str | None) -> bool:
     """True if `dest` carries a govkit:editable header and its body no longer
     matches the content govkit installed. Used by edit-protection (A2) to
@@ -51,9 +61,8 @@ def is_user_edited(dest: Path, applied_at: str | None) -> bool:
         return False
     if not dest.is_file():
         return False
-    try:
-        content = dest.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    content = read_text_or_none(dest)
+    if content is None:
         return False
     if not has_editable_header(content):
         return False
@@ -95,10 +104,8 @@ def _copy_entry_should_refuse(
         )
         # A refused pre-hash file keeps mtime-only protection, which a future
         # upgrade's applied_at re-stamp resets — warn about the window.
-        try:
-            fields = parse_editable_header(dest.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError):
-            fields = None
+        text = read_text_or_none(dest)
+        fields = parse_editable_header(text) if text is not None else None
         if not fields or "hash" not in fields:
             print(
                 f"  note: {dest} predates content-hash protection; its edits "

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import paths
-from .fs import copy_entry
+from .fs import copy_entry, read_text_or_none
 from .headers import GOVKIT_BLOCK_BEGIN, upsert_govkit_block
 from .marker import _compare_version, read_govkit_marker
 
@@ -79,12 +79,7 @@ def write_managed_agent_block(dest: Path, body: str, applied_at: str | None = No
     untouched since the marker's `applied_at`); otherwise it is treated as the
     team's and the block is appended below their content.
     """
-    existing: str | None = None
-    if dest.exists():
-        try:
-            existing = dest.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            existing = None
+    existing = read_text_or_none(dest)
     replace_unblocked = False
     if existing is not None and GOVKIT_BLOCK_BEGIN not in existing:
         replace_unblocked = existing == body or _unmodified_since(dest, applied_at)
@@ -144,10 +139,7 @@ def reconcile_legacy_instruction_files(
             keep.append(entry)
             continue
         govkit_body = (agent_dir / entry["src"]).read_text(encoding="utf-8")
-        try:
-            legacy_body = legacy.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            legacy_body = None
+        legacy_body = read_text_or_none(legacy)
         is_govkit_orphan = legacy_body == govkit_body or _unmodified_since(legacy, applied_at)
         if is_govkit_orphan:
             try:
@@ -229,10 +221,8 @@ def _trees_identical(legacy: Path, src: Path) -> bool:
         rel = p.relative_to(legacy)
         if rel not in src_files:
             return False
-        try:
-            if p.read_text(encoding="utf-8") != (src / rel).read_text(encoding="utf-8"):
-                return False
-        except (OSError, UnicodeDecodeError):
+        legacy_text = read_text_or_none(p)
+        if legacy_text is None or legacy_text != read_text_or_none(src / rel):
             return False
     return True
 
@@ -252,10 +242,8 @@ def _is_govkit_pre_namespace_copy(legacy: Path, src: Path) -> bool:
         return src.is_dir() and _trees_identical(legacy, src)
     if not src.is_file():
         return False
-    try:
-        return legacy.read_text(encoding="utf-8") == src.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return False
+    legacy_text = read_text_or_none(legacy)
+    return legacy_text is not None and legacy_text == read_text_or_none(src)
 
 
 def retire_pre_namespace_agent_files(

--- a/cli/overlay.py
+++ b/cli/overlay.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import yaml
 
-from .fs import copy_entry
+from .fs import copy_entry, read_text_or_none
 
 # STACKS_DIR resolves to the bundled cli/stacks/ directory, mirroring how
 # AGENTS_DIR resolves AGENTS in cli/govkit.py. The repo-checkout vs
@@ -48,9 +48,8 @@ class Overlay:
 
 
 def _parse_overlay_yaml(overlay_path: Path) -> dict | None:
-    try:
-        text = overlay_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    text = read_text_or_none(overlay_path)
+    if text is None:
         return None
     try:
         data = yaml.safe_load(text)

--- a/cli/rule_templating.py
+++ b/cli/rule_templating.py
@@ -28,6 +28,7 @@ from pathlib import Path
 import yaml
 
 from .agent_layout import AGENT_LAYOUTS
+from .fs import read_text_or_none
 
 # Each agent uses its own frontmatter shape:
 #   claude-code → paths_template: layers.<k>  →  paths: [<globs>]      (list)
@@ -136,9 +137,8 @@ def template_installed_rules(
         return 0
     modified = 0
     for md in rules_root.rglob("*.md"):
-        try:
-            text = md.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(md)
+        if text is None:
             continue
         new_text = expand_rule_template(text, layers)
         if new_text != text:

--- a/cli/skill_templating.py
+++ b/cli/skill_templating.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .agent_layout import AGENT_LAYOUTS
+from .fs import read_text_or_none
 
 _DOCS_AREA_TOKEN = "{{docs_area}}"
 _PII_KEYWORDS_TOKEN = "{{pii_keywords}}"
@@ -76,9 +77,8 @@ def template_installed_rule_bodies(target: Path, agent: str, pii_keywords: list[
 
     modified = 0
     for path in candidates:
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(path)
+        if text is None:
             continue
         if _PII_KEYWORDS_TOKEN not in text:
             continue
@@ -103,9 +103,8 @@ def template_installed_skills(target: Path, agent: str, docs_area: str) -> int:
 
     modified = 0
     for path in sorted(skills_root.rglob("*.md")):
-        try:
-            text = path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        text = read_text_or_none(path)
+        if text is None:
             continue
         expanded = expand_skill_tokens(text, docs_area)
         if expanded != text:

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -29,6 +29,7 @@ import re
 import subprocess
 from pathlib import Path
 
+from .features import list_user_features
 from .marker import TYPE_AREA, read_govkit_marker
 
 # ---------------------------------------------------------------------------
@@ -67,11 +68,6 @@ REQUIRED_ARTIFACTS = L4_REQUIRED_ARTIFACTS
 PASS = "\033[32mPASS\033[0m"
 FAIL = "\033[31mFAIL\033[0m"
 WARN = "\033[33mWARN\033[0m"
-
-STARTERS = {
-    "starter_backend", "starter_ui", "starter_cli", "starter_data",
-    "starter_backend_l5", "starter_cli_l5",
-}
 
 
 # ---------------------------------------------------------------------------
@@ -636,10 +632,7 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
 
     _, checks = _build_checks(level, (marker.get("options") or {}).get("type"))
 
-    feature_dirs = sorted(
-        d for d in features_dir.iterdir()
-        if d.is_dir() and d.name not in STARTERS and not d.name.startswith(".")
-    )
+    feature_dirs = list_user_features(features_dir)
 
     if not feature_dirs:
         print("No feature directories found to validate.")

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -27,6 +27,7 @@ eval_criteria.yaml is deferred to CI or `check-jsonschema` if installed.
 
 import re
 import subprocess
+from enum import Enum
 from pathlib import Path
 
 from .features import list_user_features
@@ -70,11 +71,27 @@ FAIL = "\033[31mFAIL\033[0m"
 WARN = "\033[33mWARN\033[0m"
 
 
+class CheckStatus(Enum):
+    """Outcome of one governance check on a feature. WARN surfaces a visible
+    gap without failing the run."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    WARN = "warn"
+
+
+_STATUS_LABEL = {
+    CheckStatus.PASS: PASS,
+    CheckStatus.FAIL: FAIL,
+    CheckStatus.WARN: WARN,
+}
+
+
 # ---------------------------------------------------------------------------
 # Individual checks
 # ---------------------------------------------------------------------------
 
-def check_completeness(feature_dir: Path, artifacts: list[str] | None = None) -> tuple[bool, str]:
+def check_completeness(feature_dir: Path, artifacts: list[str] | None = None) -> tuple[CheckStatus, str]:
     """Check that all required artifacts exist and are non-empty."""
     if artifacts is None:
         artifacts = L4_REQUIRED_ARTIFACTS
@@ -93,15 +110,15 @@ def check_completeness(feature_dir: Path, artifacts: list[str] | None = None) ->
         if empty:
             parts.append(f"empty: {', '.join(empty)}")
         present = len(artifacts) - len(missing)
-        return False, f"{present}/{len(artifacts)} artifacts — {'; '.join(parts)}"
-    return True, f"{len(artifacts)}/{len(artifacts)} required artifacts present"
+        return CheckStatus.FAIL, f"{present}/{len(artifacts)} artifacts — {'; '.join(parts)}"
+    return CheckStatus.PASS, f"{len(artifacts)}/{len(artifacts)} required artifacts present"
 
 
-def check_gherkin_syntax(feature_dir: Path) -> tuple[bool, str]:
+def check_gherkin_syntax(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Basic Gherkin structure validation using text matching."""
     path = feature_dir / _ACCEPTANCE_FEATURE
     if not path.exists():
-        return False, f"{_ACCEPTANCE_FEATURE} not found"
+        return CheckStatus.FAIL, f"{_ACCEPTANCE_FEATURE} not found"
     text = path.read_text(encoding="utf-8")
     issues = []
     if not re.search(r"^Feature:", text, re.MULTILINE):
@@ -113,23 +130,23 @@ def check_gherkin_syntax(feature_dir: Path) -> tuple[bool, str]:
     if not re.search(r"^\s*(Given|When|Then)", active_text, re.MULTILINE):
         issues.append("no Given/When/Then steps found")
     if issues:
-        return False, f"{_ACCEPTANCE_FEATURE}: {'; '.join(issues)}"
-    return True, f"{_ACCEPTANCE_FEATURE} has valid Gherkin structure"
+        return CheckStatus.FAIL, f"{_ACCEPTANCE_FEATURE}: {'; '.join(issues)}"
+    return CheckStatus.PASS, f"{_ACCEPTANCE_FEATURE} has valid Gherkin structure"
 
 
-def check_nfrs_no_tbd(feature_dir: Path) -> tuple[bool, str]:
+def check_nfrs_no_tbd(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that nfrs.md has no remaining TBD entries."""
     path = feature_dir / _NFRS_MD
     if not path.exists():
-        return False, f"{_NFRS_MD} not found"
+        return CheckStatus.FAIL, f"{_NFRS_MD} not found"
     lines = path.read_text(encoding="utf-8").splitlines()
     tbd_lines = [i + 1 for i, ln in enumerate(lines) if re.search(r"\bTBD\b", ln)]
     if tbd_lines:
-        return False, f"{_NFRS_MD} contains TBD entries (lines {', '.join(map(str, tbd_lines))})"
-    return True, f"{_NFRS_MD} has no TBD entries"
+        return CheckStatus.FAIL, f"{_NFRS_MD} contains TBD entries (lines {', '.join(map(str, tbd_lines))})"
+    return CheckStatus.PASS, f"{_NFRS_MD} has no TBD entries"
 
 
-def check_nfrs_sections(feature_dir: Path) -> tuple[bool | None, str]:
+def check_nfrs_sections(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Advisory check of the nfrs.md section contract (see NFRS_CONVENTIONS.md).
 
     Required sections (Repository Scope) are hard-gated elsewhere — repo-scope-check CI
@@ -141,12 +158,12 @@ def check_nfrs_sections(feature_dir: Path) -> tuple[bool | None, str]:
     whitespace-only lines and HTML comments are stripped. An empty `## Out of scope` — header
     only, or header plus a placeholder comment — is treated as missing, matching
     spec-planning's "missing or empty -> infer and label" behaviour (otherwise the validator
-    would say OK while the plan still inserts an INFERRED marker). Returns True when the full
+    would say OK while the plan still inserts an INFERRED marker). Returns PASS when the full
     contract is met.
     """
     path = feature_dir / _NFRS_MD
     if not path.exists():
-        return False, f"{_NFRS_MD} not found"
+        return CheckStatus.FAIL, f"{_NFRS_MD} not found"
     text = path.read_text(encoding="utf-8")
 
     def _populated(section: str) -> bool:
@@ -164,16 +181,16 @@ def check_nfrs_sections(feature_dir: Path) -> tuple[bool | None, str]:
     missing_required = [s for s in NFRS_REQUIRED_SECTIONS if not _populated(s)]
     if missing_required:
         sections = ", ".join(f"## {s}" for s in missing_required)
-        return None, (f"{_NFRS_MD} missing or empty required section(s) {sections} "
+        return CheckStatus.WARN, (f"{_NFRS_MD} missing or empty required section(s) {sections} "
                       f"(NFRS_CONVENTIONS.md) — hard-gated by repo-scope-check/preflight")
 
     missing_recommended = [s for s in NFRS_RECOMMENDED_SECTIONS if not _populated(s)]
     if missing_recommended:
         sections = ", ".join(f"## {s}" for s in missing_recommended)
-        return None, (f"{_NFRS_MD} {sections} missing or empty — "
+        return CheckStatus.WARN, (f"{_NFRS_MD} {sections} missing or empty — "
                       f"spec planning will infer deferrals (NFRS_CONVENTIONS.md)")
 
-    return True, f"{_NFRS_MD} section contract OK (Repository Scope + Out of scope populated)"
+    return CheckStatus.PASS, f"{_NFRS_MD} section contract OK (Repository Scope + Out of scope populated)"
 
 
 # marker.TYPE_AREA maps options.type to its governance area. data maps to its
@@ -225,16 +242,16 @@ def _resolve_eval_schema(feature_dir: Path) -> tuple[Path | None, str]:
     return None, _NO_SCHEMA_REASON
 
 
-def check_eval_criteria(feature_dir: Path) -> tuple[bool | None, str]:
+def check_eval_criteria(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check eval_criteria.yaml required keys, then validate the instance
     against the installed schema via check-jsonschema.
 
-    WARN (None) when no schema is installed for this project type or the
-    binary is unavailable — visible gaps, not silent green.
+    WARN when no schema is installed for this project type or the binary is
+    unavailable — visible gaps, not silent green.
     """
     path = feature_dir / _EVAL_CRITERIA_YAML
     if not path.exists():
-        return False, f"{_EVAL_CRITERIA_YAML} not found"
+        return CheckStatus.FAIL, f"{_EVAL_CRITERIA_YAML} not found"
     text = path.read_text(encoding="utf-8")
     issues = []
     if not re.search(r"^version:", text, re.MULTILINE):
@@ -242,30 +259,30 @@ def check_eval_criteria(feature_dir: Path) -> tuple[bool | None, str]:
     if not re.search(r"^mode:", text, re.MULTILINE):
         issues.append("missing 'mode' key")
     if issues:
-        return False, f"{_EVAL_CRITERIA_YAML}: {'; '.join(issues)}"
+        return CheckStatus.FAIL, f"{_EVAL_CRITERIA_YAML}: {'; '.join(issues)}"
 
     schema, skip_reason = _resolve_eval_schema(feature_dir)
     if schema is None:
-        return None, f"{_EVAL_CRITERIA_YAML} structure OK — {skip_reason}; instance validation skipped"
+        return CheckStatus.WARN, f"{_EVAL_CRITERIA_YAML} structure OK — {skip_reason}; instance validation skipped"
     try:
         result = subprocess.run(
             ["check-jsonschema", "--schemafile", str(schema), str(path)],
             capture_output=True, text=True, timeout=10,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        return None, f"{_EVAL_CRITERIA_YAML} structure OK — install check-jsonschema for full validation"
+        return CheckStatus.WARN, f"{_EVAL_CRITERIA_YAML} structure OK — install check-jsonschema for full validation"
     if result.returncode != 0:
         detail = (result.stdout or result.stderr or "").strip().splitlines()
         snippet = detail[-1] if detail else "schema validation failed"
-        return False, f"{_EVAL_CRITERIA_YAML} fails {schema.name}: {snippet}"
-    return True, f"{_EVAL_CRITERIA_YAML} valid against {schema.name}"
+        return CheckStatus.FAIL, f"{_EVAL_CRITERIA_YAML} fails {schema.name}: {snippet}"
+    return CheckStatus.PASS, f"{_EVAL_CRITERIA_YAML} valid against {schema.name}"
 
 
-def check_plan_eval_prediction(feature_dir: Path) -> tuple[bool, str]:
+def check_plan_eval_prediction(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that plan.md has an evaluation_prediction block with averages >= 4.0."""
     path = feature_dir / _PLAN_MD
     if not path.exists():
-        return False, f"{_PLAN_MD} not found"
+        return CheckStatus.FAIL, f"{_PLAN_MD} not found"
     text = path.read_text(encoding="utf-8")
 
     block_match = re.search(
@@ -273,17 +290,17 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[bool, str]:
         text, re.DOTALL,
     )
     if not block_match:
-        return False, f"{_PLAN_MD} missing evaluation_prediction block"
+        return CheckStatus.FAIL, f"{_PLAN_MD} missing evaluation_prediction block"
 
     block = block_match.group(1)
 
     null_matches = re.findall(r":\s*null\b", block)
     if null_matches:
-        return False, f"{_PLAN_MD} evaluation_prediction has {len(null_matches)} null value(s) — all must be populated"
+        return CheckStatus.FAIL, f"{_PLAN_MD} evaluation_prediction has {len(null_matches)} null value(s) — all must be populated"
 
     averages = re.findall(r"average:\s*([\d.]+)", block)
     if not averages:
-        return False, f"{_PLAN_MD} evaluation_prediction missing average values"
+        return CheckStatus.FAIL, f"{_PLAN_MD} evaluation_prediction missing average values"
 
     below_threshold = []
     for avg_str in averages:
@@ -292,8 +309,8 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[bool, str]:
             below_threshold.append(avg_str)
 
     if below_threshold:
-        return False, f"{_PLAN_MD} evaluation_prediction average(s) below 4.0: {', '.join(below_threshold)}"
-    return True, f"{_PLAN_MD} evaluation_prediction averages OK ({', '.join(averages)})"
+        return CheckStatus.FAIL, f"{_PLAN_MD} evaluation_prediction average(s) below 4.0: {', '.join(below_threshold)}"
+    return CheckStatus.PASS, f"{_PLAN_MD} evaluation_prediction averages OK ({', '.join(averages)})"
 
 
 # A markdown table's delimiter row (`|---|:---:|`). Rows before it are the
@@ -301,7 +318,7 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[bool, str]:
 _RE_TABLE_DELIMITER = re.compile(r"^\|(?:\s*:?-+:?\s*\|)+$")
 
 
-def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
+def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Cross-reference populated NFR categories vs @nfr-* tags in acceptance.feature.
 
     A section heading may be either the plain category (`## Freshness`) or the
@@ -313,7 +330,7 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
     nfrs_path = feature_dir / _NFRS_MD
     feature_path = feature_dir / _ACCEPTANCE_FEATURE
     if not nfrs_path.exists() or not feature_path.exists():
-        return False, f"cannot check NFR coverage — missing {_NFRS_MD} or {_ACCEPTANCE_FEATURE}"
+        return CheckStatus.FAIL, f"cannot check NFR coverage — missing {_NFRS_MD} or {_ACCEPTANCE_FEATURE}"
 
     nfrs_text = nfrs_path.read_text(encoding="utf-8")
     feature_text = feature_path.read_text(encoding="utf-8")
@@ -341,7 +358,7 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
             current_heading = None
 
     if not populated:
-        return True, "no populated NFR categories — tag coverage not required"
+        return CheckStatus.PASS, "no populated NFR categories — tag coverage not required"
 
     tags_found = set(re.findall(r"@nfr-(\w+)", feature_text))
 
@@ -359,8 +376,8 @@ def check_gherkin_nfr_coverage(feature_dir: Path) -> tuple[bool, str]:
     ]
 
     if missing_tags:
-        return False, f"Gherkin missing NFR tags: {', '.join(missing_tags)}"
-    return True, "Gherkin @nfr-* tag coverage matches populated NFR categories"
+        return CheckStatus.FAIL, f"Gherkin missing NFR tags: {', '.join(missing_tags)}"
+    return CheckStatus.PASS, "Gherkin @nfr-* tag coverage matches populated NFR categories"
 
 
 # ---------------------------------------------------------------------------
@@ -378,27 +395,27 @@ def _is_multi_agent(feature_dir: Path) -> bool | None:
     return bool(re.search(_RE_MULTI_AGENT, eval_path.read_text(encoding="utf-8"), re.MULTILINE))
 
 
-def check_agent_topology_exists(feature_dir: Path) -> tuple[bool, str]:
+def check_agent_topology_exists(feature_dir: Path) -> tuple[CheckStatus, str]:
     """When multi_agent: true, agent_topology.md must exist and be non-empty."""
     is_ma = _is_multi_agent(feature_dir)
     if not is_ma:
-        return True, "multi_agent not declared — agent topology check not applicable"
+        return CheckStatus.PASS, "multi_agent not declared — agent topology check not applicable"
     path = feature_dir / _AGENT_TOPOLOGY_MD
     if not path.exists():
-        return False, f"{_AGENT_TOPOLOGY_MD} missing — required when multi_agent: true"
+        return CheckStatus.FAIL, f"{_AGENT_TOPOLOGY_MD} missing — required when multi_agent: true"
     if path.stat().st_size == 0:
-        return False, f"{_AGENT_TOPOLOGY_MD} is empty"
-    return True, f"{_AGENT_TOPOLOGY_MD} present"
+        return CheckStatus.FAIL, f"{_AGENT_TOPOLOGY_MD} is empty"
+    return CheckStatus.PASS, f"{_AGENT_TOPOLOGY_MD} present"
 
 
-def check_agent_topology_sections(feature_dir: Path) -> tuple[bool, str]:
+def check_agent_topology_sections(feature_dir: Path) -> tuple[CheckStatus, str]:
     """When multi_agent: true, agent_topology.md must have all required sections."""
     is_ma = _is_multi_agent(feature_dir)
     if not is_ma:
-        return True, "multi_agent not declared — agent topology sections check not applicable"
+        return CheckStatus.PASS, "multi_agent not declared — agent topology sections check not applicable"
     path = feature_dir / _AGENT_TOPOLOGY_MD
     if not path.exists():
-        return False, f"{_AGENT_TOPOLOGY_MD} not found"
+        return CheckStatus.FAIL, f"{_AGENT_TOPOLOGY_MD} not found"
     text = path.read_text(encoding="utf-8")
     required = [
         (r"^##\s+Orchestrator", "Orchestrator"),
@@ -409,8 +426,8 @@ def check_agent_topology_sections(feature_dir: Path) -> tuple[bool, str]:
     missing = [name for pattern, name in required
                if not re.search(pattern, text, re.MULTILINE)]
     if missing:
-        return False, f"{_AGENT_TOPOLOGY_MD} missing sections: {', '.join(missing)}"
-    return True, f"{_AGENT_TOPOLOGY_MD} has all required sections"
+        return CheckStatus.FAIL, f"{_AGENT_TOPOLOGY_MD} missing sections: {', '.join(missing)}"
+    return CheckStatus.PASS, f"{_AGENT_TOPOLOGY_MD} has all required sections"
 
 
 def _is_mode_llm(feature_dir: Path) -> bool | None:
@@ -422,17 +439,17 @@ def _is_mode_llm(feature_dir: Path) -> bool | None:
     return bool(re.search(_RE_MODE_LLM, text, re.MULTILINE))
 
 
-def check_llm_nfrs(feature_dir: Path) -> tuple[bool, str]:
+def check_llm_nfrs(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that nfrs.md has populated LLM-specific NFR categories when mode is llm."""
     mode_llm = _is_mode_llm(feature_dir)
     if mode_llm is None:
-        return False, f"{_EVAL_CRITERIA_YAML} not found — cannot check LLM NFRs"
+        return CheckStatus.FAIL, f"{_EVAL_CRITERIA_YAML} not found — cannot check LLM NFRs"
     if not mode_llm:
-        return True, "mode is not llm — LLM NFR check not applicable"
+        return CheckStatus.PASS, "mode is not llm — LLM NFR check not applicable"
 
     nfrs_path = feature_dir / _NFRS_MD
     if not nfrs_path.exists():
-        return False, f"{_NFRS_MD} not found"
+        return CheckStatus.FAIL, f"{_NFRS_MD} not found"
     nfrs_text = nfrs_path.read_text(encoding="utf-8")
 
     missing = []
@@ -449,11 +466,11 @@ def check_llm_nfrs(feature_dir: Path) -> tuple[bool, str]:
             missing.append(f"{category} (TBD)")
 
     if missing:
-        return False, f"LLM NFR categories incomplete: {', '.join(missing)}"
-    return True, "LLM NFR categories populated (latency, cost, fallback, safety)"
+        return CheckStatus.FAIL, f"LLM NFR categories incomplete: {', '.join(missing)}"
+    return CheckStatus.PASS, "LLM NFR categories populated (latency, cost, fallback, safety)"
 
 
-def check_l5_eval_criteria(feature_dir: Path) -> tuple[bool, str]:
+def check_l5_eval_criteria(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that mode:llm declares at least one model evaluation criterion.
 
     Evaluator products are selected by an implementation profile or ADR, so
@@ -461,29 +478,29 @@ def check_l5_eval_criteria(feature_dir: Path) -> tuple[bool, str]:
     """
     mode_llm = _is_mode_llm(feature_dir)
     if mode_llm is None:
-        return False, f"{_EVAL_CRITERIA_YAML} not found"
+        return CheckStatus.FAIL, f"{_EVAL_CRITERIA_YAML} not found"
     if not mode_llm:
-        return True, "mode is not llm — L5 eval criteria check not applicable"
+        return CheckStatus.PASS, "mode is not llm — L5 eval criteria check not applicable"
 
     text = (feature_dir / _EVAL_CRITERIA_YAML).read_text(encoding="utf-8")
     has_llm_section = bool(re.search(r"^\s*llm_evaluation:\s*$", text, re.MULTILINE))
     criterion_count = len(re.findall(r"^\s*eval_class:\s*\S+", text, re.MULTILINE))
     if not has_llm_section or criterion_count == 0:
-        return False, (
+        return CheckStatus.FAIL, (
             f"{_EVAL_CRITERIA_YAML} mode is llm but llm_evaluation has no criteria"
         )
-    return True, f"L5 eval criteria present ({criterion_count} declared)"
+    return CheckStatus.PASS, f"L5 eval criteria present ({criterion_count} declared)"
 
 
-def check_l5_preflight_sections(feature_dir: Path) -> tuple[bool, str]:
+def check_l5_preflight_sections(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that architecture_preflight.md has L5 sections (10-14) when mode is llm."""
     mode_llm = _is_mode_llm(feature_dir)
     if mode_llm is not None and not mode_llm:
-        return True, "mode is not llm — L5 preflight sections not required"
+        return CheckStatus.PASS, "mode is not llm — L5 preflight sections not required"
 
     path = feature_dir / _ARCH_PREFLIGHT_MD
     if not path.exists():
-        return False, f"{_ARCH_PREFLIGHT_MD} not found"
+        return CheckStatus.FAIL, f"{_ARCH_PREFLIGHT_MD} not found"
     text = path.read_text(encoding="utf-8")
 
     required_sections = [
@@ -499,19 +516,19 @@ def check_l5_preflight_sections(feature_dir: Path) -> tuple[bool, str]:
             missing.append(name)
 
     if missing:
-        return False, f"{_ARCH_PREFLIGHT_MD} missing L5 sections: {', '.join(missing)}"
-    return True, f"{_ARCH_PREFLIGHT_MD} has all L5 sections (10-14)"
+        return CheckStatus.FAIL, f"{_ARCH_PREFLIGHT_MD} missing L5 sections: {', '.join(missing)}"
+    return CheckStatus.PASS, f"{_ARCH_PREFLIGHT_MD} has all L5 sections (10-14)"
 
 
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
-def _data_prediction_not_required(feature_dir: Path) -> tuple[bool, str]:
+def _data_prediction_not_required(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Data features carry no FIRST/Virtue self-prediction (ADR-0001 under
     docs/data/architecture/ADR/): enforcement is artifact completeness, the
     data eval-criteria schema, NFR tag coverage, and the mart-contract gate."""
-    return True, (
+    return CheckStatus.PASS, (
         "evaluation prediction not required for data features "
         "(docs/data/architecture/ADR/0001-data-features-skip-prediction-gate.md)"
     )
@@ -563,14 +580,10 @@ def _run_feature_checks(feature_dir: Path, checks: list) -> bool:
     feature_ok = True
     print(f"features/{feature_dir.name}/")
     for check_fn in checks:
-        result, message = check_fn(feature_dir)
-        if result is True:
-            print(f"  {PASS}  {message}")
-        elif result is False:
-            print(f"  {FAIL}  {message}")
+        status, message = check_fn(feature_dir)
+        print(f"  {_STATUS_LABEL[status]}  {message}")
+        if status is CheckStatus.FAIL:
             feature_ok = False
-        else:
-            print(f"  {WARN}  {message}")
     print()
     return feature_ok
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.14.0"
+version = "0.15.0"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,67 @@
+"""Tests for cli/features.py — the shared definition of "starter feature".
+
+One owner for the fact "which features/ subdirectories are govkit's starters,
+not the team's features". validate and upgrade both consume it; cmd_init
+generates names inside the same grammar (starter_{slug}, starter_{slug}_l5).
+"""
+
+from cli.features import is_starter_feature, list_user_features
+
+
+class TestIsStarterFeature:
+    def test_bundled_starter_names_match(self):
+        assert is_starter_feature("starter_backend")
+        assert is_starter_feature("starter_backend_l5")
+
+    def test_grammar_is_open(self):
+        # cmd_init derives starter_{slug}[_l5] for any slug, so the predicate
+        # must accept starters that don't exist yet.
+        assert is_starter_feature("starter_data_l5")
+        assert is_starter_feature("starter_custom")
+
+    def test_user_feature_names_do_not_match(self):
+        assert not is_starter_feature("my_feature")
+        assert not is_starter_feature("starterkit")
+        assert not is_starter_feature("restarter_backend")
+
+
+class TestListUserFeatures:
+    def test_excludes_starters_dotdirs_and_files(self, tmp_path):
+        features = tmp_path / "features"
+        (features / "alpha").mkdir(parents=True)
+        (features / "starter_backend").mkdir()
+        (features / "starter_custom").mkdir()
+        (features / ".hidden").mkdir()
+        (features / "notes.md").write_text("not a feature dir", encoding="utf-8")
+        assert [p.name for p in list_user_features(features)] == ["alpha"]
+
+    def test_sorted_by_name(self, tmp_path):
+        features = tmp_path / "features"
+        for name in ("zeta", "alpha", "mid"):
+            (features / name).mkdir(parents=True)
+        assert [p.name for p in list_user_features(features)] == ["alpha", "mid", "zeta"]
+
+    def test_missing_dir_returns_empty(self, tmp_path):
+        assert list_user_features(tmp_path / "features") == []
+
+
+class TestBundledStarterGrammar:
+    def test_every_bundled_starter_matches_the_grammar(self):
+        """Every starter govkit ships must satisfy the shared predicate, so
+        validate/upgrade exclude it in a target. Replaces the retired STARTERS
+        set-coverage guard — the open grammar cannot go stale the way the
+        closed set did when starter_data was added. Bundled features/ also
+        holds repo-side worked examples (schema_contract_example etc.); those
+        never install into targets and are outside this invariant."""
+        from cli import paths
+
+        starters = [
+            p.name
+            for p in (paths.REPO_ROOT / "features").iterdir()
+            if p.is_dir() and p.name.startswith("starter")
+        ]
+        assert starters, "no bundled starters found — REPO_ROOT misresolved?"
+        assert all(is_starter_feature(n) for n in starters), (
+            f"bundled starter outside the grammar: "
+            f"{[n for n in starters if not is_starter_feature(n)]}"
+        )

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -28,6 +28,35 @@ def _write_hashed_doc(path, body, recorded_body=None):
     path.write_text(header + body, encoding="utf-8")
 
 
+class TestReadTextOrNone:
+    """The single owner of govkit's skip-on-failure file read: text on
+    success, None when the file is missing, unreadable, or not UTF-8."""
+
+    def test_reads_utf8_text(self, tmp_path):
+        from cli.fs import read_text_or_none
+
+        doc = tmp_path / "doc.md"
+        doc.write_text("# Héading\n", encoding="utf-8")
+        assert read_text_or_none(doc) == "# Héading\n"
+
+    def test_missing_file_returns_none(self, tmp_path):
+        from cli.fs import read_text_or_none
+
+        assert read_text_or_none(tmp_path / "absent.md") is None
+
+    def test_directory_returns_none(self, tmp_path):
+        from cli.fs import read_text_or_none
+
+        assert read_text_or_none(tmp_path) is None
+
+    def test_invalid_utf8_returns_none(self, tmp_path):
+        from cli.fs import read_text_or_none
+
+        blob = tmp_path / "binary.md"
+        blob.write_bytes(b"\xff\xfe\x00garbage")
+        assert read_text_or_none(blob) is None
+
+
 class TestIsUserEditedHashBranch:
     def test_edited_body_detected_despite_restamped_applied_at(self, tmp_path):
         """The amnesia repro: upgrade re-stamps applied_at to now, so the

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,6 +5,7 @@ import textwrap
 from pathlib import Path
 
 from cli.validate import (
+    CheckStatus,
     check_agent_topology_exists,
     check_agent_topology_sections,
     check_completeness,
@@ -104,25 +105,54 @@ def make_full_feature(feature_dir: Path, **overrides) -> None:
 # ---------------------------------------------------------------------------
 
 
+class TestCheckStatus:
+    """The check-outcome vocabulary: every check returns an explicit
+    tri-state, replacing the bool|None protocol where None meant WARN."""
+
+    def test_three_outcomes(self):
+        assert {s.name for s in CheckStatus} == {"PASS", "FAIL", "WARN"}
+
+    def test_pass_status(self, tmp_path):
+        make_full_feature(tmp_path / "f")
+        status, _ = check_completeness(tmp_path / "f")
+        assert status is CheckStatus.PASS
+
+    def test_fail_status(self, tmp_path):
+        (tmp_path / "f").mkdir()
+        status, _ = check_completeness(tmp_path / "f")
+        assert status is CheckStatus.FAIL
+
+    def test_warn_status(self, tmp_path):
+        # Repository Scope populated, Out of scope absent — advisory WARN,
+        # previously encoded as None.
+        write(tmp_path / "nfrs.md", """\
+            ## Repository Scope
+
+            **Scope:** `single-repo`
+        """)
+        status, _ = check_nfrs_sections(tmp_path)
+        assert status is CheckStatus.WARN
+
+
 class TestCheckCompleteness:
     def test_all_present(self, tmp_path):
         make_full_feature(tmp_path)
         ok, msg = check_completeness(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "5/5" in msg
 
     def test_missing_artifact(self, tmp_path):
         make_full_feature(tmp_path)
         (tmp_path / "plan.md").unlink()
         ok, msg = check_completeness(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "missing: plan.md" in msg
 
     def test_empty_artifact(self, tmp_path):
         make_full_feature(tmp_path)
         (tmp_path / "nfrs.md").write_text("", encoding="utf-8")
         ok, msg = check_completeness(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "empty: nfrs.md" in msg
 
     def test_multiple_missing(self, tmp_path):
@@ -130,7 +160,7 @@ class TestCheckCompleteness:
         (tmp_path / "plan.md").unlink()
         (tmp_path / "nfrs.md").unlink()
         ok, msg = check_completeness(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "3/5" in msg
 
 
@@ -143,12 +173,12 @@ class TestCheckGherkinSyntax:
     def test_valid_gherkin(self, tmp_path):
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_syntax(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
 
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_gherkin_syntax(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "not found" in msg
 
     def test_missing_feature_keyword(self, tmp_path):
@@ -159,7 +189,7 @@ class TestCheckGherkinSyntax:
               Then result
         """)
         ok, msg = check_gherkin_syntax(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "Feature:" in msg
 
     def test_missing_scenario_keyword(self, tmp_path):
@@ -170,7 +200,7 @@ class TestCheckGherkinSyntax:
               Then result
         """)
         ok, msg = check_gherkin_syntax(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "Scenario:" in msg
 
     def test_missing_steps(self, tmp_path):
@@ -179,7 +209,7 @@ class TestCheckGherkinSyntax:
               Scenario: Empty scenario
         """)
         ok, msg = check_gherkin_syntax(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "Given/When/Then" in msg
 
     def test_comments_ignored_for_steps(self, tmp_path):
@@ -191,7 +221,7 @@ class TestCheckGherkinSyntax:
                 # Then result
         """)
         ok, msg = check_gherkin_syntax(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "Given/When/Then" in msg
 
 
@@ -204,7 +234,7 @@ class TestCheckNfrsNoTbd:
     def test_no_tbd(self, tmp_path):
         write(tmp_path / "nfrs.md", VALID_NFRS)
         ok, msg = check_nfrs_no_tbd(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
 
     def test_has_tbd(self, tmp_path):
         write(tmp_path / "nfrs.md", """\
@@ -212,13 +242,13 @@ class TestCheckNfrsNoTbd:
             - TBD
         """)
         ok, msg = check_nfrs_no_tbd(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "TBD" in msg
 
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_nfrs_no_tbd(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "not found" in msg
 
     def test_tbd_in_word_ignored(self, tmp_path):
@@ -227,7 +257,7 @@ class TestCheckNfrsNoTbd:
             - The TBDATA format is used
         """)
         ok, msg = check_nfrs_no_tbd(tmp_path)
-        assert ok is True  # \bTBD\b won't match TBDATA
+        assert ok is CheckStatus.PASS  # \bTBD\b won't match TBDATA
 
 
 # ---------------------------------------------------------------------------
@@ -249,7 +279,7 @@ class TestCheckNfrsSections:
             - Response time < 200ms
         """)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is True
+        assert result is CheckStatus.PASS
         assert "section contract OK" in msg
 
     def test_missing_out_of_scope_warns(self, tmp_path):
@@ -262,7 +292,7 @@ class TestCheckNfrsSections:
             - Response time < 200ms
         """)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is None  # WARN, not FAIL — plan will infer
+        assert result is CheckStatus.WARN  # WARN, not FAIL — plan will infer
         assert "Out of scope" in msg
         assert "infer" in msg
 
@@ -279,7 +309,7 @@ class TestCheckNfrsSections:
             - Response time < 200ms
         """)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is None
+        assert result is CheckStatus.WARN
         assert "Out of scope" in msg
         assert "empty" in msg
 
@@ -297,7 +327,7 @@ class TestCheckNfrsSections:
             - Response time < 200ms
         """)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is None
+        assert result is CheckStatus.WARN
         assert "Out of scope" in msg
 
     def test_missing_repository_scope_warns(self, tmp_path):
@@ -309,7 +339,7 @@ class TestCheckNfrsSections:
             - Response time < 200ms
         """)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is None  # WARN — hard-gated by repo-scope-check/preflight
+        assert result is CheckStatus.WARN  # WARN — hard-gated by repo-scope-check/preflight
         assert "Repository Scope" in msg
 
     def test_out_of_scope_with_suffix_matches(self, tmp_path):
@@ -323,13 +353,13 @@ class TestCheckNfrsSections:
             - Source system reliability (owned elsewhere)
         """)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is True
+        assert result is CheckStatus.PASS
         assert "section contract OK" in msg
 
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         result, msg = check_nfrs_sections(tmp_path)
-        assert result is False
+        assert result is CheckStatus.FAIL
         assert "not found" in msg
 
 
@@ -342,15 +372,15 @@ class TestCheckEvalCriteria:
     def test_valid_criteria(self, tmp_path):
         write(tmp_path / "eval_criteria.yaml", VALID_EVAL_CRITERIA)
         result, msg = check_eval_criteria(tmp_path)
-        # Result is True or None depending on check-jsonschema availability
-        assert result is not False
+        # Result is PASS or WARN depending on check-jsonschema availability
+        assert result is not CheckStatus.FAIL
 
     def test_missing_version(self, tmp_path):
         write(tmp_path / "eval_criteria.yaml", """\
             mode: deterministic
         """)
         ok, msg = check_eval_criteria(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "version" in msg
 
     def test_missing_mode(self, tmp_path):
@@ -358,13 +388,13 @@ class TestCheckEvalCriteria:
             version: "1"
         """)
         ok, msg = check_eval_criteria(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "mode" in msg
 
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_eval_criteria(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "not found" in msg
 
     # -- honest schema validation (instance vs installed schema) -------------
@@ -406,7 +436,7 @@ class TestCheckEvalCriteria:
         monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
 
         ok, msg = check_eval_criteria(feature_dir)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert calls, "check-jsonschema was not invoked"
         assert "--schemafile" in calls[0]
         assert str(schema) in calls[0]
@@ -423,7 +453,7 @@ class TestCheckEvalCriteria:
         monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
 
         ok, msg = check_eval_criteria(feature_dir)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "eval_criteria.schema.json" in msg
 
     def test_missing_binary_warns(self, tmp_path, monkeypatch):
@@ -435,7 +465,7 @@ class TestCheckEvalCriteria:
         monkeypatch.setattr("cli.validate.subprocess.run", fake_run)
 
         ok, msg = check_eval_criteria(feature_dir)
-        assert ok is None
+        assert ok is CheckStatus.WARN
         assert "check-jsonschema" in msg
 
     def test_no_installed_schema_warns(self, tmp_path):
@@ -444,7 +474,7 @@ class TestCheckEvalCriteria:
         feature_dir, _ = self._install(tmp_path, with_schema=False)
 
         ok, msg = check_eval_criteria(feature_dir)
-        assert ok is None
+        assert ok is CheckStatus.WARN
         assert "no eval_criteria schema installed" in msg
 
     # -- marker-type-aware schema resolution ---------------------------------
@@ -468,7 +498,7 @@ class TestCheckEvalCriteria:
 
         ok, msg = check_eval_criteria(feature_dir)
 
-        assert ok is True
+        assert ok is CheckStatus.PASS
         ui_schema = tmp_path / "target" / "governance" / "ui" / "schemas" / "eval_criteria.schema.json"
         assert str(ui_schema) in calls[0]
 
@@ -480,7 +510,7 @@ class TestCheckEvalCriteria:
 
         ok, msg = check_eval_criteria(feature_dir)
 
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert str(backend_schema) in calls[0]
 
     def test_data_marker_warns_despite_stale_schema_tree(self, tmp_path, monkeypatch):
@@ -491,7 +521,7 @@ class TestCheckEvalCriteria:
 
         ok, msg = check_eval_criteria(feature_dir)
 
-        assert ok is None
+        assert ok is CheckStatus.WARN
         assert "no eval_criteria schema installed" in msg
         assert not calls
 
@@ -503,7 +533,7 @@ class TestCheckEvalCriteria:
 
         ok, msg = check_eval_criteria(feature_dir)
 
-        assert ok is None
+        assert ok is CheckStatus.WARN
         assert "ambiguous" in msg
         assert not calls
 
@@ -517,14 +547,14 @@ class TestCheckPlanEvalPrediction:
     def test_valid_prediction(self, tmp_path):
         write(tmp_path / "plan.md", VALID_PLAN)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "4.6" in msg
         assert "4.4" in msg
 
     def test_missing_prediction_block(self, tmp_path):
         write(tmp_path / "plan.md", "# Plan\nNo prediction here.\n")
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "missing evaluation_prediction" in msg
 
     def test_null_values(self, tmp_path):
@@ -539,7 +569,7 @@ class TestCheckPlanEvalPrediction:
             ```
         """)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "null" in msg
 
     def test_below_threshold(self, tmp_path):
@@ -555,13 +585,13 @@ class TestCheckPlanEvalPrediction:
             ```
         """)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "3.5" in msg
 
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "not found" in msg
 
     def test_missing_averages(self, tmp_path):
@@ -575,7 +605,7 @@ class TestCheckPlanEvalPrediction:
             ```
         """)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "missing average" in msg
 
 
@@ -603,7 +633,7 @@ class TestCheckGherkinNfrCoverage:
                 Then authorized
         """)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
 
     def test_missing_nfr_tag(self, tmp_path):
         write(tmp_path / "nfrs.md", VALID_NFRS)
@@ -617,7 +647,7 @@ class TestCheckGherkinNfrCoverage:
                 Then fast
         """)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "@nfr-security" in msg
 
     def test_no_populated_nfrs(self, tmp_path):
@@ -627,7 +657,7 @@ class TestCheckGherkinNfrCoverage:
         """)
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is True  # no populated categories, so coverage not required
+        assert ok is CheckStatus.PASS  # no populated categories, so coverage not required
 
     # -- data-shaped NFRs: @nfr-* headings, table-style sections -------------
 
@@ -657,7 +687,7 @@ class TestCheckGherkinNfrCoverage:
                 Then customer_email is masked
         """)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "@nfr-freshness" in msg
         assert "@nfr-pii" not in msg
 
@@ -689,7 +719,7 @@ class TestCheckGherkinNfrCoverage:
                 Then lineage shows the upstream
         """)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
 
     def test_plain_heading_normalizes_to_category(self, tmp_path):
         """`## Freshness` and `## @nfr-freshness` are the same category."""
@@ -702,7 +732,7 @@ class TestCheckGherkinNfrCoverage:
         """)
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "@nfr-freshness" in msg
 
     def test_new_categories_recognized_in_bullet_form(self, tmp_path):
@@ -717,7 +747,7 @@ class TestCheckGherkinNfrCoverage:
         """)
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "@nfr-cost" in msg
         assert "@nfr-quality" in msg
 
@@ -732,7 +762,7 @@ class TestCheckGherkinNfrCoverage:
         """)
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
 
     def test_table_rows_all_tbd_are_not_populated(self, tmp_path):
         write(tmp_path / "nfrs.md", """\
@@ -744,7 +774,7 @@ class TestCheckGherkinNfrCoverage:
         """)
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
 
     def test_checkbox_line_populates_section(self, tmp_path):
         write(tmp_path / "nfrs.md", """\
@@ -753,7 +783,7 @@ class TestCheckGherkinNfrCoverage:
         """)
         write(tmp_path / "acceptance.feature", VALID_FEATURE)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "@nfr-compliance" in msg
 
     def test_bundled_data_starter_has_full_coverage(self):
@@ -763,12 +793,12 @@ class TestCheckGherkinNfrCoverage:
 
         starter = paths.REPO_ROOT / "features" / "starter_data"
         ok, msg = check_gherkin_nfr_coverage(starter)
-        assert ok is True, msg
+        assert ok is CheckStatus.PASS, msg
 
     def test_missing_files(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "missing" in msg
 
 
@@ -1294,14 +1324,14 @@ class TestMultiAgentValidation:
         write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
         write(tmp_path / "agent_topology.md", VALID_AGENT_TOPOLOGY)
         ok, msg = check_agent_topology_exists(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "agent_topology.md present" in msg
 
     def test_topology_exists_missing_fails(self, tmp_path):
         """check_agent_topology_exists fails when multi_agent: true but file missing."""
         write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
         ok, msg = check_agent_topology_exists(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "missing" in msg
 
     def test_topology_exists_empty_fails(self, tmp_path):
@@ -1309,20 +1339,20 @@ class TestMultiAgentValidation:
         write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
         (tmp_path / "agent_topology.md").write_text("", encoding="utf-8")
         ok, msg = check_agent_topology_exists(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "empty" in msg
 
     def test_topology_exists_not_declared_skips(self, tmp_path):
         """check_agent_topology_exists skips when multi_agent not declared."""
         write(tmp_path / "eval_criteria.yaml", "version: 1\nmode: llm\n")
         ok, msg = check_agent_topology_exists(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "not applicable" in msg
 
     def test_topology_exists_no_eval_criteria_skips(self, tmp_path):
         """check_agent_topology_exists skips when eval_criteria.yaml is missing."""
         ok, msg = check_agent_topology_exists(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "not applicable" in msg
 
     def test_topology_sections_pass(self, tmp_path):
@@ -1330,7 +1360,7 @@ class TestMultiAgentValidation:
         write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
         write(tmp_path / "agent_topology.md", VALID_AGENT_TOPOLOGY)
         ok, msg = check_agent_topology_sections(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "all required sections" in msg
 
     def test_topology_sections_missing_one_fails(self, tmp_path):
@@ -1352,21 +1382,21 @@ class TestMultiAgentValidation:
             # Missing Failure Modes section
         """)
         ok, msg = check_agent_topology_sections(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "Failure Modes" in msg
 
     def test_topology_sections_not_declared_skips(self, tmp_path):
         """check_agent_topology_sections skips when multi_agent not declared."""
         write(tmp_path / "eval_criteria.yaml", "version: 1\nmode: llm\n")
         ok, msg = check_agent_topology_sections(tmp_path)
-        assert ok is True
+        assert ok is CheckStatus.PASS
         assert "not applicable" in msg
 
     def test_topology_sections_file_missing_fails(self, tmp_path):
         """check_agent_topology_sections fails when file is missing (multi_agent declared)."""
         write(tmp_path / "eval_criteria.yaml", MULTI_AGENT_EVAL_CRITERIA)
         ok, msg = check_agent_topology_sections(tmp_path)
-        assert ok is False
+        assert ok is CheckStatus.FAIL
         assert "not found" in msg
 
     def test_l5_multi_agent_full_pass(self, tmp_path):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -765,6 +765,12 @@ class TestCheckGherkinNfrCoverage:
         ok, msg = check_gherkin_nfr_coverage(starter)
         assert ok is True, msg
 
+    def test_missing_files(self, tmp_path):
+        tmp_path.mkdir(exist_ok=True)
+        ok, msg = check_gherkin_nfr_coverage(tmp_path)
+        assert ok is False
+        assert "missing" in msg
+
 
 # ---------------------------------------------------------------------------
 # Data prediction gate (ADR-0001)
@@ -832,36 +838,6 @@ class TestDataPredictionGate:
 
 
 # ---------------------------------------------------------------------------
-# STARTERS registry
-# ---------------------------------------------------------------------------
-
-
-class TestStartersRegistry:
-    def test_starters_covers_every_bundled_starter_dir(self):
-        """validate skips starter dirs by name when scanning a target's
-        features/; a bundled starter missing from STARTERS gets validated as
-        if it were a user feature (and fails — starters omit plan.md by
-        design). Guard so the next starter cannot repeat starter_data's
-        omission."""
-        from cli import paths
-        from cli.validate import STARTERS
-
-        bundled = {
-            p.name
-            for p in (paths.REPO_ROOT / "features").iterdir()
-            if p.is_dir() and p.name.startswith("starter_")
-        }
-        assert bundled, "no bundled starters found — REPO_ROOT misresolved?"
-        assert bundled <= STARTERS, f"STARTERS missing: {sorted(bundled - STARTERS)}"
-
-    def test_missing_files(self, tmp_path):
-        tmp_path.mkdir(exist_ok=True)
-        ok, msg = check_gherkin_nfr_coverage(tmp_path)
-        assert ok is False
-        assert "missing" in msg
-
-
-# ---------------------------------------------------------------------------
 # run_validation
 # ---------------------------------------------------------------------------
 
@@ -921,6 +897,18 @@ class TestRunValidation:
             """,
         })
         result = run_validation(tmp_path)
+        assert result == 0
+
+    def test_skips_any_starter_named_dir(self, tmp_path):
+        """Any dir matching the starter grammar is govkit's, not the team's.
+        validate must skip starters it has never heard of — upgrade already
+        does — so a starter shipped by a future govkit cannot fail a target's
+        validation. (An incomplete starter-named dir would fail if scanned.)"""
+        features = tmp_path / "features"
+        incomplete = features / "starter_custom"
+        incomplete.mkdir(parents=True)
+        write(incomplete / "acceptance.feature", VALID_FEATURE)
+        result = run_validation(tmp_path, level="4")
         assert result == 0
 
     def test_missing_target_returns_one(self, tmp_path):


### PR DESCRIPTION
## What
Three representation refactors in the installer (`cli/`) from a zero-one-many review, plus the 0.15.0 release bump.

## Why
Each targets duplicated or implicit knowledge that made changes error-prone: the definition of "starter feature" existed twice with different semantics (a closed set in validate vs a prefix rule in upgrade — the set went stale when `starter_data` shipped and would again); validate's check outcomes crammed three states into `bool | None` with `None` secretly meaning WARN; and the skip-on-failure file read was restated inline 21 times across 12 files.

## Changes
- **One owner for "starter feature"** — new `cli/features.py` (`is_starter_feature`, `list_user_features`) adopted by `validate` and `upgrade`; the `STARTERS` set and `cmd_upgrade._list_user_features` are deleted. Behavior change (intended): `govkit validate` now skips *any* `features/` dir matching the `starter_*` grammar, matching upgrade — a starter shipped by a future govkit can no longer be mis-validated as a user feature.
- **`CheckStatus` enum in `validate.py`** — all 13 check functions return an explicit PASS/FAIL/WARN instead of `bool | None`; the print loop collapses to a status→label table. CLI output verified byte-identical via before/after diff on a sandbox exercising all three labels. The schema resolver and `_is_mode_llm`-style helpers keep their `None` (different meaning).
- **`fs.read_text_or_none`** — single owner of "unreadable/non-UTF-8 ⇒ treat as absent", adopted at 16 sites across 7 files; `doctor._read_lower` and `detect._read_text` fold into it. Deliberately left inline: `headers.py` (fs imports headers — adopting would cycle), `extensions.py` (reports the exception), `skill_context.py` (also catches `YAMLError`).
- **Release 0.15.0** — `pyproject.toml` bump; CHANGELOG `[Unreleased]` released as `[0.15.0] — 2026-07-24` with entries for the above.
- Tests: new `tests/test_features.py`; the `STARTERS` set-coverage guard is replaced by a grammar guard (nothing left to go stale); `TestCheckStatus` and `TestReadTextOrNone` added; the stray `test_missing_files` moved into `TestCheckGherkinNfrCoverage`.

## Testing
- `pytest` — 1212 passed, 1 skipped (15 new tests, written failing-first per increment)
- Output parity for the CheckStatus migration verified byte-identical on a sandbox producing PASS/WARN/FAIL lines
- `ruff check` clean, scoped to changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)