### PR TITLE
fix(cli): widen LLM SDK detection across markers and manifests

### DIFF
--- a/cli/detect.py
+++ b/cli/detect.py
@@ -48,7 +48,44 @@ _LANG_FILE_SIGNALS: list[tuple[str, str]] = [
 ]
 
 # LLM SDK / framework markers — substring searches in dep manifests.
-_LLM_MARKERS = ("langchain", "litellm", "openai", "anthropic", "semantic-kernel", "langgraph")
+# Substrings that mark an LLM dependency, matched case-insensitively against
+# the text of a dependency file. Chosen to cover each ecosystem's spelling of
+# the same SDK — `anthropic` catches both `@anthropic-ai/sdk` and
+# `Anthropic.SDK`, `openai` catches `Azure.AI.OpenAI` and `go-openai` — so
+# the list stays shorter than the set of packages it recognises.
+#
+# `claude-agent-sdk` needs its own entry: it drives the Claude Code CLI and
+# never pulls in `anthropic`, which is how a Claude-based service could look
+# like it had no LLM dependency at all.
+_LLM_MARKERS = (
+    # Anthropic
+    "anthropic", "claude-agent-sdk", "claude-code-sdk",
+    # OpenAI (also matches azure.ai.openai, go-openai, openai-agents)
+    "openai",
+    # Google
+    "genai", "generativeai", "vertexai", "vertex-ai",
+    # AWS / local runtimes
+    "bedrock", "ollama",
+    # Orchestration frameworks
+    "langchain", "langgraph", "llama", "haystack", "dspy",
+    "semantic-kernel", "semantickernel", "spring-ai",
+    # Multi-agent frameworks
+    "crewai", "autogen", "pydantic-ai",
+    # Gateways and other providers
+    "litellm", "mistralai", "cohere", "instructor",
+)
+
+# Dependency manifests scanned for those markers, as fnmatch patterns.
+# Covers every stack govkit ships an overlay for — omitting .csproj, go.mod
+# and build.gradle meant D008 false-negatived on dotnet-aspnet, go-gin and
+# java-spring-boot no matter which SDK the project used.
+_DEP_FILE_PATTERNS = (
+    "pyproject.toml", "requirements*.txt",   # python
+    "package.json",                          # node
+    "pom.xml", "build.gradle", "build.gradle.kts",  # java (maven + gradle)
+    "*.csproj",                              # .net
+    "go.mod",                                # go
+)
 
 # Architecture style markers — folder names (any depth under target).
 _HEXAGONAL_FOLDERS = {"ports", "adapters"}
@@ -113,16 +150,24 @@ _SKIP_DIRS = frozenset({
 })
 
 
-def _find_recursive(target: Path, pattern: str, max_depth: int = 4) -> list[Path]:
+def _find_recursive(
+    target: Path, pattern: str | tuple[str, ...], max_depth: int = 4,
+) -> list[Path]:
     """Recursive search bounded by depth, pruning noise dirs during traversal.
 
     Uses os.walk with in-place `dirnames[:]` mutation so node_modules / .venv /
     etc. are never entered — important for large repos where rglob's
     walk-then-filter approach dominated build_profile() runtime.
 
+    `pattern` may be a tuple, in which case a file matching any of them is
+    returned from a single walk. Callers needing several manifests should
+    pass them together rather than calling once per pattern — the walk, not
+    the matching, is what costs.
+
     Depth is counted as path segments from target: a file at target/a/b/c.txt
     is depth 3. With max_depth=4, files up to four segments deep are returned.
     """
+    patterns = (pattern,) if isinstance(pattern, str) else tuple(pattern)
     matches: list[Path] = []
     if not target.is_dir():
         return matches
@@ -138,7 +183,7 @@ def _find_recursive(target: Path, pattern: str, max_depth: int = 4) -> list[Path
                 dirnames[:] = []
                 continue
             for fname in filenames:
-                if fnmatch.fnmatch(fname, pattern):
+                if any(fnmatch.fnmatch(fname, p) for p in patterns):
                     matches.append(current / fname)
             if depth + 1 >= max_depth:
                 # Next level's files would exceed max_depth; stop descent.
@@ -218,7 +263,7 @@ def _detect_aspnet_core(target: Path) -> bool:
 
 def _detect_fastapi(target: Path) -> bool:
     """Substring search across pyproject.toml + requirements*.txt."""
-    py_files = _find_recursive(target, "pyproject.toml") + _find_recursive(target, "requirements*.txt")
+    py_files = _find_recursive(target, ("pyproject.toml", "requirements*.txt"))
     for path in py_files:
         text = _read_text(path)
         if "fastapi" in text.lower():
@@ -274,11 +319,7 @@ def _detect_tailwindcss(target: Path) -> bool:
 
 def _detect_spring_boot(target: Path) -> bool:
     """Substring search across pom.xml and build.gradle*."""
-    candidates = (
-        _find_recursive(target, "pom.xml")
-        + _find_recursive(target, "build.gradle")
-        + _find_recursive(target, "build.gradle.kts")
-    )
+    candidates = _find_recursive(target, ("pom.xml", "build.gradle", "build.gradle.kts"))
     for path in candidates:
         text = _read_text(path)
         if "spring-boot" in text or "springframework.boot" in text:
@@ -489,12 +530,15 @@ def _detect_architecture(target: Path, prof: RepoProfile) -> None:
 # ---------------------------------------------------------------------------
 
 def _detect_llm_signals(target: Path, prof: RepoProfile) -> None:
-    candidates = (
-        _find_recursive(target, "pyproject.toml")
-        + _find_recursive(target, "requirements*.txt")
-        + ([target / "package.json"] if (target / "package.json").is_file() else [])
-        + _find_recursive(target, "pom.xml")
-    )
+    """Record which LLM SDK markers appear in the repo's dependency files.
+
+    package.json is searched recursively like every other manifest — a JS
+    monorepo keeps its dependencies in `apps/<app>/package.json`, and only
+    reading the root one hid them. `_find_recursive` prunes node_modules and
+    bounds depth, so this stays cheap.
+    """
+    candidates = _find_recursive(target, _DEP_FILE_PATTERNS)
+
     found: list[str] = []
     for path in candidates:
         text = _read_text(path).lower()

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -498,6 +498,18 @@ def _check_llm_leakage_in_non_l5(target: Path, marker: dict) -> list[ValidationF
     return findings
 
 
+def _dep_files_checked() -> str:
+    """Human-readable list of the manifests the LLM scan reads.
+
+    Derived from detect._DEP_FILE_PATTERNS rather than restated, so the
+    message cannot claim to check files the scan does not — the drift that
+    let this finding name four manifests while the repo shipped stacks
+    using three others.
+    """
+    from .detect import _DEP_FILE_PATTERNS
+    return " / ".join(_DEP_FILE_PATTERNS)
+
+
 @_register_check("D008")
 def _check_l5_without_llm_deps(target: Path, marker: dict) -> list[ValidationFinding]:
     """D008 — install is L5 (GenAI Operations) but no LLM SDK appears in
@@ -505,7 +517,7 @@ def _check_l5_without_llm_deps(target: Path, marker: dict) -> list[ValidationFin
     """
     if marker.get("level") != "5":
         return []
-    from .detect import build_profile
+    from .detect import _LLM_MARKERS, build_profile
     profile = build_profile(target)
     if profile.detected_llm_signals:
         return []
@@ -516,8 +528,8 @@ def _check_l5_without_llm_deps(target: Path, marker: dict) -> list[ValidationFin
         file=None,
         message=(
             "level is 5 (GenAI Operations) but no LLM SDK detected in repo "
-            "(checked pyproject.toml / requirements / package.json / pom.xml "
-            "for langchain, litellm, openai, anthropic, semantic-kernel, langgraph)"
+            f"(checked {_dep_files_checked()} for "
+            f"{len(_LLM_MARKERS)} known SDK markers)"
         ),
         suggested_action=(
             "if this is not actually an LLM service, downgrade with "

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -387,6 +387,65 @@ class TestLLMSignals:
         prof = build_profile(tmp_path)
         assert prof.detected_llm_signals == []
 
+    def test_claude_agent_sdk_detected(self, tmp_path):
+        """The SDK that drives the Claude Code CLI. It never pulls in
+        `anthropic`, so the substring match on that name misses it entirely —
+        the false negative this check was reported for."""
+        from cli.detect import build_profile
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname="x"\ndependencies = ["claude-agent-sdk>=0.1"]\n',
+            encoding="utf-8",
+        )
+        prof = build_profile(tmp_path)
+        assert prof.detected_llm_signals
+
+    @pytest.mark.parametrize(
+        ("filename", "content"),
+        [
+            ("app.csproj", '<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />'),
+            ("app.csproj", '<PackageReference Include="Microsoft.SemanticKernel" Version="1.0" />'),
+            ("go.mod", "require github.com/sashabaranov/go-openai v1.32.0"),
+            ("go.mod", "require github.com/tmc/langchaingo v0.1.12"),
+            ("build.gradle", "implementation 'dev.langchain4j:langchain4j:0.35.0'"),
+            ("build.gradle.kts", 'implementation("org.springframework.ai:spring-ai-core:1.0.0")'),
+        ],
+    )
+    def test_llm_detected_in_stack_dependency_files(self, tmp_path, filename, content):
+        """govkit ships dotnet-aspnet, go-gin and java-spring-boot stacks, but
+        the scan only read pyproject / requirements / package.json / pom.xml —
+        so D008 false-negatived on three of its own supported stacks
+        regardless of which SDK was in use."""
+        from cli.detect import build_profile
+
+        (tmp_path / filename).write_text(content, encoding="utf-8")
+        prof = build_profile(tmp_path)
+        assert prof.detected_llm_signals, f"{filename} with {content!r} not detected"
+
+    def test_package_json_found_below_the_target_root(self, tmp_path):
+        """Only the root package.json was checked, unlike every other
+        dependency file, so a JS monorepo hid its dependencies from the scan."""
+        from cli.detect import build_profile
+
+        app = tmp_path / "apps" / "web"
+        app.mkdir(parents=True)
+        (app / "package.json").write_text(
+            '{"dependencies":{"@anthropic-ai/sdk":"^0.30.0"}}', encoding="utf-8",
+        )
+        prof = build_profile(tmp_path)
+        assert prof.detected_llm_signals
+
+    def test_plain_dotnet_and_go_repos_stay_clean(self, tmp_path):
+        """Widening the file scan must not widen false positives."""
+        from cli.detect import build_profile
+
+        (tmp_path / "app.csproj").write_text(
+            '<PackageReference Include="Microsoft.AspNetCore.App" />', encoding="utf-8",
+        )
+        (tmp_path / "go.mod").write_text("require github.com/gin-gonic/gin v1.10.0", encoding="utf-8")
+        prof = build_profile(tmp_path)
+        assert prof.detected_llm_signals == []
+
 
 class TestTargetScoping:
     """A10: build_profile takes an explicit target. Detectors must never walk

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -135,6 +135,57 @@ class TestUnexpandedSkillTokens:
         assert [f for f in findings if f.id == "D015"] == []
 
 
+class TestD008LlmDependencies:
+    def test_does_not_fire_for_a_claude_agent_sdk_service(self, tmp_path):
+        """The reported false negative: a service driving the Claude Code CLI
+        has no `anthropic` dependency, so the old marker list saw nothing."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, level="5")
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname="x"\ndependencies = ["claude-agent-sdk>=0.1"]\n',
+            encoding="utf-8",
+        )
+        assert [f for f in run_doctor(tmp_path) if f.id == "D008"] == []
+
+    def test_does_not_fire_for_a_dotnet_llm_service(self, tmp_path):
+        """govkit ships a dotnet-aspnet stack, but .csproj was never scanned."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, level="5")
+        (tmp_path / "app.csproj").write_text(
+            '<PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />',
+            encoding="utf-8",
+        )
+        assert [f for f in run_doctor(tmp_path) if f.id == "D008"] == []
+
+    def test_still_fires_for_an_l5_install_with_no_llm_dependency(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, level="5")
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname="x"\ndependencies = ["fastapi"]\n', encoding="utf-8",
+        )
+        hits = [f for f in run_doctor(tmp_path) if f.id == "D008"]
+        assert len(hits) == 1
+        assert hits[0].severity == "info"
+
+    def test_message_names_every_manifest_the_scan_actually_reads(self, tmp_path):
+        """The message used to restate the file list in prose, which is how it
+        came to advertise four manifests while the scan covered three of
+        govkit's own stacks not at all. Deriving it removes the drift."""
+        from cli.detect import _DEP_FILE_PATTERNS
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, level="5")
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname="x"\ndependencies = ["fastapi"]\n', encoding="utf-8",
+        )
+        message = [f for f in run_doctor(tmp_path) if f.id == "D008"][0].message
+        for pattern in _DEP_FILE_PATTERNS:
+            assert pattern in message, f"{pattern} scanned but not named in D008"
+
+
 class TestNextjsBoundary:
     def test_database_dependency_is_a_non_waivable_error(self, tmp_path):
         from cli.doctor import run_doctor


### PR DESCRIPTION
Closes #79.

D008 told L5 installs "no LLM SDK detected" for two independent reasons.

## Markers

The list held six names. **`claude-agent-sdk` was not one of them**, and it never pulls in `anthropic`, so a service driving the Claude Code CLI looked like it had no LLM dependency at all — the case this was reported for.

Now 25 markers, chosen so one entry covers each ecosystem's spelling of the same SDK: `anthropic` catches both `@anthropic-ai/sdk` and `Anthropic.SDK`; `openai` catches `Azure.AI.OpenAI` and `go-openai`. That keeps the list shorter than the set of packages it recognises.

## Manifests

The scan read `pyproject.toml` / `requirements*.txt` / `package.json` / `pom.xml` — so it false-negatived on **dotnet-aspnet, go-gin and java-spring-boot**, three stacks govkit ships overlays for, whatever SDK they used.

Adds `*.csproj`, `go.mod`, `build.gradle`, `build.gradle.kts`. `package.json` is now searched recursively like every other manifest; reading only the root one hid a JS monorepo's dependencies in `apps/<app>/`.

## The message could drift, so now it can't

D008 restated the file list in prose — which is exactly how it came to advertise four manifests while three of govkit's own stacks went unscanned. It now derives from `_DEP_FILE_PATTERNS`, and a test asserts every scanned pattern appears in the message.

```
level is 5 (GenAI Operations) but no LLM SDK detected in repo (checked
pyproject.toml / requirements*.txt / package.json / pom.xml / build.gradle /
build.gradle.kts / *.csproj / go.mod for 25 known SDK markers)
```

## Performance — I regressed it, then fixed it

Scanning eight patterns as eight separate walks measured **2.6x slower than main**. The walk costs, not the matching:

| approach | this repo | vs main |
| --- | --- | --- |
| original (main, 3 walks) | 83 ms | — |
| my first cut (8 walks) | 218 ms | **2.6x slower** |
| current (1 walk, 8 patterns) | 35 ms | **2.4x faster** |

`_find_recursive` now accepts a tuple and matches any of them in a single walk. Applied to the Java and Python framework detectors too, which each walked once per pattern for the same reason.

**Net: `build_profile` on this repo 351 ms → 242 ms**, while covering twice the manifest types.

Worth noting I first chased this through the test suite, where totals swung 80s → 68s → 38s → 21s. That was machine noise — no test exceeds 0.40s. The microbenchmark above is what actually isolated it.

## Guards

Widening the scan must not widen false positives: a plain .NET repo (`Microsoft.AspNetCore.App`) and a plain Go repo (`gin-gonic/gin`) still report no LLM signals.

Suite: 1267 fast + 84 e2e, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)