### PR TITLE
fix(cli): discover nested installs instead of stopping at a governed root

### DIFF
--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -17,6 +17,7 @@ directories under cwd so monorepos get checked per-app.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import sys
 from dataclasses import dataclass
@@ -851,34 +852,44 @@ def _check_ui_framework_matches_type(
 # ---------------------------------------------------------------------------
 
 
+_DISCOVERY_SKIP_DIRS = frozenset({
+    ".git", "node_modules", ".venv", "venv", "__pycache__",
+    "dist", "build", "target", "bin", "obj",
+})
+
+
 def discover_install_targets(cwd: Path) -> list[Path]:
-    """Find every .govkit/ directory under `cwd` (A9).
+    """Every govkit install at or under `cwd`, nearest first (A9).
 
-    If `cwd` itself is a govkit install (has .govkit/), returns [cwd] and
-    does NOT recurse — apps/ subdirs of a single install don't get
-    double-counted.
+    A governed root does **not** hide governed subprojects. This used to
+    return `[cwd]` and stop as soon as the root had a marker, justified as
+    stopping `apps/` subdirs of a single install being double-counted — but
+    a subdirectory holding its own marker is by definition a separate
+    install, with its own agent, level, type and stack. `run_doctor` is
+    per-target and reads each marker independently, so there was nothing to
+    double-count; the rule only skipped real installs silently.
 
-    Otherwise walks under cwd looking for .govkit/ markers. Skips
-    `.git`, `node_modules`, `.venv`, etc. so the walk is bounded.
+    That shape is one govkit actively encourages: `marker.json` holds a
+    single `type` and UI types reject `--stack`, so a backend+frontend
+    monorepo must be a governed root plus a governed `apps/web`.
+
+    Pass `--target` to scope to one install.
+
+    Uses os.walk with in-place `dirnames[:]` pruning so vendored trees are
+    never entered. Every run now scans, where before a governed root
+    short-circuited it, so the cost has to stay off the large repos that
+    can least afford it.
     """
-    cwd_marker = cwd / MARKER_DIRNAME
-    if cwd_marker.is_dir() or cwd_marker.is_file():
-        return [cwd]
-
-    skip_dirs = {".git", "node_modules", ".venv", "venv", "__pycache__",
-                 "dist", "build", "target", "bin", "obj"}
     targets: list[Path] = []
-    for marker in cwd.rglob(MARKER_DIRNAME):
-        # Skip if any parent in the chain is a skip-dir
-        try:
-            rel_parts = marker.relative_to(cwd).parts
-        except ValueError:
-            continue
-        if any(p in skip_dirs for p in rel_parts):
-            continue
-        if not (marker.is_dir() or marker.is_file()):
-            continue
-        targets.append(marker.parent)
+    try:
+        for dirpath, dirnames, filenames in os.walk(cwd):
+            dirnames[:] = [d for d in dirnames if d not in _DISCOVERY_SKIP_DIRS]
+            # `.govkit` is normally a directory; tolerate a file for the
+            # marker-as-file shape read_govkit_marker also accepts.
+            if MARKER_DIRNAME in dirnames or MARKER_DIRNAME in filenames:
+                targets.append(Path(dirpath))
+    except OSError:
+        return sorted(set(targets))
     return sorted(set(targets))
 
 

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -243,6 +243,30 @@ class TestMonorepoDispatch:
         assert "apps/api" in out.replace("\\", "/")
         assert "apps/web" in out.replace("\\", "/")
 
+    def test_a_governed_root_does_not_hide_nested_installs(self, tmp_path, monkeypatch, capsys):
+        """calibrate shares `discover_install_targets` with doctor, so it
+        inherits the fix for a governed root masking governed subprojects.
+
+        Asserted explicitly rather than left as a side effect of the shared
+        helper: calibrating only the root of a backend+frontend monorepo
+        would silently leave the frontend uncalibrated."""
+        from cli.calibrate import cmd_calibrate
+
+        _write_marker(tmp_path)
+        _write_marker(tmp_path / "apps" / "web")
+        monkeypatch.chdir(tmp_path)
+
+        cmd_calibrate(argparse.Namespace(
+            target=None,
+            non_interactive=True,
+            only=None,
+        ))
+
+        out = capsys.readouterr().out.replace("\\", "/")
+        assert "apps/web" in out, "nested install was not calibrated"
+        assert (tmp_path / "GOVKIT_CALIBRATION_CHECKLIST.md").is_file()
+        assert (tmp_path / "apps" / "web" / "GOVKIT_CALIBRATION_CHECKLIST.md").is_file()
+
     def test_errors_when_no_marker_anywhere(self, tmp_path, monkeypatch):
         from cli.calibrate import cmd_calibrate
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -7,7 +7,9 @@ exits non-zero on errors. Designed to run in CI.
 
 import argparse
 import json
+import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -304,16 +306,89 @@ class TestMonorepoDiscovery:
         assert web in targets
         assert tmp_path not in targets
 
-    def test_root_marker_takes_precedence_over_nested(self, tmp_path):
-        """If the root has its own .govkit, scope to root only — don't dive
-        into subdirs looking for more installs."""
+    def test_a_governed_root_does_not_hide_nested_installs(self, tmp_path):
+        """A governed root plus governed subprojects is a supported shape, so
+        every install must be discovered.
+
+        This previously returned `[root]` and stopped. The rule was justified
+        as stopping `apps/` subdirs of a single install being double-counted —
+        but a subdirectory holding its own marker is by definition a separate
+        install, with its own agent, level, type and stack. `run_doctor` is
+        per-target and reads each marker independently, so there was nothing
+        to double-count; the rule only skipped real installs.
+
+        It matters more now that `marker.json` holds one `type` and UI types
+        reject `--stack`: a backend+frontend monorepo *has* to be a governed
+        root plus a governed `apps/web`."""
+        from cli.doctor import discover_install_targets
+
+        _write_marker(tmp_path)
+        _write_marker(tmp_path / "apps" / "api")
+        _write_marker(tmp_path / "apps" / "web")
+
+        targets = discover_install_targets(tmp_path)
+        assert targets == [
+            tmp_path,
+            tmp_path / "apps" / "api",
+            tmp_path / "apps" / "web",
+        ]
+
+    def test_each_install_is_returned_once(self, tmp_path):
         from cli.doctor import discover_install_targets
 
         _write_marker(tmp_path)
         _write_marker(tmp_path / "apps" / "api")
 
         targets = discover_install_targets(tmp_path)
-        assert targets == [tmp_path]
+        assert len(targets) == len(set(targets))
+
+    def test_installs_nested_more_than_one_level_are_found(self, tmp_path):
+        from cli.doctor import discover_install_targets
+
+        _write_marker(tmp_path)
+        deep = tmp_path / "packages" / "backend" / "svc"
+        _write_marker(deep)
+
+        assert deep in discover_install_targets(tmp_path)
+
+    def test_noise_directories_are_not_searched(self, tmp_path):
+        """A vendored copy of a governed project must not be reported, and
+        the walk must not descend into it to find out."""
+        from cli.doctor import discover_install_targets
+
+        _write_marker(tmp_path)
+        _write_marker(tmp_path / "node_modules" / "vendored")
+        _write_marker(tmp_path / ".venv" / "lib" / "copied")
+
+        assert discover_install_targets(tmp_path) == [tmp_path]
+
+    def test_walk_prunes_noise_directories_instead_of_filtering_after(self, tmp_path):
+        """Now that a governed root no longer short-circuits the walk, every
+        `doctor` run scans the tree. It must prune noise dirs during traversal
+        rather than walking them and discarding the results, or the cost lands
+        on exactly the large repos that can least afford it."""
+        from cli.doctor import discover_install_targets
+
+        _write_marker(tmp_path)
+        buried = tmp_path / "node_modules" / "pkg"
+        buried.mkdir(parents=True)
+        for i in range(50):
+            (buried / f"nested{i}").mkdir()
+
+        visited: list[str] = []
+        real_walk = os.walk
+
+        def counting_walk(top, *a, **kw):
+            for dirpath, dirnames, filenames in real_walk(top, *a, **kw):
+                visited.append(dirpath)
+                yield dirpath, dirnames, filenames
+
+        with mock.patch.object(os, "walk", counting_walk):
+            discover_install_targets(tmp_path)
+
+        assert not any("node_modules" in v for v in visited), (
+            "walked into node_modules instead of pruning it"
+        )
 
     def test_d001_passes_when_rule_globs_match_files(self, tmp_path):
         from cli.doctor import run_doctor


### PR DESCRIPTION
Closes #78. Implements the **recurse** decision.

`discover_install_targets` returned `[cwd]` and stopped as soon as the root had a marker, so a governed root hid every governed subproject. `doctor` and `calibrate` both silently skipped them unless `--target` named each one — while doctor's own `--target` help promised it *"finds nested installs in monorepos"*.

## Why the old rule didn't hold

It was justified as stopping `apps/` subdirs of a single install being double-counted. But a subdirectory holding its own marker is **by definition a separate install**, with its own agent, level, type and stack. `run_doctor` is per-target and reads each marker independently, so there was nothing to double-count — the rule only skipped real installs.

This matters more since #82: `marker.json` holds one `type` and UI types reject `--stack`, so a backend+frontend monorepo **must** be a governed root plus a governed `apps/web`. That's a shape govkit actively encourages, and CI wasn't validating it.

## Verified end to end

From a governed monorepo root:

```
=== . ===
  reading <root>/.govkit/marker.json
=== apps\web ===
  reading <root>/apps/web/.govkit/marker.json
  doctor: errors present (see above).      exit 1
```

Both installs checked; a vendored `.govkit` planted under `node_modules` correctly ignored. The root's D001 findings are identical whether discovered or scoped with `--target .`, so they're pre-existing sandbox artifacts rather than anything this change introduced.

## Performance

Every run scans now, where a governed root previously short-circuited it — so the cost had to stay off the large repos that can least afford it. Discovery moved from `rglob`'s walk-then-filter to `os.walk` with in-place `dirnames[:]` pruning, matching what `_find_recursive` already does. **A test asserts `node_modules` is never entered**, not merely that its results are discarded.

## No changes needed downstream

`cmd_doctor` and `calibrate` already looped over multiple targets, printed a per-target header, and exited non-zero if any had errors.

## Tests

`test_root_marker_takes_precedence_over_nested` is **inverted** — it pinned the contract being changed, not incidental coverage. Added: deduplication, multi-level nesting, noise-dir exclusion, the pruning guard, and an explicit `calibrate` assertion rather than relying on the shared helper as a side effect — calibrating only the root of a monorepo would leave the frontend uncalibrated.

Suite: 1313 fast + 85 e2e, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)