### PR TITLE
fix(cli): re-render the PII keyword list when calibration tunes it

### DIFF
--- a/cli/calibrate.py
+++ b/cli/calibrate.py
@@ -589,10 +589,14 @@ def _retemplate_rules(target: Path, marker: dict) -> None:
     agent actually reads — scoped to the style detection originally chose,
     so the correction appears to apply while changing nothing.
 
+    Also re-renders the PII keyword list into rule bodies: `pii.keyword_list`
+    is team-tunable, and calibration is exactly when a team tunes it.
+
     Silent on agents with no rules dir (codex scopes by placement instead).
     """
     from .rule_templating import template_installed_rules
     from .skill_context import load_skill_context
+    from .skill_templating import template_installed_rule_bodies
 
     context = load_skill_context(target)
     if context is None:
@@ -601,6 +605,9 @@ def _retemplate_rules(target: Path, marker: dict) -> None:
     count = template_installed_rules(target, agent, context.layers)
     if count:
         print(f"  re-scoped {count} rule file(s) to the calibrated architecture.")
+    bodies = template_installed_rule_bodies(target, agent, context.pii_keywords)
+    if bodies:
+        print(f"  re-rendered the PII keyword list into {bodies} rule file(s).")
 
 
 _PROMPT_HELP = (

--- a/cli/skill_templating.py
+++ b/cli/skill_templating.py
@@ -22,6 +22,7 @@ refreshed on apply/upgrade), so rewriting them in place clobbers nothing.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from .agent_layout import AGENT_LAYOUTS
@@ -48,6 +49,35 @@ def render_pii_keywords(keywords: list[str]) -> str:
     return ", ".join(f"`{k}`" for k in keywords)
 
 
+# The rendered list is fenced so a later pass can find and replace it.
+# `pii.keyword_list` is team-tunable, and substituting the token in place
+# left nothing to re-render from: `apply`/`upgrade` recovered because they
+# re-copy each rule from the bundle, but `calibrate` does not, so a tuned
+# list never reached the rule bodies. Same marker idiom as the managed
+# AGENTS.md block and the `govkit:editable` header.
+_PII_OPEN = "<!-- govkit:pii_keywords -->"
+_PII_CLOSE = "<!-- /govkit:pii_keywords -->"
+_PII_SPAN = re.compile(
+    re.escape(_PII_OPEN) + r".*?" + re.escape(_PII_CLOSE), re.DOTALL,
+)
+
+
+def expand_pii_keywords(text: str, keywords: list[str]) -> str:
+    """Render `keywords` into `text`, replacing either the source token or a
+    previously rendered span.
+
+    Idempotent: rendering the same list twice is a no-op. An empty list
+    leaves the text untouched, matching the docs_area rule that unknown
+    context stays visible rather than being guessed away.
+    """
+    if not keywords:
+        return text
+    fenced = f"{_PII_OPEN}{render_pii_keywords(keywords)}{_PII_CLOSE}"
+    if _PII_SPAN.search(text):
+        return _PII_SPAN.sub(lambda _m: fenced, text)
+    return text.replace(_PII_KEYWORDS_TOKEN, fenced)
+
+
 def template_installed_rule_bodies(target: Path, agent: str, pii_keywords: list[str]) -> int:
     """Expand `{{pii_keywords}}` in installed rule bodies.
 
@@ -64,8 +94,6 @@ def template_installed_rule_bodies(target: Path, agent: str, pii_keywords: list[
     layout = AGENT_LAYOUTS.get(agent)
     if layout is None:
         return 0
-    rendered = render_pii_keywords(pii_keywords)
-
     candidates: list[Path] = []
     if layout.rules_dir and (target / layout.rules_dir).is_dir():
         candidates.extend(sorted((target / layout.rules_dir).rglob("*.md")))
@@ -80,9 +108,14 @@ def template_installed_rule_bodies(target: Path, agent: str, pii_keywords: list[
         text = read_text_or_none(path)
         if text is None:
             continue
-        if _PII_KEYWORDS_TOKEN not in text:
+        # Either an unrendered token (fresh copy from the bundle) or a span
+        # rendered by an earlier run whose list has since been tuned.
+        if _PII_KEYWORDS_TOKEN not in text and not _PII_SPAN.search(text):
             continue
-        path.write_text(text.replace(_PII_KEYWORDS_TOKEN, rendered), encoding="utf-8")
+        new_text = expand_pii_keywords(text, pii_keywords)
+        if new_text == text:
+            continue
+        path.write_text(new_text, encoding="utf-8")
         modified += 1
     return modified
 

--- a/tests/test_skill_templating.py
+++ b/tests/test_skill_templating.py
@@ -312,3 +312,82 @@ class TestApplyExpandsSkillDocsArea:
         text = spec.read_text(encoding="utf-8")
         assert "docs/backend/architecture" in text
         assert "{{docs_area}}" not in text
+
+
+class TestPiiKeywordReRendering:
+    """Tuning `pii.keyword_list` must reach the rule bodies seeded from it.
+
+    The list is documented as team-tunable and is preserved across rewrites,
+    but the rendering was one-way: the first install consumed
+    `{{pii_keywords}}`, leaving nothing for a later pass to re-render from.
+
+    `apply` and `upgrade` were unaffected — they re-copy each rule from the
+    bundle, which restores the token before re-expanding. `calibrate` does
+    not re-copy, so it silently kept the original defaults. Calibrating is
+    exactly when a team would tune the list.
+    """
+
+    def test_rendering_is_repeatable(self):
+        from cli.skill_templating import expand_pii_keywords
+
+        source = "PII list ({{pii_keywords}}) MUST be tagged\n"
+        first = expand_pii_keywords(source, ["email", "dob"])
+        assert "`email`, `dob`" in first
+
+        second = expand_pii_keywords(first, ["email", "iban", "national_id"])
+        assert "`email`, `iban`, `national_id`" in second
+        assert "`dob`" not in second, "the previous rendering was not replaced"
+        assert "MUST be tagged" in second
+
+    def test_re_rendering_is_idempotent(self):
+        from cli.skill_templating import expand_pii_keywords
+
+        once = expand_pii_keywords("list ({{pii_keywords}})\n", ["email"])
+        twice = expand_pii_keywords(once, ["email"])
+        assert once == twice
+
+    def test_installed_bodies_re_render_from_a_tuned_list(self, tmp_path):
+        from cli.skill_templating import template_installed_rule_bodies
+
+        rule = tmp_path / ".claude" / "rules" / "govkit" / "staging.md"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("PII list ({{pii_keywords}}) MUST be tagged\n", encoding="utf-8")
+
+        template_installed_rule_bodies(tmp_path, "claude-code", ["email", "dob"])
+        count = template_installed_rule_bodies(tmp_path, "claude-code", ["email", "iban"])
+
+        assert count == 1, "second pass found nothing to re-render"
+        text = rule.read_text(encoding="utf-8")
+        assert "`email`, `iban`" in text
+        assert "`dob`" not in text
+
+    def test_calibrate_re_renders_after_the_list_is_tuned(self, tmp_path):
+        """End-to-end: the case from the issue."""
+        import argparse
+
+        import yaml
+
+        from cli.calibrate import cmd_calibrate
+        from cli.cmd_apply import cmd_apply
+
+        target = tmp_path / "project"
+        target.mkdir()
+        cmd_apply(argparse.Namespace(
+            agent="claude-code", target=str(target), level="4", type="data",
+            ci="github", stack=None, force=False, detect=False,
+        ))
+        rule = target / ".claude" / "rules" / "govkit" / "staging.md"
+        assert "`phone`" in rule.read_text(encoding="utf-8")
+
+        context = target / ".govkit" / "skill_context.yaml"
+        data = yaml.safe_load(context.read_text(encoding="utf-8"))
+        data["pii"]["keyword_list"] = ["email", "iban", "national_id"]
+        context.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+        cmd_calibrate(argparse.Namespace(
+            target=str(target), non_interactive=True, only=None,
+        ))
+
+        text = rule.read_text(encoding="utf-8")
+        assert "`email`, `iban`, `national_id`" in text
+        assert "`phone`" not in text, "rule body kept the pre-tuning defaults"


### PR DESCRIPTION
Closes #97.

`pii.keyword_list` is documented as team-tunable and **is** preserved across rewrites — but the rendering into rule bodies was one-way. The first install substituted `{{pii_keywords}}` in place, leaving nothing for a later pass to re-render from.

## Narrower than I filed it

Investigating corrected the report. `apply` and `upgrade` were **never affected** — they re-copy each rule from the bundle, restoring the token before re-expanding. Only `calibrate` is broken, because it doesn't re-copy:

| after | rule body shows |
| --- | --- |
| `calibrate` | `` `email`, `phone`, `ssn`, … `` — defaults kept |
| `upgrade --force` | `` `email`, `iban`, `national_id` `` — tuned, correct |

The issue title said tuning "never reaches" the bodies. It reaches them on upgrade. But calibrating is exactly when a team tunes the list, so it was the one command where the tuning didn't take — which is arguably worse than a uniform failure, because the obvious next command silently no-ops.

## The fix

The rendered list is fenced in `<!-- govkit:pii_keywords -->` markers, so `expand_pii_keywords` can replace **either** the source token **or** a span an earlier run rendered.

That keeps it self-contained — `calibrate` needs no access to the bundle — and idempotent. Same marker idiom as the managed `AGENTS.md` block and the `govkit:editable` header, so it's not new vocabulary.

The markers carry no braces, so doctor's D015 unexpanded-token check doesn't flag them. Verified rather than assumed.

## Why `{{docs_area}}` is deliberately left alone

It derives from `marker.options.type`, which `calibrate` cannot change, and it appears **inline inside doc paths** — `docs/{{docs_area}}/architecture/` — where fencing would mangle the prose into `docs/<!-- ... -->backend<!-- ... -->/architecture/`.

So the split is principled rather than partial: the tunable value needs re-derivation, the derived one doesn't.

## Verified across all three agents

Data install, tune the list, calibrate:

```
claude-code  staging.md                 `email`, `iban`, `national_id`
codex        AGENTS.md (nested block)   `email`, `iban`, `national_id`
copilot      staging.instructions.md    `email`, `iban`, `national_id`

stale defaults present: False    D015 findings: 0
```

Suite: 1317 fast + 85 e2e, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)