### PR TITLE
docs(plans): record completion status on the hexagonal vocabulary plan

### DIFF
--- a/plans/HEXAGONAL_LAYER_VOCABULARY_PLAN.md
+++ b/plans/HEXAGONAL_LAYER_VOCABULARY_PLAN.md
@@ -1,5 +1,10 @@
 # Hexagonal Layer Vocabulary and Boundary Contract Plan
 
+**Status:** Implemented — 2026-08-01, all 8 increments, via #82. Closed #75 and #77.
+Follow-ups deliberately left open: #83 (orphaned root-level codex rules after
+upgrade), #84 (D001 cannot resolve brace-expansion globs), #85 (L3 gate ships
+without a contract), #86 (skill_context has no multi-service shape).
+
 Settle the backend layer vocabulary across the whole payload — the domain
 layer's name, where entities live, and which source layout the tooling
 assumes — and replace `governance/backend/importlinter-reference.toml`


### PR DESCRIPTION
Adds a `**Status:**` line to `plans/HEXAGONAL_LAYER_VOCABULARY_PLAN.md`.

## Why

`plans/` has no way to distinguish a finished plan from an abandoned one. Only **7 of 21** carry any status marker, and `L5_IMPLEMENTATION_PLAN.md` / `IMPROVEMENT_PLAN.md` have been untouched since May with no indication whether they shipped. This plan read as active work despite landing in #82.

## The line

```
**Status:** Implemented — 2026-08-01, all 8 increments, via #82. Closed #75 and #77.
Follow-ups deliberately left open: #83, #84, #85, #86.
```

Naming the follow-ups matters as much as the status: #83–#86 were scoped out on purpose, and without that note a later reader would reasonably read them as things the plan missed.

## Convention going forward

```
**Status:** <Draft | Approved | In progress | Implemented | Superseded | Abandoned>
            — <date, PR, issues closed, follow-ups left open>
```

Deliberately *not* doing: thin tracking issues per plan. The status line lives with the plan, versioned alongside it, and needs no second source of truth to keep in sync.

This PR marks one plan. Backfilling the other 20 is a separate pass — several would need archaeology to determine what actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)