### PR TITLE
fix(doctor): expand brace globs so D001 stops reporting valid repos

### DIFF
--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -135,6 +135,21 @@ def _split_glob_list(value: str) -> list[str]:
     glob, not three — so a naive split would shred it into fragments that
     match nothing.
     """
+    return [p.strip() for p in _split_top_level_commas(value) if p.strip()]
+
+
+# Bound the fan-out from nested alternations so a pathological pattern
+# cannot turn one glob into thousands of filesystem walks.
+_MAX_BRACE_EXPANSIONS = 64
+
+
+def _split_top_level_commas(value: str) -> list[str]:
+    """Split on commas that sit outside any `{...}` group.
+
+    Used for both the comma-separated `applyTo` string and the body of a
+    brace group. In the second case it keeps a nested alternation whole:
+    the body of `{a,{b,c}}` is `a` and `{b,c}`, not `a`, `{b` and `c}`.
+    """
     parts: list[str] = []
     depth = 0
     current: list[str] = []
@@ -149,22 +164,62 @@ def _split_glob_list(value: str) -> list[str]:
             continue
         current.append(ch)
     parts.append("".join(current))
-    return [p.strip() for p in parts if p.strip()]
+    return parts
+
+
+def _expand_braces(pattern: str) -> list[str]:
+    """Expand `{a,b}` alternation into concrete patterns.
+
+    `pathlib` has no brace support, so `**/*.{py,go}` passed through
+    verbatim matches nothing — the rule looks broken against a repo full of
+    Python. Expanding to `**/*.py` and `**/*.go` and trying each restores
+    the meaning the rule author intended.
+
+    Handles nesting by expanding the leftmost group and recursing. Returns
+    `[pattern]` unchanged when there is no alternation, when braces are
+    unbalanced, or when expansion would exceed `_MAX_BRACE_EXPANSIONS`.
+    """
+    start = pattern.find("{")
+    if start == -1:
+        return [pattern]
+    depth = 0
+    for i in range(start, len(pattern)):
+        if pattern[i] == "{":
+            depth += 1
+        elif pattern[i] == "}":
+            depth -= 1
+            if depth == 0:
+                head, body, tail = pattern[:start], pattern[start + 1:i], pattern[i + 1:]
+                alternatives = _split_top_level_commas(body)
+                if len(alternatives) < 2:
+                    # `{x}` is not alternation — leave it for the caller's glob.
+                    break
+                out: list[str] = []
+                for alt in alternatives:
+                    for expanded in _expand_braces(head + alt + tail):
+                        out.append(expanded)
+                        if len(out) > _MAX_BRACE_EXPANSIONS:
+                            return [pattern]
+                return out
+    return [pattern]
 
 
 def _glob_resolves_in(target: Path, glob_pattern: str) -> bool:
     """Does `glob_pattern` match at least one path under `target`?
 
-    Patterns from rule files look like `**/adapters/**`. Path.glob handles
-    these natively. We accept matches on either files or directories.
+    Patterns from rule files look like `**/adapters/**`, which Path.glob
+    handles natively, or `**/*.{py,go}`, which it does not — brace
+    alternation is expanded first. We accept matches on either files or
+    directories.
     """
     # Normalize: rule globs use `**/x/**` to mean "x as a directory anywhere".
     # Path.glob requires that pattern syntax (also).
-    try:
-        for _ in target.glob(glob_pattern):
-            return True
-    except (ValueError, OSError):
-        return False
+    for candidate in _expand_braces(glob_pattern):
+        try:
+            for _ in target.glob(candidate):
+                return True
+        except (ValueError, OSError):
+            continue
     return False
 
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -299,6 +299,71 @@ class TestMonorepoDiscovery:
         assert "ports" in d001s[0].message
         assert d001s[0].file and "ports.md" in d001s[0].file
 
+    def test_d001_resolves_brace_expansion_globs(self, tmp_path):
+        """`**/*.{py,go,ts}` is one glob with three alternatives. Path.glob has
+        no brace expansion, so passing it through verbatim matches nothing and
+        reports D001 against a repo that plainly contains matching files.
+
+        Two shipped rules use this form — copilot's repo-scope-backend
+        (`{py,go,ts,js,java,rs,cs,rb,php}`) and its UI counterpart
+        (`{ts,tsx,js,jsx,html}`) — so every copilot install carried a
+        permanent, unfixable D001 error."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, agent="claude-code")
+        rules_dir = tmp_path / ".claude" / "rules" / "govkit"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "repo-scope.md").write_text(
+            '---\npaths:\n  - "**/*.{py,go,ts,js,java,rs,cs,rb,php}"\n---\n# Scope\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.py").write_text("x", encoding="utf-8")
+
+        findings = run_doctor(tmp_path)
+        d001s = [f for f in findings if f.id == "D001"]
+        assert d001s == [], f"brace glob should resolve against src/main.py; got: {d001s}"
+
+    def test_d001_still_fires_when_no_brace_alternative_matches(self, tmp_path):
+        """Expansion must not turn D001 into a rubber stamp — a brace glob
+        whose every alternative is absent still reports."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, agent="claude-code")
+        rules_dir = tmp_path / ".claude" / "rules" / "govkit"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "repo-scope.md").write_text(
+            '---\npaths:\n  - "**/*.{py,go,rs}"\n---\n# Scope\n', encoding="utf-8",
+        )
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "README.md").write_text("x", encoding="utf-8")
+
+        findings = run_doctor(tmp_path)
+        d001s = [f for f in findings if f.id == "D001"]
+        assert len(d001s) == 1
+        assert "{py,go,rs}" in d001s[0].message, (
+            "the reported glob should be the rule's own pattern, not an expansion"
+        )
+
+    def test_d001_resolves_copilot_brace_glob_in_comma_string(self, tmp_path):
+        """copilot combines both features: an `applyTo` comma-string whose
+        members may themselves contain brace alternation."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, agent="copilot")
+        rules_dir = tmp_path / ".github" / "instructions" / "govkit"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "ui.instructions.md").write_text(
+            '---\napplyTo: "**/*.{ts,tsx,js,jsx,html},**/components/**"\n---\n# UI\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "src" / "components").mkdir(parents=True)
+        (tmp_path / "src" / "app.tsx").write_text("x", encoding="utf-8")
+
+        findings = run_doctor(tmp_path)
+        d001s = [f for f in findings if f.id == "D001"]
+        assert d001s == [], f"both members should resolve; got: {d001s}"
+
     def test_d001_checks_rules_in_govkit_subdirectory(self, tmp_path):
         """Rules live in `.claude/rules/govkit/` once govkit owns its own
         namespace; doctor must descend into subdirectories, not just glob the


### PR DESCRIPTION
Closes #84.

## The bug

`pathlib` has no brace expansion, so `**/*.{py,go,ts}` handed to `Path.glob` matches nothing. D001 is severity **`error`**, so every install carrying such a rule reported a permanent, unfixable failure against a perfectly correct repo — which trains users to ignore the check CI is meant to gate on.

Two shipped rules use the form, so this hit copilot **backend and UI** installs, not just backend as originally filed:

| Rule | Glob |
| --- | --- |
| `instructions/generic/repo-scope-backend.instructions.md` | `**/*.{py,go,ts,js,java,rs,cs,rb,php}` |
| its UI counterpart | `**/*.{ts,tsx,js,jsx,html}` |

`repo-scope-backend` appears in four manifest variants, so effectively every copilot backend install was affected.

## The fix

`_expand_braces` rewrites alternations into concrete patterns; `_glob_resolves_in` accepts a match from any of them. Nesting expands leftmost-first and recurses. Unbalanced braces and single-member groups (`{only}`) pass through untouched. Fan-out is capped at 64 so a pathological pattern cannot become thousands of filesystem walks.

```
**/*.{py,go,ts}          -> ['**/*.py', '**/*.go', '**/*.ts']
**/*.{a,{b,c}}           -> ['**/*.a', '**/*.b', '**/*.c']
**/adapters/**           -> unchanged
unbalanced{a,b           -> unchanged
{a,b}{c,d}...{m,n}       -> capped, returns the original
```

The alternation body is split with the **same depth-aware helper** the comma-separated `applyTo` string uses. Splitting `{a,{b,c}}` naively gives `a`, `{b`, `c}` — the identical bug fixed for comma-strings in #82, and one I reintroduced here before catching it. `_split_glob_list` now delegates to the shared helper instead of carrying its own copy.

## Guarding against over-correction

A negative test pins that expansion did not turn D001 into a rubber stamp: a brace glob whose every alternative is absent still reports, and the message quotes the rule's own pattern rather than an expansion, so the finding stays actionable.

## Verification

`govkit apply --agent copilot --level 4 --type api` against a complete hexagonal repo:

```
doctor: clean — no findings
doctor: ok — no errors.
```

That state was not reachable before this change. Suite: 1241 fast + 84 e2e, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)