### PR TITLE
test(govkit): fast/full feedback loops + deterministic eval-criteria assertion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ When a task says "fix the API conventions" or "update the spec-planning skill," 
 
 ```bash
 pip install -e ".[test]"      # dev install (extra is [test]; CONTRIBUTING.md's ".[dev]" is stale — [dev] doesn't exist)
-pytest                        # full suite (~765 tests across tests/)
+pytest                        # full suite (~1200 tests across tests/; what CI runs)
+pytest -m "not e2e"           # fast loop (~20s) — skips the full-install e2e tier (test_fixtures.py, test_stack_rules.py)
 pytest tests/test_doctor.py                          # one file
 pytest tests/test_doctor.py::TestRunDoctor           # one class
 pytest -k parity                                     # by keyword (parity checks span several files)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,12 +97,13 @@ python_files = [
     "test_*.py"
 ]
 
-addopts = "-ra"
+addopts = "-ra --strict-markers"
 
 markers = [
     "unit: unit tests",
     "bdd: BDD integration tests",
-    "contract: contract tests"
+    "contract: contract tests",
+    "e2e: full-install end-to-end tests (apply/doctor/calibrate cycles over real bundle trees); excluded from the fast loop via -m 'not e2e'",
 ]
 
 # Note: import-linter config below is a reference template for target projects.

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -23,6 +23,10 @@ from pathlib import Path
 import pytest
 import yaml
 
+# Full apply/doctor/calibrate cycles over real fixture repos — the slow tier.
+# The fast loop (`pytest -m "not e2e"`) skips this module.
+pytestmark = pytest.mark.e2e
+
 FIXTURES = Path(__file__).parent / "fixtures"
 
 

--- a/tests/test_stack_rules.py
+++ b/tests/test_stack_rules.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 import pytest
 
+# Full apply + stack-swap cycles over the real bundle — the slow tier.
+# The fast loop (`pytest -m "not e2e"`) skips this module.
+pytestmark = pytest.mark.e2e
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 STACK_DIR = REPO_ROOT / "cli" / "stacks" / "databricks-lakehouse"
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -372,8 +372,11 @@ class TestCheckEvalCriteria:
     def test_valid_criteria(self, tmp_path):
         write(tmp_path / "eval_criteria.yaml", VALID_EVAL_CRITERIA)
         result, msg = check_eval_criteria(tmp_path)
-        # Result is PASS or WARN depending on check-jsonschema availability
-        assert result is not CheckStatus.FAIL
+        # No governance tree can resolve under tmp_path, so the structure-OK
+        # path deterministically WARNs (schema validation skipped) — it must
+        # never silently PASS.
+        assert result is CheckStatus.WARN
+        assert "instance validation skipped" in msg
 
     def test_missing_version(self, tmp_path):
         write(tmp_path / "eval_criteria.yaml", """\


### PR DESCRIPTION
## What
Applies the two accepted findings from a unit-testing-rubric review: splits the suite into fast/full feedback loops and tightens one environment-tolerant assertion.

## Why
The single `pytest` loop ran 1213 tests in ~42s — over a ~30s fast-feedback budget and growing — with the cost concentrated in the two full-install e2e modules. Separately, `test_valid_criteria` asserted `is not CheckStatus.FAIL` citing check-jsonschema availability, but no governance tree can resolve under `tmp_path`, so the outcome is deterministically WARN — the tolerant assertion couldn't catch a regression that silently flipped it to PASS.

## Changes
- `tests/test_fixtures.py`, `tests/test_stack_rules.py`: module-level `pytestmark = pytest.mark.e2e` — the full apply/doctor/calibrate tier.
- `pyproject.toml`: registers the `e2e` marker and adds `--strict-markers` (merged into the existing `addopts`/`markers` keys) so a typo'd marker fails instead of silently matching nothing.
- `tests/test_validate.py`: `test_valid_criteria` now pins `CheckStatus.WARN` + the "instance validation skipped" message.
- `CLAUDE.md`: documents both loops in the commands block; corrects the stale "~765 tests" count.

## Testing
- Fast loop: `pytest -m "not e2e"` — 1138 passed in ~20s (75 deselected)
- Full loop: `pytest` — 1212 passed, 1 skipped in ~38s; CI invokes plain `pytest`, so its behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)