### PR TITLE
fix(cli): preserve team edits to the architecture block

### DIFF
--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -196,16 +196,33 @@ def _preserve_team_edits(existing: dict, architecture: dict) -> dict:
     Files from before this record existed have nothing to compare against,
     so they rewrite as they always did — the edit is lost once, then
     protected from the next run onward.
+
+    `layers` describes `style`, so the two are kept coherent: a team that
+    corrects only the style gets hints reseeded from the style they chose.
+    Without that, the file would claim one architecture while scoping rules
+    to another's folders — and since `rule_templating` expands these hints
+    into the concrete globs on every backend rule, the rules would target
+    packages the repo does not have.
     """
     recorded = existing.get(_PROVENANCE_KEY)
     live = existing.get("architecture")
     if not isinstance(recorded, dict) or not isinstance(live, dict):
         return architecture
+
+    preserved: set[str] = set()
     for key in _TEAM_TUNABLE_ARCHITECTURE:
         if key not in live or key not in recorded:
             continue
         if live[key] != recorded[key]:
             architecture[key] = live[key]
+            preserved.add(key)
+
+    # Only fills in for hints the team left alone — layers they chose
+    # deliberately are already preserved above and must win.
+    if "style" in preserved and "layers" not in preserved:
+        architecture["layers"] = deepcopy(
+            _STYLE_LAYERS.get(architecture.get("style"), _STYLE_LAYERS["unknown"]),
+        )
     return architecture
 
 

--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -14,6 +14,7 @@ The file lives at .govkit/skill_context.yaml alongside marker.json.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -156,6 +157,58 @@ def _extension_facts(target: Path) -> list[dict]:
     return out
 
 
+# Architecture fields govkit only *seeds*. A team may correct any of them
+# when detection guesses wrong, and that correction has to survive the
+# rewrite every apply / upgrade / stack apply / calibrate performs.
+#
+# `detected_signals` is deliberately absent: it is an observation of the
+# repo, never a preference, so it always refreshes.
+_TEAM_TUNABLE_ARCHITECTURE = ("style", "source_root", "layers")
+
+# Where govkit records what it derived, so a later run can tell a team's
+# edit from a value it wrote itself. Leading underscore marks it as
+# bookkeeping — `load_skill_context` does not expose it.
+_PROVENANCE_KEY = "_govkit_generated"
+
+
+def _read_existing_context(target: Path) -> dict:
+    """Parse the installed skill_context.yaml, or `{}` when absent/unreadable."""
+    path = target / ".govkit" / "skill_context.yaml"
+    if not path.is_file():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _preserve_team_edits(existing: dict, architecture: dict) -> dict:
+    """Overlay a team's architecture edits onto freshly derived values.
+
+    Provenance, not "non-empty wins": govkit records what it derived under
+    `_govkit_generated`, so a field differing from that record was edited by
+    hand and is kept, while a field still matching it refreshes normally.
+    That distinction is what lets an untouched install pick up new hints
+    when the repo is restructured or a stack is swapped, instead of freezing
+    whatever was written first.
+
+    Files from before this record existed have nothing to compare against,
+    so they rewrite as they always did — the edit is lost once, then
+    protected from the next run onward.
+    """
+    recorded = existing.get(_PROVENANCE_KEY)
+    live = existing.get("architecture")
+    if not isinstance(recorded, dict) or not isinstance(live, dict):
+        return architecture
+    for key in _TEAM_TUNABLE_ARCHITECTURE:
+        if key not in live or key not in recorded:
+            continue
+        if live[key] != recorded[key]:
+            architecture[key] = live[key]
+    return architecture
+
+
 def _pii_facts(target: Path) -> dict:
     """Seed the tunable PII keyword list, preserving a team's edited list.
 
@@ -204,8 +257,9 @@ def _stack_facts(marker: dict) -> dict:
 def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None = None) -> dict:
     """Build the skill-context dict that gets serialized to YAML.
 
-    Pure function — does no I/O beyond build_profile (which reads the
-    target tree) and discover_extensions (which reads target/extensions/).
+    Reads the target tree (build_profile, discover_extensions) and the
+    installed skill_context.yaml, so a team's hand-edits to the architecture
+    block and the PII keyword list survive the rewrite.
 
     Callers that already built a `RepoProfile` for this target (cmd_apply
     builds one during stack-overlay selection) can pass it in to skip a
@@ -219,13 +273,26 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
     level = marker.get("level")
 
     style = _infer_architecture_style(profile)
+    derived = {
+        "style": style,
+        "source_root": "src/",
+        # deepcopy, not a reference: handing out the module-level dict lets a
+        # caller mutating the result corrupt _STYLE_LAYERS for every later
+        # install in the process.
+        "layers": deepcopy(_STYLE_LAYERS.get(style, _STYLE_LAYERS["unknown"])),
+    }
+    existing = _read_existing_context(target)
+    # Independent copies. Sharing one object between the live block and the
+    # provenance record makes yaml.safe_dump emit an anchor and an alias, so
+    # on reload they are the same object again — a team's hand-edit would
+    # rewrite the very record it is compared against, silently disabling
+    # preservation.
+    architecture = _preserve_team_edits(existing, deepcopy(derived))
+    # Observation of the repo, not a preference — never preserved.
+    architecture["detected_signals"] = list(profile.detected_architecture_signals)
+
     return {
-        "architecture": {
-            "style": style,
-            "source_root": "src/",  # caller may edit post-write
-            "detected_signals": list(profile.detected_architecture_signals),
-            "layers": _STYLE_LAYERS.get(style, _STYLE_LAYERS["unknown"]),
-        },
+        "architecture": architecture,
         "stack": _stack_facts(marker),
         "ci": _CI_NAME.get(options.get("ci"), options.get("ci")),
         # The docs tree this install's type reads (docs/<area>/architecture/).
@@ -235,6 +302,10 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
         "llm": level == "5",
         "pii": _pii_facts(target),
         "extensions": _extension_facts(target),
+        # What govkit derived this run, regardless of what the live fields
+        # hold. Comparing the two is how the next write tells a team's edit
+        # from a value govkit wrote itself.
+        _PROVENANCE_KEY: derived,
     }
 
 

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -495,6 +495,207 @@ class TestLoadSkillContextDocsArea:
             assert ctx.docs_area == ""
 
 
+class TestArchitectureEditPreservation:
+    """A team's hand-edits to the architecture block must survive the rewrite
+    that apply / upgrade / stack apply / calibrate each perform.
+
+    Two comments in cli/skill_context.py have long promised this — "Teams
+    using medallion (bronze/silver/gold) edit `architecture.layers` ...
+    directly during calibrate" and `source_root` "caller may edit
+    post-write" — while every write clobbered both.
+
+    Preservation is provenance-based rather than "non-empty wins": govkit
+    records what it derived, so a value differing from that record is a
+    team edit and is kept, while an untouched value still refreshes when
+    the derivation legitimately changes (a stack swap, a restructured repo).
+    """
+
+    @staticmethod
+    def _read(target):
+        import yaml
+        return yaml.safe_load(
+            (target / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+        )
+
+    @staticmethod
+    def _edit(target, mutate):
+        import yaml
+        path = target / ".govkit" / "skill_context.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        mutate(data)
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    def _hexagonal(self, tmp_path):
+        (tmp_path / "src" / "ports").mkdir(parents=True)
+        (tmp_path / "src" / "adapters").mkdir(parents=True)
+
+    def test_rewrite_preserves_edited_layers(self, tmp_path):
+        """The medallion case the docstring promises: a data team renames the
+        layer hints to bronze/silver/gold and re-runs calibrate."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        medallion = {"inbound": ["bronze/"], "outbound": ["gold/"], "domain": ["silver/"]}
+        self._edit(tmp_path, lambda d: d["architecture"].update(layers=medallion))
+
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["layers"] == medallion
+
+    def test_rewrite_preserves_a_single_edited_layer_hint(self, tmp_path):
+        """Editing one hint in place is what a team actually does, and it must
+        not silently edit the provenance record too.
+
+        The live block and the record must be independent objects. Sharing
+        one makes `yaml.safe_dump` emit an anchor and an alias, so on reload
+        they are the same object again — a hand-edit rewrites the record it
+        is supposed to be compared against, and preservation quietly stops
+        working while whole-dict replacement still appears to pass."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        self._edit(tmp_path, lambda d: d["architecture"]["layers"].__setitem__("domain", ["core/"]))
+        raw = (tmp_path / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8")
+        assert "*id" not in raw, f"YAML alias in skill_context.yaml:\n{raw}"
+
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["layers"]["domain"] == ["core/"]
+
+    def test_style_layers_constant_is_not_mutated(self, tmp_path):
+        """The derived block must be a copy — handing out the module-level
+        _STYLE_LAYERS dict lets any caller corrupt every later install in
+        the same process."""
+        from cli.skill_context import _STYLE_LAYERS, build_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        data = build_skill_context(tmp_path, marker)
+        data["architecture"]["layers"]["domain"] = ["mutated/"]
+
+        assert _STYLE_LAYERS["hexagonal"]["domain"] == ["services/", "models/"]
+
+    def test_rewrite_preserves_edited_source_root(self, tmp_path):
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        self._edit(tmp_path, lambda d: d["architecture"].update(source_root="services/"))
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["source_root"] == "services/"
+
+    def test_rewrite_preserves_edited_style(self, tmp_path):
+        """Detection can guess wrong on a mixed repo; a corrected style must
+        stick, and must keep the layer hints the team chose with it."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        self._edit(tmp_path, lambda d: d["architecture"].update(style="clean"))
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["style"] == "clean"
+
+    def test_untouched_values_still_refresh_when_derivation_changes(self, tmp_path):
+        """The reason this is not "non-empty wins": a team that never edited
+        the file must still get updated hints when the repo's shape changes.
+        Freezing the first-written value would be its own bug."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+        assert self._read(tmp_path)["architecture"]["style"] == "hexagonal"
+
+        # Repo restructured into Clean Architecture; nothing was hand-edited.
+        for layer in ("Application", "Domain", "Infrastructure", "Presentation"):
+            (tmp_path / "src" / layer).mkdir(parents=True, exist_ok=True)
+        for layer in ("ports", "adapters"):
+            (tmp_path / "src" / layer).rmdir()
+
+        write_skill_context(tmp_path, marker)
+
+        arch = self._read(tmp_path)["architecture"]
+        assert arch["style"] == "clean"
+        assert arch["layers"]["domain"] == ["Application/", "Domain/"]
+
+    def test_detected_signals_always_refresh(self, tmp_path):
+        """detected_signals is pure observation of the repo, never a team
+        preference, so it must not be caught by preservation."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+        self._edit(tmp_path, lambda d: d["architecture"].update(
+            style="clean", detected_signals=["nonsense"],
+        ))
+
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["detected_signals"] == ["hexagonal-shape"]
+
+    def test_fresh_install_is_unaffected(self, tmp_path):
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        arch = self._read(tmp_path)["architecture"]
+        assert arch["style"] == "hexagonal"
+        assert arch["layers"]["domain"] == ["services/", "models/"]
+
+    def test_load_skill_context_ignores_the_provenance_record(self, tmp_path):
+        """The bookkeeping govkit writes must not leak into the typed view
+        skills consume."""
+        from cli.skill_context import load_skill_context, write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.architecture_style == "hexagonal"
+        assert ctx.layers["domain"] == ["services/", "models/"]
+
+    def test_missing_provenance_record_does_not_crash(self, tmp_path):
+        """Files written by an older govkit carry no record. Those rewrite as
+        before rather than failing — the edit is lost once, then protected."""
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        path = tmp_path / ".govkit" / "skill_context.yaml"
+        path.write_text(
+            yaml.safe_dump({
+                "architecture": {"style": "layered", "source_root": "app/", "layers": {}},
+                "stack": {}, "pii": {"keyword_list": ["email"]},
+            }, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        write_skill_context(tmp_path, marker)
+
+        data = self._read(tmp_path)
+        assert data["architecture"]["style"] == "hexagonal"
+        assert data["pii"]["keyword_list"] == ["email"]
+
+
 class TestPiiKeywordList:
     def test_write_seeds_default_keyword_list(self, tmp_path):
         import yaml

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -595,7 +595,7 @@ class TestArchitectureEditPreservation:
 
     def test_rewrite_preserves_edited_style(self, tmp_path):
         """Detection can guess wrong on a mixed repo; a corrected style must
-        stick, and must keep the layer hints the team chose with it."""
+        stick."""
         from cli.skill_context import write_skill_context
 
         marker = _write_marker(tmp_path)
@@ -606,6 +606,63 @@ class TestArchitectureEditPreservation:
         write_skill_context(tmp_path, marker)
 
         assert self._read(tmp_path)["architecture"]["style"] == "clean"
+
+    def test_editing_only_style_reseeds_the_layer_hints(self, tmp_path):
+        """`layers` describes `style` — the two cannot disagree.
+
+        Correcting the style alone is the natural edit: a team on a mixed
+        repo fixes the one field they can see is wrong. If `layers` then
+        kept the *detected* style's hints, the file would claim Clean
+        Architecture while scoping rules to hexagonal folders, and
+        rule_templating would expand globs for packages the repo does not
+        have."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        self._edit(tmp_path, lambda d: d["architecture"].update(style="clean"))
+        write_skill_context(tmp_path, marker)
+
+        arch = self._read(tmp_path)["architecture"]
+        assert arch["style"] == "clean"
+        assert arch["layers"]["domain"] == ["Application/", "Domain/"]
+        assert arch["layers"]["outbound"] == ["Infrastructure/"]
+
+    def test_editing_style_and_layers_keeps_the_teams_layers(self, tmp_path):
+        """Reseeding must not overwrite hints the team chose deliberately —
+        it only fills in for hints they left alone."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        custom = {"inbound": ["Web/"], "outbound": ["Data/"], "domain": ["Core/"]}
+        self._edit(tmp_path, lambda d: d["architecture"].update(style="clean", layers=custom))
+        write_skill_context(tmp_path, marker)
+
+        arch = self._read(tmp_path)["architecture"]
+        assert arch["style"] == "clean"
+        assert arch["layers"] == custom
+
+    def test_unrecognised_edited_style_falls_back_to_empty_hints(self, tmp_path):
+        """A style govkit does not know cannot seed hints; empty lists tell
+        skills to ask rather than guess, and rule_templating leaves each
+        rule's fallback glob intact."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        self._hexagonal(tmp_path)
+        write_skill_context(tmp_path, marker)
+
+        self._edit(tmp_path, lambda d: d["architecture"].update(style="onion"))
+        write_skill_context(tmp_path, marker)
+
+        arch = self._read(tmp_path)["architecture"]
+        assert arch["style"] == "onion"
+        assert arch["layers"] == {"inbound": [], "outbound": [], "domain": []}
 
     def test_untouched_values_still_refresh_when_derivation_changes(self, tmp_path):
         """The reason this is not "non-empty wins": a team that never edited


### PR DESCRIPTION
Closes #76.

## The bug

`write_skill_context` regenerated the entire file on every `apply`, `upgrade`, `stack apply`, and `calibrate`. `pii.keyword_list` was the **only** field with read-back preservation, so hand-edits to `architecture.layers` and `architecture.source_root` were destroyed every run — the downstream report that opened this issue lost the same fix three times.

Two comments in the module had long promised otherwise:

- *"Teams using medallion (bronze/silver/gold) edit `architecture.layers` in skill_context.yaml directly during calibrate"*
- `"source_root": "src/",  # caller may edit post-write`

Both are now true.

## Why provenance, not "non-empty wins"

The obvious fix — keep whatever is already there — would be its own bug. An untouched install must still pick up new hints when the repo is restructured or a stack is swapped; freezing the first-written value breaks that.

So govkit records what it derived under `_govkit_generated`. A live field **differing** from that record was edited by hand and is kept; a field still **matching** it refreshes normally. A test pins the refresh case: a repo restructured from hexagonal to Clean gets `style: clean` and Clean layer hints, because nothing was hand-edited.

`detected_signals` is excluded entirely — it observes the repo, it is never a preference.

## The aliasing bug underneath

Found only by running the reporter's actual scenario; the unit tests were green.

`derived["layers"]` handed out the module-level `_STYLE_LAYERS` dict **by reference**, shared with the provenance record. `yaml.safe_dump` therefore emitted an anchor and an alias, and on reload both were the same object again. A team editing one hint *in place* silently rewrote the record it was supposed to be compared against — preservation stopped working, while whole-dict replacement (what my first test did) still appeared to pass.

Deep copies fix it, and also stop a caller from corrupting `_STYLE_LAYERS` for every later install in the process.

Two tests cover it: one asserts no YAML alias survives a single nested edit, one asserts the module constant is never mutated. Without the fix the second **contaminates later tests in the same process** — which is how sharp the aliasing was.

## Verification

`apply` → edit two fields in place → `calibrate` ×3 → `upgrade --force` → `stack apply`:

```
domain      = ['core/']        (team value kept)
source_root = 'src/mypkg/'     (team value kept)
signals     = ['hexagonal-shape']  (refreshed)
stack.id    = 'python-fastapi'     (refreshed)
```

Suite: 1248 fast + 84 e2e, green.

## Migration

Files written before the record existed have nothing to compare against, so they rewrite as they always did — the edit is lost once, then protected from the next run onward. A test pins that this path does not crash and still preserves `pii.keyword_list`.

## Related

#86 covers the separate gap that `source_root` cannot describe a multi-service repo at all. Preserving an edit is worth more once the field can express the layout; that stays a schema decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)