### PR TITLE
refactor(ci): select the boundary gate per stack (#93)

### DIFF
--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -398,8 +398,18 @@
         "shared": [],
         "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "api":        {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+            }
+          },
+          "cli":        {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+            }
+          },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-nextjs":  { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-nextjs-quality-gate.yml"] },
@@ -437,24 +447,34 @@
           "shared": [],
           "governed": ["ci/github/repo-scope-check.yml"],
           "by_type": {
-            "api": { "governed": [
-              "ci/github/l3-quality-gate.yml",
-              "ci/github/quality-gate.yml",
-              "ci/github/eval-gate.yml",
-              "ci/github/deepeval-gate.yml",
-              "ci/github/guardrails-check.yml",
-              "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
-            ] },
-            "cli": { "governed": [
-              "ci/github/l3-quality-gate.yml",
-              "ci/github/quality-gate.yml",
-              "ci/github/eval-gate.yml",
-              "ci/github/deepeval-gate.yml",
-              "ci/github/guardrails-check.yml",
-              "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
-            ] },
+            "api": {
+              "governed": [
+                "ci/github/l3-quality-gate.yml",
+                "ci/github/quality-gate.yml",
+                "ci/github/eval-gate.yml",
+                "ci/github/deepeval-gate.yml",
+                "ci/github/guardrails-check.yml",
+                "ci/github/multi-agent-gate.yml",
+                "ci/github/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              }
+            },
+            "cli": {
+              "governed": [
+                "ci/github/l3-quality-gate.yml",
+                "ci/github/quality-gate.yml",
+                "ci/github/eval-gate.yml",
+                "ci/github/deepeval-gate.yml",
+                "ci/github/guardrails-check.yml",
+                "ci/github/multi-agent-gate.yml",
+                "ci/github/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              }
+            },
             "ui-react": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
               "ci/github/ui-quality-gate.yml",
@@ -489,8 +509,18 @@
         "shared": [],
         "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "api":        {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+            }
+          },
+          "cli":        {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+            }
+          },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-nextjs":  { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-nextjs-quality-gate.yml"] },
@@ -528,24 +558,34 @@
           "shared": [],
           "governed": ["ci/azure/repo-scope-check.yml"],
           "by_type": {
-            "api": { "governed": [
-              "ci/azure/l3-quality-gate.yml",
-              "ci/azure/quality-gate.yml",
-              "ci/azure/eval-gate.yml",
-              "ci/azure/deepeval-gate.yml",
-              "ci/azure/guardrails-check.yml",
-              "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
-            ] },
-            "cli": { "governed": [
-              "ci/azure/l3-quality-gate.yml",
-              "ci/azure/quality-gate.yml",
-              "ci/azure/eval-gate.yml",
-              "ci/azure/deepeval-gate.yml",
-              "ci/azure/guardrails-check.yml",
-              "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
-            ] },
+            "api": {
+              "governed": [
+                "ci/azure/l3-quality-gate.yml",
+                "ci/azure/quality-gate.yml",
+                "ci/azure/eval-gate.yml",
+                "ci/azure/deepeval-gate.yml",
+                "ci/azure/guardrails-check.yml",
+                "ci/azure/multi-agent-gate.yml",
+                "ci/azure/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              }
+            },
+            "cli": {
+              "governed": [
+                "ci/azure/l3-quality-gate.yml",
+                "ci/azure/quality-gate.yml",
+                "ci/azure/eval-gate.yml",
+                "ci/azure/deepeval-gate.yml",
+                "ci/azure/guardrails-check.yml",
+                "ci/azure/multi-agent-gate.yml",
+                "ci/azure/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              }
+            },
             "ui-react": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
               "ci/azure/ui-quality-gate.yml",

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -420,8 +420,18 @@
         "shared": [],
         "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "api":        {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+            }
+          },
+          "cli":        {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+            }
+          },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-nextjs":  { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-nextjs-quality-gate.yml"] },
@@ -459,24 +469,34 @@
           "shared": [],
           "governed": ["ci/github/repo-scope-check.yml"],
           "by_type": {
-            "api": { "governed": [
-              "ci/github/l3-quality-gate.yml",
-              "ci/github/quality-gate.yml",
-              "ci/github/eval-gate.yml",
-              "ci/github/deepeval-gate.yml",
-              "ci/github/guardrails-check.yml",
-              "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
-            ] },
-            "cli": { "governed": [
-              "ci/github/l3-quality-gate.yml",
-              "ci/github/quality-gate.yml",
-              "ci/github/eval-gate.yml",
-              "ci/github/deepeval-gate.yml",
-              "ci/github/guardrails-check.yml",
-              "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
-            ] },
+            "api": {
+              "governed": [
+                "ci/github/l3-quality-gate.yml",
+                "ci/github/quality-gate.yml",
+                "ci/github/eval-gate.yml",
+                "ci/github/deepeval-gate.yml",
+                "ci/github/guardrails-check.yml",
+                "ci/github/multi-agent-gate.yml",
+                "ci/github/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              }
+            },
+            "cli": {
+              "governed": [
+                "ci/github/l3-quality-gate.yml",
+                "ci/github/quality-gate.yml",
+                "ci/github/eval-gate.yml",
+                "ci/github/deepeval-gate.yml",
+                "ci/github/guardrails-check.yml",
+                "ci/github/multi-agent-gate.yml",
+                "ci/github/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              }
+            },
             "ui-react": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
               "ci/github/ui-quality-gate.yml",
@@ -511,8 +531,18 @@
         "shared": [],
         "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "api":        {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+            }
+          },
+          "cli":        {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+            }
+          },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-nextjs":  { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-nextjs-quality-gate.yml"] },
@@ -550,24 +580,34 @@
           "shared": [],
           "governed": ["ci/azure/repo-scope-check.yml"],
           "by_type": {
-            "api": { "governed": [
-              "ci/azure/l3-quality-gate.yml",
-              "ci/azure/quality-gate.yml",
-              "ci/azure/eval-gate.yml",
-              "ci/azure/deepeval-gate.yml",
-              "ci/azure/guardrails-check.yml",
-              "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
-            ] },
-            "cli": { "governed": [
-              "ci/azure/l3-quality-gate.yml",
-              "ci/azure/quality-gate.yml",
-              "ci/azure/eval-gate.yml",
-              "ci/azure/deepeval-gate.yml",
-              "ci/azure/guardrails-check.yml",
-              "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
-            ] },
+            "api": {
+              "governed": [
+                "ci/azure/l3-quality-gate.yml",
+                "ci/azure/quality-gate.yml",
+                "ci/azure/eval-gate.yml",
+                "ci/azure/deepeval-gate.yml",
+                "ci/azure/guardrails-check.yml",
+                "ci/azure/multi-agent-gate.yml",
+                "ci/azure/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              }
+            },
+            "cli": {
+              "governed": [
+                "ci/azure/l3-quality-gate.yml",
+                "ci/azure/quality-gate.yml",
+                "ci/azure/eval-gate.yml",
+                "ci/azure/deepeval-gate.yml",
+                "ci/azure/guardrails-check.yml",
+                "ci/azure/multi-agent-gate.yml",
+                "ci/azure/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              }
+            },
             "ui-react": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
               "ci/azure/ui-quality-gate.yml",

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -402,8 +402,18 @@
         "shared": [],
         "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"] },
+          "api":        {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+            }
+          },
+          "cli":        {
+            "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+            }
+          },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
           "ui-nextjs":  { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-nextjs-quality-gate.yml"] },
@@ -441,24 +451,34 @@
           "shared": [],
           "governed": ["ci/github/repo-scope-check.yml"],
           "by_type": {
-            "api": { "governed": [
-              "ci/github/l3-quality-gate.yml",
-              "ci/github/quality-gate.yml",
-              "ci/github/eval-gate.yml",
-              "ci/github/deepeval-gate.yml",
-              "ci/github/guardrails-check.yml",
-              "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
-            ] },
-            "cli": { "governed": [
-              "ci/github/l3-quality-gate.yml",
-              "ci/github/quality-gate.yml",
-              "ci/github/eval-gate.yml",
-              "ci/github/deepeval-gate.yml",
-              "ci/github/guardrails-check.yml",
-              "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
-            ] },
+            "api": {
+              "governed": [
+                "ci/github/l3-quality-gate.yml",
+                "ci/github/quality-gate.yml",
+                "ci/github/eval-gate.yml",
+                "ci/github/deepeval-gate.yml",
+                "ci/github/guardrails-check.yml",
+                "ci/github/multi-agent-gate.yml",
+                "ci/github/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              }
+            },
+            "cli": {
+              "governed": [
+                "ci/github/l3-quality-gate.yml",
+                "ci/github/quality-gate.yml",
+                "ci/github/eval-gate.yml",
+                "ci/github/deepeval-gate.yml",
+                "ci/github/guardrails-check.yml",
+                "ci/github/multi-agent-gate.yml",
+                "ci/github/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              }
+            },
             "ui-react": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
               "ci/github/ui-quality-gate.yml",
@@ -493,8 +513,18 @@
         "shared": [],
         "governed": [],
         "by_type": {
-          "api":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
-          "cli":        { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"] },
+          "api":        {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+            }
+          },
+          "cli":        {
+            "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
+            "by_stack": {
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+            }
+          },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-angular": { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
           "ui-nextjs":  { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-nextjs-quality-gate.yml"] },
@@ -532,24 +562,34 @@
           "shared": [],
           "governed": ["ci/azure/repo-scope-check.yml"],
           "by_type": {
-            "api": { "governed": [
-              "ci/azure/l3-quality-gate.yml",
-              "ci/azure/quality-gate.yml",
-              "ci/azure/eval-gate.yml",
-              "ci/azure/deepeval-gate.yml",
-              "ci/azure/guardrails-check.yml",
-              "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
-            ] },
-            "cli": { "governed": [
-              "ci/azure/l3-quality-gate.yml",
-              "ci/azure/quality-gate.yml",
-              "ci/azure/eval-gate.yml",
-              "ci/azure/deepeval-gate.yml",
-              "ci/azure/guardrails-check.yml",
-              "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
-            ] },
+            "api": {
+              "governed": [
+                "ci/azure/l3-quality-gate.yml",
+                "ci/azure/quality-gate.yml",
+                "ci/azure/eval-gate.yml",
+                "ci/azure/deepeval-gate.yml",
+                "ci/azure/guardrails-check.yml",
+                "ci/azure/multi-agent-gate.yml",
+                "ci/azure/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              }
+            },
+            "cli": {
+              "governed": [
+                "ci/azure/l3-quality-gate.yml",
+                "ci/azure/quality-gate.yml",
+                "ci/azure/eval-gate.yml",
+                "ci/azure/deepeval-gate.yml",
+                "ci/azure/guardrails-check.yml",
+                "ci/azure/multi-agent-gate.yml",
+                "ci/azure/promptfoo-gate.yml"
+              ],
+              "by_stack": {
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              }
+            },
             "ui-react": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
               "ci/azure/ui-quality-gate.yml",

--- a/ci/README.md
+++ b/ci/README.md
@@ -32,6 +32,7 @@ Copy the relevant templates for your project type:
 | `quality-gate.yml` | ✓ | ✓ | optional | — |
 | `eval-gate.yml` (L4+) | ✓ | ✓ | — | — |
 | `l3-quality-gate.yml` (L3 only) | ✓ | ✓ | — | — |
+| `boundary-gate-python.yml` | `python-fastapi` | `python-fastapi` | — | — |
 | `ui-quality-gate.yml` | — | — | ✓ | — |
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
@@ -54,24 +55,31 @@ Copy the relevant templates for your project type:
 
 ---
 
-### Boundary enforcement is opt-in
+### Boundary enforcement is selected by stack
 
-`boundary-check` runs `import-linter` against the contract in your
-`pyproject.toml` (or `.importlinter` / `setup.cfg` / `tox.ini`). govkit ships
-`governance/backend/importlinter-reference.toml` as a **template** — copy it in
-and replace `myservice` with your package name to switch enforcement on.
+Boundary enforcement needs a tool that can read your language, so it is **not**
+part of the shared quality gate. govkit installs a boundary gate chosen by
+`--stack`:
 
-Until you do, the job **skips** rather than failing, so a fresh install is
+| Stack | Gate file | Tool |
+|---|---|---|
+| `python-fastapi` | `boundary-gate-python.yml` | `import-linter` |
+| `nodejs-fastify`, `go-gin`, `java-spring-boot`, `dotnet-aspnet` | *none yet* | tracked separately |
+
+A stack with no gate receives **no boundary workflow at all**, rather than one
+that silently skips. Shipping a Python linter to a Go repo enforces nothing
+whether it fails or skips, and the architecture docs would still be promising
+enforcement that does not exist.
+
+Boundary enforcement ships from **L3** upward. L3 has no `features/` model, but
+it does carry the architecture contracts, and this is what enforces them.
+
+**The Python gate is opt-in.** `boundary-check` runs `import-linter` against the
+contract in your `pyproject.toml` (or `.importlinter` / `setup.cfg` / `tox.ini`).
+govkit ships `governance/backend/importlinter-reference.toml` as a **template** —
+copy it in and replace `myservice` with your package name to switch enforcement
+on. Until you do, the job **skips** rather than failing, so a fresh install is
 green. It logs a notice telling you how to enable it.
-
-Two consequences worth knowing:
-
-- Boundary enforcement ships from **L3** upward. L3 has no `features/` model,
-  but it does carry the architecture contracts, and this is what enforces them.
-- import-linter is Python-only, so the job stays skipped on the `go-gin`,
-  `dotnet-aspnet`, `java-spring-boot` and `nodejs-fastify` stacks. Equivalent
-  per-stack tooling is tracked separately — a skipped job is honest, a Python
-  linter pointed at Go is not.
 
 ---
 
@@ -85,7 +93,8 @@ files made L4+ repos run each twice on every push.
 
 | Pipeline | Level 3 | Level 4 |
 |----------|---------|---------|
-| `l3-quality-gate.yml` | Governance artifacts (3), commit format, boundary enforcement, SonarQube, Snyk | — |
+| `l3-quality-gate.yml` | Governance artifacts (3), commit format, SonarQube, Snyk | — |
+| `boundary-gate-python.yml` | Architecture boundary enforcement (`python-fastapi` only) | — |
 | `quality-gate.yml` | — | Schema validation, contract compatibility, governance artifacts (5) |
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |
@@ -118,9 +127,9 @@ A critical distinction in this governance framework: some checks enforce **actua
 | Check | Pipeline | What it does |
 |---|---|---|
 | Schema validation | quality-gate | Validates `eval_criteria.yaml` against JSON Schema |
-| Architecture boundaries | quality-gate | Runs `import-linter` to enforce hexagonal layering |
-| Security vulnerabilities | quality-gate | Snyk dependency scan |
-| Code quality metrics | quality-gate | SonarQube duplication and complexity |
+| Architecture boundaries | boundary-gate-python | Runs `import-linter` to enforce hexagonal layering (`python-fastapi` only) |
+| Security vulnerabilities | l3-quality-gate | Snyk dependency scan |
+| Code quality metrics | l3-quality-gate | SonarQube duplication and complexity |
 
 ### Prediction-only (plan.md scores, not actuals)
 
@@ -257,8 +266,10 @@ policy, and cost controls.
 ### Backend
 
 ```
-quality-gate.yml    → schema validation, boundaries, SonarQube, Snyk, contracts
-eval-gate.yml       → FIRST/Virtue prediction check, LLM eval suite
+l3-quality-gate.yml       → commit format, SonarQube, Snyk
+boundary-gate-python.yml  → import-linter boundaries (python-fastapi only)
+quality-gate.yml          → schema validation, contract compatibility, artifacts
+eval-gate.yml             → FIRST/Virtue prediction check, LLM eval suite
 ```
 
 ### UI

--- a/ci/azure/boundary-gate-python.yml
+++ b/ci/azure/boundary-gate-python.yml
@@ -1,0 +1,46 @@
+# Azure DevOps pipeline — architecture boundary enforcement for the
+# `python-fastapi` stack. Runs `import-linter` against the hexagonal layer
+# contract described in docs/backend/architecture/BOUNDARIES.md.
+#
+# STAGES:
+#   BoundaryCheck    — enforces hexagonal architecture boundaries via import-linter
+#
+# STACK-SELECTED: govkit installs this file only for `--stack python-fastapi`.
+# import-linter reads Python imports and cannot analyse Go, Java, C# or
+# TypeScript, so the other backend stacks receive no boundary gate rather than
+# one that silently skips. Their equivalents are tracked separately.
+#
+# OPT-IN: govkit ships governance/backend/importlinter-reference.toml as a
+# template. The contract is live only once you copy it into pyproject.toml and
+# set your package name; until then this stage skips so a fresh install is
+# green.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: BoundaryCheck
+    displayName: Architecture boundary enforcement
+    dependsOn: []
+    jobs:
+      - job: BoundaryCheck
+        displayName: Run import-linter
+        steps:
+          - checkout: self
+
+          - script: |
+              if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+                 || [ -f .importlinter ]; then
+                pip install import-linter
+                lint-imports
+              else
+                echo "##vso[task.logissue type=warning]No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
+              fi
+            displayName: Enforce hexagonal architecture boundaries

--- a/ci/azure/l3-quality-gate.yml
+++ b/ci/azure/l3-quality-gate.yml
@@ -3,10 +3,12 @@
 #
 # STAGES:
 #   CommitFormat     — validates commit message format
-#   BoundaryCheck    — enforces hexagonal architecture boundaries via import-linter
-#                      (requires .importlinter config in your repo root)
 #   SonarQube        — SonarQube quality gate (optional, requires SONAR_TOKEN)
 #   SecurityScan    — Snyk vulnerability scan (optional, requires SNYK_TOKEN)
+#
+# Architecture boundary enforcement is NOT here: it is stack-specific, and
+# this gate ships for every backend stack. govkit installs a boundary gate
+# selected by stack — ci/azure/boundary-gate-python.yml for `python-fastapi`.
 #
 # NOTE: This is the Level 3 (Foundations) gate. It does NOT include
 # per-feature governance checks because L3 has no `features/` directory model.
@@ -65,30 +67,6 @@ stages:
               fi
               echo "All commit messages match expected format."
             displayName: Validate commit message format
-
-  - stage: BoundaryCheck
-    displayName: Architecture boundary enforcement
-    dependsOn: []
-    jobs:
-      - job: BoundaryCheck
-        displayName: Run import-linter
-        steps:
-          - checkout: self
-
-          # govkit ships governance/backend/importlinter-reference.toml as a
-          # template; the contract is only live once you copy it in and set
-          # the package name. Until then this step skips rather than failing,
-          # so a fresh install is green. It also skips on non-Python stacks,
-          # which import-linter cannot check at all.
-          - script: |
-              if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
-                 || [ -f .importlinter ]; then
-                pip install import-linter
-                lint-imports
-              else
-                echo "##vso[task.logissue type=warning]No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
-              fi
-            displayName: Enforce hexagonal architecture boundaries
 
   - stage: SonarQube
     displayName: SonarQube quality gate

--- a/ci/github/boundary-gate-python.yml
+++ b/ci/github/boundary-gate-python.yml
@@ -1,0 +1,54 @@
+# boundary-gate-python.yml
+#
+# PURPOSE: Architecture boundary enforcement for the `python-fastapi` stack.
+# Runs `import-linter` against the hexagonal layer contract described in
+# docs/backend/architecture/BOUNDARIES.md.
+# Copy this file to .github/workflows/boundary-gate.yml.
+#
+# JOBS:
+#   boundary-check    — enforces hexagonal architecture boundaries via import-linter
+#
+# STACK-SELECTED: govkit installs this file only for `--stack python-fastapi`.
+# import-linter reads Python imports and cannot analyse Go, Java, C# or
+# TypeScript, so the other backend stacks receive no boundary gate rather than
+# one that silently skips. Their equivalents are tracked separately.
+#
+# OPT-IN: govkit ships governance/backend/importlinter-reference.toml as a
+# template. The contract is live only once you copy it into pyproject.toml and
+# set your package name; until then this job skips so a fresh install is green.
+#
+# REQUIRED SECRETS: none.
+
+name: Boundary Gate (Python)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  boundary-check:
+    name: Architecture boundary enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect import-linter contract
+        id: contract
+        run: |
+          if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
+             || [ -f .importlinter ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
+          fi
+
+      - name: Install import-linter
+        if: steps.contract.outputs.found == 'true'
+        run: pip install import-linter
+
+      - name: Run boundary checks
+        if: steps.contract.outputs.found == 'true'
+        run: lint-imports

--- a/ci/github/l3-quality-gate.yml
+++ b/ci/github/l3-quality-gate.yml
@@ -6,10 +6,12 @@
 #
 # JOBS:
 #   commit-format     — validates commit message format
-#   boundary-check    — enforces hexagonal architecture boundaries via import-linter
-#                       (requires .importlinter config in your repo root)
 #   sonarqube         — SonarQube quality gate (optional, requires SONAR_TOKEN)
 #   security-scan     — Snyk vulnerability scan (optional, requires SNYK_TOKEN)
+#
+# Architecture boundary enforcement is NOT here: it is stack-specific, and
+# this gate ships for every backend stack. govkit installs a boundary gate
+# selected by stack — ci/github/boundary-gate-python.yml for `python-fastapi`.
 #
 # NOTE: This is the Level 3 (Foundations) gate. It does NOT include
 # per-feature governance checks because L3 has no `features/` directory model.
@@ -68,36 +70,6 @@ jobs:
             exit 1
           fi
           echo "All commit messages match expected format."
-
-  boundary-check:
-    name: Architecture boundary enforcement
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      # govkit ships governance/backend/importlinter-reference.toml as a
-      # template; the contract is only live once you copy it in and set the
-      # package name. Until then this job skips rather than failing, so a
-      # fresh install is green. It also skips on non-Python stacks, which
-      # import-linter cannot check at all — see the per-stack tracking issue.
-      - name: Detect import-linter contract
-        id: contract
-        run: |
-          if grep -qs 'tool.importlinter' pyproject.toml setup.cfg tox.ini \
-             || [ -f .importlinter ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::No import-linter contract found. Copy governance/backend/importlinter-reference.toml into pyproject.toml and set your package name to enable boundary enforcement."
-          fi
-
-      - name: Install import-linter
-        if: steps.contract.outputs.found == 'true'
-        run: pip install import-linter
-
-      - name: Run boundary checks
-        if: steps.contract.outputs.found == 'true'
-        run: lint-imports
 
   sonarqube:
     name: SonarQube quality gate

--- a/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
+++ b/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
@@ -1,6 +1,9 @@
 # Per-Stack Boundary Enforcement Plan
 
-**Status:** Draft — 2026-08-01. Covers #93. No implementation started.
+**Status:** In progress — 2026-08-01. Increment 1 (stack-selected dispatch,
+proven with Python) is implemented. Increments 2-5 are held pending answers to
+the Open questions below; increment 6 follows them. Covers #93, which closes
+when the remaining increments land.
 
 Give each backend stack boundary enforcement in a tool that understands its
 language. Four of govkit's five backend stacks currently have none: the
@@ -138,19 +141,34 @@ Each is independently demonstrable and starts with failing tests. Payload
 edits land for **all three agents in lockstep**; run `pytest -k parity`
 before each commit.
 
-### 1. Stack-selected dispatch, proven with Python
+### 1. Stack-selected dispatch, proven with Python — done
 
 1. Failing test: a `python-fastapi` install receives a boundary gate; a
    `go-gin` install receives none. Assert per agent × CI flavour × type.
-2. Extract `boundary-check` from `l3-quality-gate.yml` and `quality-gate.yml`
-   into `ci/<flavour>/boundary-gate-python.yml`.
+   → `tests/test_boundary_gate_dispatch.py`, which also asserts the job is
+   defined in exactly one of the two files, and that UI and `data` installs
+   never receive it.
+2. Extract `boundary-check` from `l3-quality-gate.yml` into
+   `ci/<flavour>/boundary-gate-python.yml`. (`quality-gate.yml` no longer
+   defines it — #94 removed the L4 duplicate before this plan was written.)
 3. Add `by_stack` blocks under `by_type.api` and `by_type.cli` in all three
-   manifests, both flavours.
+   manifests, both flavours — at the base block and again under `level_5`,
+   which is `replace` mode and so does not inherit the base. L4 is `merge`
+   mode and inherits, as it already does for `l3-quality-gate.yml`.
 4. Extend `tests/test_ci_gate_composition.py` so the no-duplicate-jobs
-   invariant covers the new files.
+   invariant covers the new files — it is now parametrized over `stack`.
 
 No new tooling — this proves the dispatch alone, and is revertible on its
 own if the approach is wrong.
+
+Verified with real `govkit apply` runs across agent × flavour × level ×
+stack: `python-fastapi` receives the gate at L3/L4/L5 in both flavours,
+`go-gin` and `java-spring-boot` receive no boundary workflow and install
+cleanly, and `data`/`ui-nextjs` are untouched. An existing install
+upgraded from a pre-change payload was also checked — `upgrade` refreshed
+`l3-quality-gate.yml` (dropping `boundary-check`) and added the new file,
+so no repo ends up defining the job twice. That closes the assumption
+recorded under Out of scope; an automated test for it stays with #83.
 
 Commit: `refactor(ci): select the boundary gate per stack (#93)`
 
@@ -238,6 +256,8 @@ These want answers before increment 2, not before increment 1.
   file, so the manifest contradicts itself. Same parked review.
 - **Retiring superseded gate files on upgrade.** Increment 1 moves
   `boundary-check` out of `l3-quality-gate.yml`; an existing install keeps
-  the old file until upgrade refreshes it. Governed files *are* overwritten
-  on upgrade, so this should resolve itself, but it wants an explicit test
-  rather than an assumption — related to #83.
+  the old file until upgrade refreshes it. Verified by hand against a
+  simulated pre-change install: `upgrade` rewrote `l3-quality-gate.yml` and
+  added `boundary-gate-python.yml`, so the job is never defined twice. The
+  behaviour is correct; what is still missing is an automated test pinning
+  it — related to #83.

--- a/tests/test_boundary_gate_dispatch.py
+++ b/tests/test_boundary_gate_dispatch.py
@@ -1,0 +1,215 @@
+"""Boundary enforcement ships per backend stack, not per backend install.
+
+`import-linter` is Python-only, but the `boundary-check` job lived in the
+shared `l3-quality-gate.yml`, so `go-gin`, `dotnet-aspnet`,
+`java-spring-boot` and `nodejs-fastify` installs all received a Python
+linter job that cannot read their source. Since #95 it skips when no
+contract is configured, which made the failure silent rather than absent —
+a skipped job still enforces nothing while the architecture docs promise
+enforcement.
+
+The job now lives in its own stack-selected file. `python-fastapi` receives
+`ci/<flavour>/boundary-gate-python.yml`; a stack with no boundary tooling
+yet receives no boundary gate at all, rather than one that skips.
+
+Increment 1 of plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md (#93). The
+remaining four stacks arrive in increments 2-5; the "ships nothing" cases
+below are the ones that flip as each lands.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from cli import paths
+from cli.manifest import load_manifest, resolve_variant_files
+
+AGENTS = ("claude-code", "codex", "copilot")
+CI_FLAVOURS = ("github", "azure")
+BACKEND_TYPES = ("api", "cli")
+LEVELS = ("3", "4", "5")
+
+PYTHON_STACK = "python-fastapi"
+STACKS_WITHOUT_A_GATE = (
+    "dotnet-aspnet",
+    "java-spring-boot",
+    "nodejs-fastify",
+    "go-gin",
+)
+
+_AZ_STAGE = re.compile(r"^\s*- stage:\s*([A-Za-z0-9_]+)\s*$", re.MULTILINE)
+
+
+def _governed(agent: str, ci: str, project_type: str, level: str, stack: str) -> list[str]:
+    manifest = load_manifest(agent)
+    _files, _shared, governed = resolve_variant_files(
+        manifest,
+        {"level": level, "type": project_type, "ci": ci, "stack": stack},
+    )
+    return [str(entry) for entry in governed]
+
+
+def _boundary_gates(governed: list[str], ci: str) -> list[str]:
+    return [path for path in governed if path.startswith(f"ci/{ci}/boundary-gate-")]
+
+
+def _gate_text(rel_path: str) -> str:
+    return (paths.REPO_ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _github_jobs(rel_path: str) -> set[str]:
+    parsed = yaml.safe_load(_gate_text(rel_path)) or {}
+    jobs = parsed.get("jobs")
+    assert isinstance(jobs, dict) and jobs, f"{rel_path} defines no jobs"
+    return set(jobs)
+
+
+def _azure_stages(rel_path: str) -> set[str]:
+    stages = set(_AZ_STAGE.findall(_gate_text(rel_path)))
+    assert stages, f"{rel_path} defines no stages"
+    return stages
+
+
+class TestPythonBoundaryGateDispatch:
+    """A python-fastapi backend install receives the Python boundary gate."""
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    @pytest.mark.parametrize("project_type", BACKEND_TYPES)
+    @pytest.mark.parametrize("level", LEVELS)
+    def test_python_fastapi_receives_the_python_boundary_gate(
+        self, agent, ci, project_type, level,
+    ):
+        governed = _governed(agent, ci, project_type, level, PYTHON_STACK)
+
+        assert f"ci/{ci}/boundary-gate-python.yml" in governed, (
+            f"{agent} {project_type} L{level} ({ci}, {PYTHON_STACK}) must receive "
+            f"the Python boundary gate; got {_boundary_gates(governed, ci)}"
+        )
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    @pytest.mark.parametrize("project_type", BACKEND_TYPES)
+    @pytest.mark.parametrize("level", LEVELS)
+    @pytest.mark.parametrize("stack", STACKS_WITHOUT_A_GATE)
+    def test_a_stack_with_no_boundary_tooling_receives_no_gate(
+        self, agent, ci, project_type, level, stack,
+    ):
+        """Shipping nothing is the honest state — a Python linter pointed at
+        Go enforces nothing whether it fails or skips."""
+        governed = _governed(agent, ci, project_type, level, stack)
+
+        assert _boundary_gates(governed, ci) == [], (
+            f"{agent} {project_type} L{level} ({ci}, {stack}) must receive no "
+            f"boundary gate until {stack} has enforcement of its own"
+        )
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    @pytest.mark.parametrize("project_type", ["ui-react", "ui-angular", "ui-nextjs"])
+    @pytest.mark.parametrize("level", LEVELS)
+    def test_ui_types_never_receive_a_backend_boundary_gate(
+        self, agent, ci, project_type, level,
+    ):
+        """The dispatch must be nested under the backend type entries. Wiring it
+        at the `ci` block level instead would leak the gate into UI installs,
+        which reject `--stack` outright."""
+        governed = _governed(agent, ci, project_type, level, PYTHON_STACK)
+
+        assert _boundary_gates(governed, ci) == [], (
+            f"{agent} {project_type} L{level} ({ci}) must receive no backend "
+            "boundary gate"
+        )
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    @pytest.mark.parametrize("level", ["3", "4"])
+    @pytest.mark.parametrize("stack", ["python-dbt", "databricks-lakehouse"])
+    def test_data_type_never_receives_a_backend_boundary_gate(
+        self, agent, ci, level, stack,
+    ):
+        governed = _governed(agent, ci, "data", level, stack)
+
+        assert _boundary_gates(governed, ci) == [], (
+            f"{agent} data L{level} ({ci}, {stack}) must receive no backend "
+            "boundary gate"
+        )
+
+
+class TestBoundaryGateExtraction:
+    """The job moved out of the shared L3 gate — it is not defined in both."""
+
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    def test_the_python_boundary_gate_file_exists(self, ci):
+        assert (paths.REPO_ROOT / f"ci/{ci}/boundary-gate-python.yml").is_file()
+
+    def test_github_boundary_gate_defines_only_the_boundary_job(self):
+        assert _github_jobs("ci/github/boundary-gate-python.yml") == {"boundary-check"}
+
+    def test_azure_boundary_gate_defines_only_the_boundary_stage(self):
+        assert _azure_stages("ci/azure/boundary-gate-python.yml") == {"BoundaryCheck"}
+
+    def test_github_l3_gate_no_longer_defines_the_boundary_job(self):
+        jobs = _github_jobs("ci/github/l3-quality-gate.yml")
+
+        assert "boundary-check" not in jobs, (
+            "boundary-check is defined in both l3-quality-gate.yml and "
+            "boundary-gate-python.yml — a python-fastapi install ships both "
+            "files and would run it twice"
+        )
+        # Extraction must move one job, not gut the gate.
+        assert {"commit-format", "sonarqube", "security-scan"} <= jobs
+
+    def test_azure_l3_gate_no_longer_defines_the_boundary_stage(self):
+        stages = _azure_stages("ci/azure/l3-quality-gate.yml")
+
+        assert "BoundaryCheck" not in stages, (
+            "BoundaryCheck is defined in both l3-quality-gate.yml and "
+            "boundary-gate-python.yml — a python-fastapi install ships both "
+            "files and would run it twice"
+        )
+        assert {"CommitFormat", "SonarQube", "SecurityScan"} <= stages
+
+
+class TestBoundaryGateContent:
+    """The opt-in skip contract from #95 survived the move."""
+
+    @pytest.mark.parametrize(
+        "rel_path, required",
+        [
+            (
+                "ci/github/boundary-gate-python.yml",
+                [
+                    "tool.importlinter",
+                    ".importlinter",
+                    "pip install import-linter",
+                    "lint-imports",
+                    "::notice::",
+                    "governance/backend/importlinter-reference.toml",
+                ],
+            ),
+            (
+                "ci/azure/boundary-gate-python.yml",
+                [
+                    "tool.importlinter",
+                    ".importlinter",
+                    "pip install import-linter",
+                    "lint-imports",
+                    "##vso[task.logissue type=warning]",
+                    "governance/backend/importlinter-reference.toml",
+                ],
+            ),
+        ],
+    )
+    def test_gate_keeps_the_contract_detection_and_opt_in_notice(self, rel_path, required):
+        text = _gate_text(rel_path)
+
+        for fragment in required:
+            assert fragment in text, f"{rel_path} lost {fragment!r} in the move"
+
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    def test_gate_names_the_python_stack_it_is_selected_for(self, ci):
+        """The file is stack-selected, so a reader opening it must be able to
+        tell which stack it belongs to without consulting the manifest."""
+        assert "python-fastapi" in _gate_text(f"ci/{ci}/boundary-gate-python.yml")

--- a/tests/test_ci_gate_composition.py
+++ b/tests/test_ci_gate_composition.py
@@ -10,6 +10,10 @@ SonarQube runs against the same commit.
 Scoped to the `api` and `cli` types. `ui-nextjs` has the same shape at L4
 and is tracked separately as part of the wider UI review; adding it here
 would mean a failing test for work that is deliberately parked.
+
+Parametrized over `stack` since #93: the boundary gate is a separate,
+stack-selected file, so which workflows ship together now depends on the
+stack as well as the type and level.
 """
 
 import re
@@ -22,16 +26,23 @@ from cli.manifest import load_manifest, resolve_variant_files
 AGENTS = ("claude-code", "codex", "copilot")
 TYPES = ("api", "cli")
 LEVELS = ("3", "4", "5")
+STACKS = (
+    "python-fastapi",
+    "dotnet-aspnet",
+    "java-spring-boot",
+    "nodejs-fastify",
+    "go-gin",
+)
 
 _GH_JOB = re.compile(r"^  ([a-z][a-z0-9-]*):\s*$", re.MULTILINE)
 _AZ_JOB = re.compile(r"^\s*- job:\s*([A-Za-z0-9_]+)\s*$", re.MULTILINE)
 
 
-def _gate_files(agent: str, ci: str, project_type: str, level: str):
+def _gate_files(agent: str, ci: str, project_type: str, level: str, stack: str):
     """Workflow files this install actually receives, as repo-relative paths."""
     manifest = load_manifest(agent)
     _files, shared, governed = resolve_variant_files(
-        manifest, {"level": level, "type": project_type, "ci": ci},
+        manifest, {"level": level, "type": project_type, "ci": ci, "stack": stack},
     )
     return [
         str(entry) for entry in list(governed) + list(shared)
@@ -61,19 +72,22 @@ def repo_root():
 @pytest.mark.parametrize("ci", ["github", "azure"])
 @pytest.mark.parametrize("project_type", TYPES)
 @pytest.mark.parametrize("level", LEVELS)
+@pytest.mark.parametrize("stack", STACKS)
 def test_no_job_is_defined_by_two_gates_that_ship_together(
-    repo_root, agent, ci, project_type, level,
+    repo_root, agent, ci, project_type, level, stack,
 ):
+    gates = _gate_files(agent, ci, project_type, level, stack)
+    assert gates, f"{agent} {project_type} L{level} ({ci}, {stack}) receives no gate files"
     seen: dict[str, str] = {}
     duplicates: list[str] = []
-    for rel in _gate_files(agent, ci, project_type, level):
+    for rel in gates:
         for job in sorted(_job_names(repo_root, rel, ci)):
             if job in seen:
                 duplicates.append(f"{job!r} in both {seen[job]} and {rel}")
             else:
                 seen[job] = rel
     assert not duplicates, (
-        f"{agent} {project_type} L{level} ({ci}) runs duplicate jobs:\n  "
+        f"{agent} {project_type} L{level} ({ci}, {stack}) runs duplicate jobs:\n  "
         + "\n  ".join(duplicates)
     )
 


### PR DESCRIPTION
Increment 1 of `plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md`. Increments 2-5 are held pending the plan's open questions and are **not** in this PR — #93 stays open.

## The problem

`boundary-check` runs `import-linter`, which is Python-only, and it lived in `l3-quality-gate.yml`, which ships for every backend stack. `go-gin`, `dotnet-aspnet`, `java-spring-boot` and `nodejs-fastify` all received a job that cannot read their source.

Since #95 the job skips when no contract is configured, so the failure was silent rather than absent. A skipped job enforces nothing, while `BOUNDARIES.md` and `ARCH_CONTRACT.md` go on saying the layering is "enforced with `import-linter`".

## The change

The job moves into `ci/<flavour>/boundary-gate-python.yml`, selected by a `by_stack` block under `by_type.api` and `by_type.cli` in all three agent manifests, both CI flavours. A stack with no boundary tooling now ships **no boundary workflow at all** — the honest state, and a visible one: an empty slot invites the question, a green skipped job does not.

No schema change. `by_stack` nested inside `by_type` already exists — it is what the `data` type uses to dispatch `dbt-gate.yml` and `databricks-gate.yml`.

The wiring lands twice per flavour: on the base block, and again under `level_5`, which is `replace` mode and inherits nothing. L4 is `merge` mode and inherits from the base, as it already does for `l3-quality-gate.yml`.

Two notes on the plan as written:

- Its step 2 named `quality-gate.yml` as a second source of the job. #94 had already removed that duplicate, so only the L3 gate needed changing.
- `ci/README.md` needed more than the new row. Its "Enforced" table pointed at `quality-gate` for boundaries, SonarQube and Snyk, none of which have lived there since #94.

## Tests

`tests/test_boundary_gate_dispatch.py` (new, failing first — 46 failures before the implementation) asserts:

- a `python-fastapi` `api`/`cli` install receives the gate at L3/L4/L5, per agent × flavour;
- the four stacks without tooling receive none;
- UI and `data` installs receive none — the dispatch must be nested under the backend type entries, not at the `ci` block level, or it would leak into UI installs that reject `--stack` outright;
- the job is defined in exactly one file, and the L3 gate still defines the three jobs that stay.

`tests/test_ci_gate_composition.py` is parametrized over `stack`, since which workflows ship together now depends on it. It also asserts the resolved gate list is non-empty, so a stack resolving to nothing cannot satisfy the no-duplicate-jobs invariant vacuously.

`./full_test`: 1729 + 85 passed, 1 skipped.

## Verified end to end

Real `govkit apply` runs, not only unit tests:

| Install | Result |
|---|---|
| `python-fastapi` api/cli, L3/L4/L5, github + azure, all 3 agents | gate installed; 15 distinct jobs at L5, zero duplicates |
| `go-gin`, `java-spring-boot` | no boundary workflow; installs cleanly |
| `data` (python-dbt), `ui-nextjs` | unchanged |

Also checked the upgrade path the plan had left as an assumption: a simulated pre-change install (old L3 gate with `boundary-check`, no boundary gate, aged marker) was upgraded — `upgrade` rewrote `l3-quality-gate.yml` and added the new file, so no existing repo ends up defining `boundary-check` twice. The plan's Out of scope note is updated to say the behaviour is verified and only the automated test is outstanding (#83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
