### PR TITLE
fix: ship a working boundary contract from L3

### DIFF
--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -37,7 +37,8 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/"
+          "docs/backend/architecture/",
+          "governance/backend/importlinter-reference.toml"
         ],
         "level_4": {
           "mode": "merge",
@@ -56,7 +57,8 @@
           "governed": [
             "docs/backend/evaluation/",
             "docs/backend/guides/",
-            "governance/backend/",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         },
@@ -91,7 +93,9 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/",
+            "governance/backend/importlinter-reference.toml",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         }
@@ -109,7 +113,8 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/"
+          "docs/backend/architecture/",
+          "governance/backend/importlinter-reference.toml"
         ],
         "level_4": {
           "mode": "merge",
@@ -127,7 +132,8 @@
           "governed": [
             "docs/backend/evaluation/",
             "docs/backend/guides/",
-            "governance/backend/",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         },
@@ -161,7 +167,9 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/",
+            "governance/backend/importlinter-reference.toml",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         }

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -70,7 +70,8 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/"
+          "docs/backend/architecture/",
+          "governance/backend/importlinter-reference.toml"
         ],
         "level_4": {
           "mode": "merge",
@@ -89,7 +90,8 @@
           "governed": [
             "docs/backend/evaluation/",
             "docs/backend/guides/",
-            "governance/backend/",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         },
@@ -124,7 +126,9 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/",
+            "governance/backend/importlinter-reference.toml",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         }
@@ -142,7 +146,8 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/"
+          "docs/backend/architecture/",
+          "governance/backend/importlinter-reference.toml"
         ],
         "level_4": {
           "mode": "merge",
@@ -160,7 +165,8 @@
           "governed": [
             "docs/backend/evaluation/",
             "docs/backend/guides/",
-            "governance/backend/",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         },
@@ -194,7 +200,9 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/",
+            "governance/backend/importlinter-reference.toml",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         }

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -70,7 +70,8 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/"
+          "docs/backend/architecture/",
+          "governance/backend/importlinter-reference.toml"
         ],
         "level_4": {
           "mode": "merge",
@@ -89,7 +90,8 @@
           "governed": [
             "docs/backend/evaluation/",
             "docs/backend/guides/",
-            "governance/backend/",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         },
@@ -117,7 +119,9 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/",
+            "governance/backend/importlinter-reference.toml",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         }
@@ -135,7 +139,8 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/"
+          "docs/backend/architecture/",
+          "governance/backend/importlinter-reference.toml"
         ],
         "level_4": {
           "mode": "merge",
@@ -153,7 +158,8 @@
           "governed": [
             "docs/backend/evaluation/",
             "docs/backend/guides/",
-            "governance/backend/",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         },
@@ -180,7 +186,9 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/",
+            "governance/backend/importlinter-reference.toml",
+            "governance/backend/schemas/",
+            "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
           ]
         }

--- a/ci/README.md
+++ b/ci/README.md
@@ -54,18 +54,36 @@ Copy the relevant templates for your project type:
 
 ---
 
+### Boundary enforcement is opt-in
+
+`boundary-check` runs `import-linter` against the contract in your
+`pyproject.toml` (or `.importlinter` / `setup.cfg` / `tox.ini`). govkit ships
+`governance/backend/importlinter-reference.toml` as a **template** — copy it in
+and replace `myservice` with your package name to switch enforcement on.
+
+Until you do, the job **skips** rather than failing, so a fresh install is
+green. It logs a notice telling you how to enable it.
+
+Two consequences worth knowing:
+
+- Boundary enforcement ships from **L3** upward. L3 has no `features/` model,
+  but it does carry the architecture contracts, and this is what enforces them.
+- import-linter is Python-only, so the job stays skipped on the `go-gin`,
+  `dotnet-aspnet`, `java-spring-boot` and `nodejs-fastify` stacks. Equivalent
+  per-stack tooling is tracked separately — a skipped job is honest, a Python
+  linter pointed at Go is not.
+
+---
+
 ## Level 3 vs Level 4 CI
 
 | Pipeline | Level 3 | Level 4 |
 |----------|---------|---------|
-| `l3-quality-gate.yml` | Governance artifacts (3), commit format, SonarQube, Snyk | — |
+| `l3-quality-gate.yml` | Governance artifacts (3), commit format, boundary enforcement, SonarQube, Snyk | — |
 | `quality-gate.yml` | — | Schema validation, boundary enforcement, SonarQube, Snyk, contract compatibility, governance artifacts (5), commit format |
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |
 | `ui-eval-gate.yml` | — | FIRST/Virtue prediction, Playwright E2E, axe scans |
-| `l3-ui-nextjs-quality-gate.yml` | Next.js typecheck, lint, tests, build, and API/database boundary | — |
-| `ui-nextjs-quality-gate.yml` | — | Next.js typecheck, lint, tests, build, feature validation, and API/database boundary |
-| `ui-nextjs-eval-gate.yml` | — | Next.js Playwright + axe, with opt-in stable screenshot comparisons |
 | `l3-ui-nextjs-quality-gate.yml` | Next.js typecheck, lint, tests, build, and API/database boundary | — |
 | `ui-nextjs-quality-gate.yml` | — | Next.js typecheck, lint, tests, build, feature validation, and API/database boundary |
 | `ui-nextjs-eval-gate.yml` | — | Next.js Playwright + axe, with opt-in stable screenshot comparisons |

--- a/ci/azure/l3-quality-gate.yml
+++ b/ci/azure/l3-quality-gate.yml
@@ -75,9 +75,19 @@ stages:
         steps:
           - checkout: self
 
+          # govkit ships governance/backend/importlinter-reference.toml as a
+          # template; the contract is only live once you copy it in and set
+          # the package name. Until then this step skips rather than failing,
+          # so a fresh install is green. It also skips on non-Python stacks,
+          # which import-linter cannot check at all.
           - script: |
-              pip install import-linter
-              lint-imports
+              if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+                 || [ -f .importlinter ]; then
+                pip install import-linter
+                lint-imports
+              else
+                echo "##vso[task.logissue type=warning]No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
+              fi
             displayName: Enforce hexagonal architecture boundaries
 
   - stage: SonarQube

--- a/ci/azure/quality-gate.yml
+++ b/ci/azure/quality-gate.yml
@@ -54,10 +54,23 @@ stages:
         steps:
           - checkout: self
 
-          - script: pip install import-linter
+          # See ci/README.md — skips when no contract is configured, so a
+          # fresh install is green and non-Python stacks are not checked by a
+          # Python linter.
+          - script: |
+              if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+                 || [ -f .importlinter ]; then
+                pip install import-linter
+              else
+                echo "##vso[task.logissue type=warning]No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
+              fi
             displayName: Install import-linter
 
-          - script: lint-imports
+          - script: |
+              if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+                 || [ -f .importlinter ]; then
+                lint-imports
+              fi
             displayName: Run boundary checks
 
   - stage: SonarQube

--- a/ci/github/l3-quality-gate.yml
+++ b/ci/github/l3-quality-gate.yml
@@ -75,10 +75,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # govkit ships governance/backend/importlinter-reference.toml as a
+      # template; the contract is only live once you copy it in and set the
+      # package name. Until then this job skips rather than failing, so a
+      # fresh install is green. It also skips on non-Python stacks, which
+      # import-linter cannot check at all — see the per-stack tracking issue.
+      - name: Detect import-linter contract
+        id: contract
+        run: |
+          if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+             || [ -f .importlinter ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
+          fi
+
       - name: Install import-linter
+        if: steps.contract.outputs.found == 'true'
         run: pip install import-linter
 
       - name: Run boundary checks
+        if: steps.contract.outputs.found == 'true'
         run: lint-imports
 
   sonarqube:

--- a/ci/github/quality-gate.yml
+++ b/ci/github/quality-gate.yml
@@ -56,10 +56,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # See ci/README.md — skips when no contract is configured, so a fresh
+      # install is green and non-Python stacks are not checked by a Python
+      # linter.
+      - name: Detect import-linter contract
+        id: contract
+        run: |
+          if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+             || [ -f .importlinter ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
+          fi
+
       - name: Install import-linter
+        if: steps.contract.outputs.found == 'true'
         run: pip install import-linter
 
       - name: Run boundary checks
+        if: steps.contract.outputs.found == 'true'
         run: lint-imports
 
   sonarqube:

--- a/governance/backend/importlinter-reference.toml
+++ b/governance/backend/importlinter-reference.toml
@@ -1,19 +1,33 @@
 # import-linter reference configuration for hexagonal architecture enforcement.
 #
-# Copy the sections below into your project's pyproject.toml, then set
-# `root_package` and `containers` to match your source layout. The
+# Copy the sections below into your project's pyproject.toml, then replace
+# every `myservice` with your own package name. The
 # `[[tool.importlinter.contracts]]` double brackets are required — a
 # single-bracket table is valid TOML but import-linter rejects it.
 #
+# `root_package` names the *distributable package*, not the src/ directory.
+# In the layout docs/backend/architecture/REPO_STRUCTURE_README.md
+# prescribes — src/myservice/api/... — `src` is a path entry, not a package,
+# so there is no module called `src`. Setting root_package = "src" makes
+# grimp resolve zero imports: every contract reports KEPT and the gate
+# enforces nothing, silently.
+#
+# After copying, confirm the output says it analysed a non-zero number of
+# dependencies. "Analyzed N files, 0 dependencies" means the package name
+# is wrong, however many contracts report KEPT.
+#
 # Install: pip install import-linter
 # Run:     lint-imports
+#
+# src/ must be importable for that to work. An editable install
+# (`pip install -e .`) puts it there; in CI without one, `PYTHONPATH=src`.
 #
 # This configuration enforces the layering rules defined in:
 #   docs/backend/architecture/ARCH_CONTRACT.md
 #   docs/backend/architecture/BOUNDARIES.md
 
 [tool.importlinter]
-root_package = "src"
+root_package = "myservice"
 
 # Hexagonal Architecture layer contract.
 #
@@ -31,8 +45,9 @@ root_package = "src"
 #   common          cross-cutting concerns and DTOs. Dependency-free.
 #
 # `containers` must name your service package(s), not bare "src":
-#   One service:      containers = ["src.myservice"]
-#   Several services: containers = ["src.orders", "src.billing"]
+#   One service:      containers = ["myservice"]
+#   Several services: containers = ["orders", "billing"]
+#                     (with root_packages = ["orders", "billing"] above)
 # The layer list is identical either way — only the container list grows.
 #
 # Violations are blocking — they indicate a boundary breach.
@@ -46,7 +61,7 @@ layers = [
     "models",
     "common",
 ]
-containers = ["src.myservice"]
+containers = ["myservice"]
 
 # `api` sits above `services` in the layer list, so the layers contract alone
 # would permit api -> services. BOUNDARIES.md section 2 forbids it: the API
@@ -55,20 +70,20 @@ containers = ["src.myservice"]
 [[tool.importlinter.contracts]]
 name = "API talks only to inbound ports"
 type = "forbidden"
-source_modules = ["src.myservice.api"]
-forbidden_modules = ["src.myservice.services"]
+source_modules = ["myservice.api"]
+forbidden_modules = ["myservice.services"]
 
 # Multi-service repositories only.
 #
 # The layers contract applies *within* each container and says nothing about
-# service-to-service edges — src.orders.services importing src.billing.services
+# service-to-service edges — orders.services importing billing.services
 # passes it. `independence` is what forbids that. Omit this contract and
 # cross-service coupling goes unenforced.
 #
 # [[tool.importlinter.contracts]]
 # name = "Services are independent"
 # type = "independence"
-# modules = ["src.orders", "src.billing"]
+# modules = ["orders", "billing"]
 
 # Note on the composition root: whatever wires adapters into services at
 # startup necessarily imports both, so it must live outside all six packages

--- a/tests/test_importlinter_reference.py
+++ b/tests/test_importlinter_reference.py
@@ -16,6 +16,8 @@ Marked `e2e` — they shell out to `lint-imports` and are excluded from the
 fast loop.
 """
 
+import os
+import re
 import shutil
 import subprocess
 import textwrap
@@ -41,7 +43,14 @@ pytestmark = [
 
 def _write_package(root: Path, pkg: str, extra_import: str | None = None) -> None:
     """A conforming hexagonal service package, optionally with one added
-    import used to prove a specific edge is rejected."""
+    import used to prove a specific edge is rejected.
+
+    Standard src-layout: `src/` holds the distributable package and is
+    itself **not** a package — no `src/__init__.py`. Modules are therefore
+    `<pkg>.ports`, not `src.<pkg>.ports`. Writing a `src/__init__.py` here
+    would make a `root_package = "src"` config appear to work while it
+    silently analyses nothing in a real project.
+    """
     base = root / "src" / pkg
     for layer in LAYERS:
         (base / layer).mkdir(parents=True, exist_ok=True)
@@ -50,16 +59,16 @@ def _write_package(root: Path, pkg: str, extra_import: str | None = None) -> Non
 
     (base / "models" / "__init__.py").write_text("class Entity: pass\n", encoding="utf-8")
     (base / "ports" / "__init__.py").write_text(
-        f"from src.{pkg}.models import Entity\n\n\nclass Port: pass\n", encoding="utf-8"
+        f"from {pkg}.models import Entity\n\n\nclass Port: pass\n", encoding="utf-8"
     )
     (base / "services" / "core.py").write_text(
-        f"from src.{pkg}.ports import Port\nfrom src.{pkg}.models import Entity\n", encoding="utf-8"
+        f"from {pkg}.ports import Port\nfrom {pkg}.models import Entity\n", encoding="utf-8"
     )
     (base / "adapters" / "db.py").write_text(
-        f"from src.{pkg}.ports import Port\nfrom src.{pkg}.services import core\n", encoding="utf-8"
+        f"from {pkg}.ports import Port\nfrom {pkg}.services import core\n", encoding="utf-8"
     )
     (base / "api" / "routes.py").write_text(
-        f"from src.{pkg}.ports import Port\n", encoding="utf-8"
+        f"from {pkg}.ports import Port\n", encoding="utf-8"
     )
     if extra_import:
         target_file, statement = extra_import
@@ -70,53 +79,66 @@ def _write_package(root: Path, pkg: str, extra_import: str | None = None) -> Non
         )
 
 
-def _write_pyproject(root: Path, containers: list[str], independence: bool = False) -> None:
-    """Write the shipped reference contract, pointed at `containers`.
+def _write_pyproject(root: Path, packages: list[str], independence: bool = False) -> None:
+    """Write the shipped reference contract, pointed at `packages`.
 
-    The reference declares a placeholder container; adopters are told to
-    adjust it. Substituting it here is exactly that step.
+    The reference ships placeholders for the package name; substituting
+    them is exactly the step adopters are told to perform.
     """
     body = REFERENCE.read_text(encoding="utf-8")
     # Drop comment-only lines so the commented multi-service block stays inert.
     live = "\n".join(ln for ln in body.splitlines() if not ln.lstrip().startswith("#"))
-    container_list = ", ".join(f'"{c}"' for c in containers)
-    live = _replace_key(live, "containers", f"[{container_list}]")
-    live = _replace_key(live, "source_modules", f'["{containers[0]}.api"]')
-    live = _replace_key(live, "forbidden_modules", f'["{containers[0]}.services"]')
+    package_list = ", ".join(f'"{p}"' for p in packages)
+    if len(packages) == 1:
+        live = _replace_key(live, "root_package", f'"{packages[0]}"')
+    else:
+        live = _replace_key(live, "root_package", None)
+        live = f"[tool.importlinter]\nroot_packages = [{package_list}]\n" + live.split("\n", 2)[2]
+    live = _replace_key(live, "containers", f"[{package_list}]")
+    live = _replace_key(live, "source_modules", f'["{packages[0]}.api"]')
+    live = _replace_key(live, "forbidden_modules", f'["{packages[0]}.services"]')
     if independence:
         live += textwrap.dedent(f"""
             [[tool.importlinter.contracts]]
             name = "Services are independent"
             type = "independence"
-            modules = [{container_list}]
+            modules = [{package_list}]
             """)
     (root / "pyproject.toml").write_text(live, encoding="utf-8")
-    (root / "src" / "__init__.py").write_text("", encoding="utf-8")
 
 
-def _replace_key(text: str, key: str, value: str) -> str:
+def _replace_key(text: str, key: str, value: str | None) -> str:
+    """Replace `key = ...` with `key = value`, or drop the line if value is None."""
     out = []
     for line in text.splitlines():
         if line.strip().startswith(f"{key} ="):
-            out.append(f"{key} = {value}")
+            if value is not None:
+                out.append(f"{key} = {value}")
         else:
             out.append(line)
     return "\n".join(out)
 
 
+_ANALYSED = re.compile(r"Analyzed (\d+) files?, (\d+) dependenc")
+
+
 def _lint(root: Path) -> subprocess.CompletedProcess:
     """Run the real `lint-imports` console script inside `root`.
+
+    `src/` is put on the path the way a real project's packaging config
+    does, so the package is importable under its own name.
 
     Deliberately the console script rather than `python -m importlinter.cli`
     — the latter has no __main__ entry point, exits 0 with empty output, and
     would make every assertion here pass without linting anything.
     """
+    env = dict(os.environ, PYTHONPATH=str(root / "src"))
     # Explicit utf-8: import-linter prints a non-ASCII banner that the
     # Windows locale codec cannot decode, which yields stdout=None rather
     # than a failure — silently voiding every assertion below.
     result = subprocess.run(
         [_LINT_IMPORTS], cwd=root, capture_output=True,
-        text=True, encoding="utf-8", errors="replace",
+        text=True, encoding="utf-8", errors="replace", env=env,
     )
     assert result.stdout or result.stderr, (
         "lint-imports produced no output — the linter did not run, so this "
@@ -125,11 +147,30 @@ def _lint(root: Path) -> subprocess.CompletedProcess:
     return result
 
 
+def _assert_analysed_something(result: subprocess.CompletedProcess) -> None:
+    """A contract that resolves zero dependencies reports every layer KEPT
+    while enforcing nothing.
+
+    That is how `root_package = "src"` shipped: grimp found no package named
+    `src` in a standard src-layout project, analysed 0 dependencies, and the
+    gate passed vacuously. Any assertion that a repo is clean has to prove
+    the linter actually saw its imports first.
+    """
+    match = _ANALYSED.search(result.stdout)
+    assert match, f"could not find the analysis summary:\n{result.stdout}"
+    files, dependencies = int(match.group(1)), int(match.group(2))
+    assert files and dependencies, (
+        f"analysed {files} files and {dependencies} dependencies — the contract "
+        f"resolved nothing, so a KEPT verdict is meaningless:\n{result.stdout}"
+    )
+
+
 class TestSingleService:
     def test_conforming_repo_passes(self, tmp_path):
         _write_package(tmp_path, "svc")
-        _write_pyproject(tmp_path, ["src.svc"])
+        _write_pyproject(tmp_path, ["svc"])
         result = _lint(tmp_path)
+        _assert_analysed_something(result)
         assert result.returncode == 0, (
             f"conforming repo rejected:\n{result.stdout}\n{result.stderr}"
         )
@@ -137,17 +178,17 @@ class TestSingleService:
     @pytest.mark.parametrize(
         ("label", "where", "statement"),
         [
-            ("services -> adapters", "services/core.py", "from src.{pkg}.adapters import db"),
-            ("ports -> services", "ports/__init__.py", "from src.{pkg}.services import core"),
-            ("models -> services", "models/__init__.py", "from src.{pkg}.services import core"),
-            ("models -> ports", "models/__init__.py", "from src.{pkg}.ports import Port"),
-            ("api -> services", "api/routes.py", "from src.{pkg}.services import core"),
-            ("api -> adapters", "api/routes.py", "from src.{pkg}.adapters import db"),
+            ("services -> adapters", "services/core.py", "from {pkg}.adapters import db"),
+            ("ports -> services", "ports/__init__.py", "from {pkg}.services import core"),
+            ("models -> services", "models/__init__.py", "from {pkg}.services import core"),
+            ("models -> ports", "models/__init__.py", "from {pkg}.ports import Port"),
+            ("api -> services", "api/routes.py", "from {pkg}.services import core"),
+            ("api -> adapters", "api/routes.py", "from {pkg}.adapters import db"),
         ],
     )
     def test_forbidden_edge_is_rejected(self, tmp_path, label, where, statement):
         _write_package(tmp_path, "svc", extra_import=(where, statement))
-        _write_pyproject(tmp_path, ["src.svc"])
+        _write_pyproject(tmp_path, ["svc"])
         result = _lint(tmp_path)
         assert result.returncode != 0, f"{label} was permitted:\n{result.stdout}"
 
@@ -156,8 +197,9 @@ class TestMultiService:
     def test_two_conforming_services_pass(self, tmp_path):
         for pkg in ("orders", "billing"):
             _write_package(tmp_path, pkg)
-        _write_pyproject(tmp_path, ["src.orders", "src.billing"], independence=True)
+        _write_pyproject(tmp_path, ["orders", "billing"], independence=True)
         result = _lint(tmp_path)
+        _assert_analysed_something(result)
         assert result.returncode == 0, (
             f"conforming multi-service repo rejected:\n{result.stdout}\n{result.stderr}"
         )
@@ -169,11 +211,46 @@ class TestMultiService:
         _write_package(tmp_path, "billing")
         _write_package(
             tmp_path, "orders",
-            extra_import=("services/core.py", "from src.billing.services import core as _b"),
+            extra_import=("services/core.py", "from billing.services import core as _b"),
         )
-        _write_pyproject(tmp_path, ["src.orders", "src.billing"], independence=True)
+        _write_pyproject(tmp_path, ["orders", "billing"], independence=True)
         result = _lint(tmp_path)
         assert result.returncode != 0, f"cross-service import was permitted:\n{result.stdout}"
+
+
+def test_shipped_placeholders_describe_a_real_src_layout():
+    """The placeholders have to teach the right shape, because that is what
+    an adopter copies and adapts.
+
+    `root_package = "src"` shipped originally, which is wrong for the layout
+    REPO_STRUCTURE_README.md prescribes: `src/` is a path entry, not a
+    package, so there is no module named `src`. grimp then resolves zero
+    dependencies and every contract reports KEPT while enforcing nothing —
+    the failure mode is a silent pass, so nothing surfaces it.
+
+    Asserting containers sit under the declared root package keeps the two
+    from drifting apart again.
+    """
+    import tomllib
+
+    config = tomllib.loads(REFERENCE.read_text(encoding="utf-8"))
+    root = config["tool"]["importlinter"].get("root_package")
+    assert root, "reference declares no root_package"
+    assert root != "src", (
+        "root_package must name the distributable package, not the src/ "
+        "directory — `src` is a path entry in standard src-layout, so "
+        "grimp finds no such package and analyses nothing"
+    )
+    for contract in config["tool"]["importlinter"]["contracts"]:
+        for container in contract.get("containers", []):
+            assert container == root or container.startswith(f"{root}."), (
+                f"container {container!r} is not under root_package {root!r}"
+            )
+        for key in ("source_modules", "forbidden_modules"):
+            for module in contract.get(key, []):
+                assert module.startswith(f"{root}."), (
+                    f"{key} entry {module!r} is not under root_package {root!r}"
+                )
 
 
 def test_reference_is_parseable_by_import_linter(tmp_path):
@@ -185,7 +262,7 @@ def test_reference_is_parseable_by_import_linter(tmp_path):
     file would pass while the gate crashed for every adopter.
     """
     _write_package(tmp_path, "svc")
-    _write_pyproject(tmp_path, ["src.svc"])
+    _write_pyproject(tmp_path, ["svc"])
     result = _lint(tmp_path)
     combined = result.stdout + result.stderr
     assert "has no attribute" not in combined, (


### PR DESCRIPTION
Closes #85. Closes #92.

Two defects, one file. **Independent of #91** — rebased onto `main`, no overlap.

## #92 — the reference analysed nothing

It declared `root_package = "src"`. But in the src-layout `REPO_STRUCTURE_README.md` prescribes, `src/` is a **path entry, not a package** — there is no module named `src`. grimp resolved **0 dependencies**, every contract reported KEPT, and an injected `services -> adapters` violation went undetected.

A silent pass. The same class of false negative #75 was filed for, reintroduced from the other side.

```
before:  Analyzed 10 files, 0 dependencies.   Hexagonal Architecture KEPT   ← violation invisible
after:   Analyzed  9 files, 3 dependencies.   Hexagonal Architecture BROKEN ← violation caught
```

Placeholders now name the distributable package (`root_package = "myservice"`, `containers = ["myservice"]`), and the header explains why, plus how `src/` reaches the path (editable install, or `PYTHONPATH=src` in CI).

**The fixture that should have caught it wrote `src/__init__.py`**, making `src` a real package and the broken config work — it validated a layout adopters don't have. It now models standard src-layout, and every "conforming" assertion first calls `_assert_analysed_something`, because a KEPT verdict over 0 dependencies proves nothing. A second test pins that the shipped placeholders stay self-consistent: containers and module lists must sit under the declared `root_package`.

## #85 — L3 shipped the gate but not the contract

`governance/backend/` was declared at L4+ only, so an L3 install got a `boundary-check` job with nothing to enforce.

Per your framing — L3 is vibe-coding *with architectural governance* — the contract belongs there. But only `importlinter-reference.toml` moves: the directory also holds `schemas/` and `templates/` (`eval_criteria`, `guardrails_config`, `plan.md`, `architecture_preflight.md`), which are the **feature-specification package L3 deliberately excludes**. The L4+/L5 entries now name those two subtrees explicitly.

Verified across all **18** agent × type × level combinations — the contract ships exactly once in each.

## boundary-check is now conditional

The contract is a template until copied in, so the job skips when none is configured (`pyproject.toml` / `setup.cfg` / `tox.ini` / `.importlinter`) and logs how to enable it. Two things follow:

- A fresh L3 install is **green**, not red — which is why no auto-writing into anyone's `pyproject.toml` was needed.
- Non-Python stacks skip instead of running a Python linter against Go or C#. A skipped job is honest; per-stack tooling is #93.

Applied to `ci/github/` **and** `ci/azure/`, both gate files each.

## ci/README.md

Documents the opt-in, corrects the L3 row (it never mentioned boundary enforcement despite the job existing), and drops three duplicated `ui-nextjs` rows.

## Verification

- 1254 fast + 85 e2e + 18 parity, green
- **L3 smoke now passes both apply and validate** (previously apply-only)
- Reference copied verbatim onto a real `src/myservice/` tree catches the violation

## Not in scope

#93 (per-stack boundary tooling) and #94 (L4+ runs four jobs twice) were found while scoping this and filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)