### PR TITLE
feat(ci): boundary enforcement for nodejs-fastify (#93)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,27 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
+      # tests/test_dependency_cruiser_reference.py runs the real
+      # dependency-cruiser against generated skeletons, the way
+      # test_importlinter_reference.py runs the real import-linter. Without a
+      # Node toolchain those tests skip, and a skip is indistinguishable from
+      # a pass in the summary — see the guard step below.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
       - name: Install
         run: pip install -e ".[test]"
+
+      - name: Assert the Node toolchain is present
+        # The reference tests skipif npm is missing, which is right locally but
+        # wrong here: a broken setup-node step would leave the only tests that
+        # prove the shipped dependency-cruiser config works silently skipped,
+        # and CI would still be green.
+        run: |
+          set -euxo pipefail
+          command -v node
+          command -v npm
 
       - name: Run pytest
         run: pytest

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -37,8 +37,7 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/",
-          "governance/backend/importlinter-reference.toml"
+          "docs/backend/architecture/"
         ],
         "level_4": {
           "mode": "merge",
@@ -93,7 +92,6 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/importlinter-reference.toml",
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
@@ -113,8 +111,7 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/",
-          "governance/backend/importlinter-reference.toml"
+          "docs/backend/architecture/"
         ],
         "level_4": {
           "mode": "merge",
@@ -167,7 +164,6 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/importlinter-reference.toml",
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
@@ -401,13 +397,15 @@
           "api":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "cli":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -458,7 +456,8 @@
                 "ci/github/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "cli": {
@@ -472,7 +471,8 @@
                 "ci/github/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "ui-react": { "governed": [
@@ -512,13 +512,15 @@
           "api":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "cli":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -569,7 +571,8 @@
                 "ci/azure/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "cli": {
@@ -583,7 +586,8 @@
                 "ci/azure/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -70,8 +70,7 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/",
-          "governance/backend/importlinter-reference.toml"
+          "docs/backend/architecture/"
         ],
         "level_4": {
           "mode": "merge",
@@ -126,7 +125,6 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/importlinter-reference.toml",
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
@@ -146,8 +144,7 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/",
-          "governance/backend/importlinter-reference.toml"
+          "docs/backend/architecture/"
         ],
         "level_4": {
           "mode": "merge",
@@ -200,7 +197,6 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/importlinter-reference.toml",
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
@@ -423,13 +419,15 @@
           "api":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "cli":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -480,7 +478,8 @@
                 "ci/github/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "cli": {
@@ -494,7 +493,8 @@
                 "ci/github/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "ui-react": { "governed": [
@@ -534,13 +534,15 @@
           "api":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "cli":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -591,7 +593,8 @@
                 "ci/azure/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "cli": {
@@ -605,7 +608,8 @@
                 "ci/azure/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -70,8 +70,7 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/",
-          "governance/backend/importlinter-reference.toml"
+          "docs/backend/architecture/"
         ],
         "level_4": {
           "mode": "merge",
@@ -119,7 +118,6 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/importlinter-reference.toml",
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
@@ -139,8 +137,7 @@
         ],
         "shared": [],
         "governed": [
-          "docs/backend/architecture/",
-          "governance/backend/importlinter-reference.toml"
+          "docs/backend/architecture/"
         ],
         "level_4": {
           "mode": "merge",
@@ -186,7 +183,6 @@
           ],
           "governed": [
             "docs/backend/",
-            "governance/backend/importlinter-reference.toml",
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json"
@@ -405,13 +401,15 @@
           "api":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "cli":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -462,7 +460,8 @@
                 "ci/github/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "cli": {
@@ -476,7 +475,8 @@
                 "ci/github/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "ui-react": { "governed": [
@@ -516,13 +516,15 @@
           "api":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "cli":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
-              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+              "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -573,7 +575,8 @@
                 "ci/azure/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "cli": {
@@ -587,7 +590,8 @@
                 "ci/azure/promptfoo-gate.yml"
               ],
               "by_stack": {
-                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml"] }
+                "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
               }
             },
             "ui-react": { "governed": [

--- a/ci/README.md
+++ b/ci/README.md
@@ -33,6 +33,7 @@ Copy the relevant templates for your project type:
 | `eval-gate.yml` (L4+) | ✓ | ✓ | — | — |
 | `l3-quality-gate.yml` (L3 only) | ✓ | ✓ | — | — |
 | `boundary-gate-python.yml` | `python-fastapi` | `python-fastapi` | — | — |
+| `boundary-gate-node.yml` | `nodejs-fastify` | `nodejs-fastify` | — | — |
 | `ui-quality-gate.yml` | — | — | ✓ | — |
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
@@ -61,10 +62,11 @@ Boundary enforcement needs a tool that can read your language, so it is **not**
 part of the shared quality gate. govkit installs a boundary gate chosen by
 `--stack`:
 
-| Stack | Gate file | Tool |
-|---|---|---|
-| `python-fastapi` | `boundary-gate-python.yml` | `import-linter` |
-| `nodejs-fastify`, `go-gin`, `java-spring-boot`, `dotnet-aspnet` | *none yet* | tracked separately |
+| Stack | Gate file | Tool | Reference contract |
+|---|---|---|---|
+| `python-fastapi` | `boundary-gate-python.yml` | `import-linter` | `governance/backend/importlinter-reference.toml` |
+| `nodejs-fastify` | `boundary-gate-node.yml` | `dependency-cruiser` | `governance/backend/dependency-cruiser-reference.cjs` |
+| `go-gin`, `java-spring-boot`, `dotnet-aspnet` | *none yet* | tracked separately | — |
 
 A stack with no gate receives **no boundary workflow at all**, rather than one
 that silently skips. Shipping a Python linter to a Go repo enforces nothing
@@ -74,12 +76,28 @@ enforcement that does not exist.
 Boundary enforcement ships from **L3** upward. L3 has no `features/` model, but
 it does carry the architecture contracts, and this is what enforces them.
 
-**The Python gate is opt-in.** `boundary-check` runs `import-linter` against the
-contract in your `pyproject.toml` (or `.importlinter` / `setup.cfg` / `tox.ini`).
-govkit ships `governance/backend/importlinter-reference.toml` as a **template** —
-copy it in and replace `myservice` with your package name to switch enforcement
-on. Until you do, the job **skips** rather than failing, so a fresh install is
-green. It logs a notice telling you how to enable it.
+**Every boundary gate is opt-in.** govkit ships the reference contract as a
+**template**; the gate skips until you copy it in, so a fresh install is green.
+Each logs a notice telling you how to enable it.
+
+- **Python** — copy `governance/backend/importlinter-reference.toml` into your
+  `pyproject.toml` (or `.importlinter` / `setup.cfg` / `tox.ini`) and replace
+  `myservice` with your package name.
+- **Node** — copy `governance/backend/dependency-cruiser-reference.cjs` to
+  `.dependency-cruiser.cjs`. No placeholders: the rules key on layer folder
+  names, and they accept both `src/<layer>/` and `src/<package>/<layer>/`.
+
+**Confirm your gate analysed something.** Both linters report success on an
+empty analysis, so a misconfigured contract looks exactly like a clean repo:
+
+- `import-linter` prints `Analyzed N files, 0 dependencies` and reports every
+  contract KEPT when the package name is wrong.
+- `dependency-cruiser` cruises `0 modules` and exits 0 when it cannot parse
+  your sources — which is what happens on **TypeScript 7**, since
+  dependency-cruiser 17 uses the TypeScript 5.x compiler API.
+
+`boundary-gate-node.yml` fails the build on a zero module count rather than
+trusting the exit code. If you adapt these gates, keep that check.
 
 ---
 
@@ -94,7 +112,8 @@ files made L4+ repos run each twice on every push.
 | Pipeline | Level 3 | Level 4 |
 |----------|---------|---------|
 | `l3-quality-gate.yml` | Governance artifacts (3), commit format, SonarQube, Snyk | — |
-| `boundary-gate-python.yml` | Architecture boundary enforcement (`python-fastapi` only) | — |
+| `boundary-gate-python.yml` | Architecture boundary enforcement (`python-fastapi`) | — |
+| `boundary-gate-node.yml` | Architecture boundary enforcement (`nodejs-fastify`) | — |
 | `quality-gate.yml` | — | Schema validation, contract compatibility, governance artifacts (5) |
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |

--- a/ci/azure/boundary-gate-node.yml
+++ b/ci/azure/boundary-gate-node.yml
@@ -1,0 +1,76 @@
+# Azure DevOps pipeline — architecture boundary enforcement for the
+# `nodejs-fastify` stack. Runs `dependency-cruiser` against the hexagonal layer
+# contract described in docs/backend/architecture/BOUNDARIES.md.
+#
+# STAGES:
+#   BoundaryCheck    — enforces hexagonal architecture boundaries via dependency-cruiser
+#
+# STACK-SELECTED: govkit installs this file only for `--stack nodejs-fastify`.
+# Each backend stack gets a boundary gate in a tool that can read its source;
+# see ci/README.md for the mapping.
+#
+# OPT-IN: govkit ships governance/backend/dependency-cruiser-reference.cjs as a
+# template. The contract is live only once you copy it to
+# `.dependency-cruiser.cjs`; until then this stage skips so a fresh install is
+# green.
+#
+# WHY THE MODULE-COUNT CHECK: dependency-cruiser fails open in two ways, both
+# reproduced against 17.4.3. `--output-type json` reports every violation and
+# still exits 0 — so this stage uses the default reporter. And with TypeScript 7
+# installed, dependency-cruiser 17 cruises 0 modules and exits 0, because it
+# uses the TypeScript 5.x compiler API. A green run that analysed nothing is
+# indistinguishable from a clean one unless the module count is checked, so
+# this stage checks it and fails loudly.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: BoundaryCheck
+    displayName: Architecture boundary enforcement
+    dependsOn: []
+    jobs:
+      - job: BoundaryCheck
+        displayName: Run dependency-cruiser
+        steps:
+          - checkout: self
+
+          - task: NodeTool@0
+            displayName: Use Node.js 22
+            inputs:
+              versionSpec: '22.x'
+
+          - script: |
+              if [ ! -f .dependency-cruiser.cjs ] && [ ! -f .dependency-cruiser.js ] \
+                 && [ ! -f .dependency-cruiser.json ]; then
+                echo "##vso[task.logissue type=warning]No dependency-cruiser config found. Copy governance/backend/dependency-cruiser-reference.cjs to .dependency-cruiser.cjs to enable boundary enforcement."
+                exit 0
+              fi
+
+              set -euo pipefail
+              # The project's own TypeScript is what dependency-cruiser parses with.
+              if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+              # Default (err) reporter — `--output-type json` always exits 0.
+              if ! output=$(npx --yes dependency-cruiser@^17 src --config .dependency-cruiser.cjs 2>&1); then
+                echo "$output"
+                echo "##vso[task.logissue type=error]Architecture boundary violations found."
+                exit 1
+              fi
+              echo "$output"
+
+              summary=$(printf '%s' "$output" | grep -oE '[0-9]+ modules?, [0-9]+ dependenc' | head -1)
+              modules=$(printf '%s' "$summary" | grep -oE '^[0-9]+' || echo 0)
+              if [ -z "$summary" ] || [ "$modules" -eq 0 ]; then
+                echo "##vso[task.logissue type=error]dependency-cruiser cruised ${modules:-no} modules. The boundary check analysed nothing, so it would pass no matter what the code does. Check that your sources are under src/, and that the project's TypeScript is 5.x — dependency-cruiser 17 cannot parse with TypeScript 7."
+                exit 1
+              fi
+              echo "Boundary check analysed $modules modules."
+            displayName: Enforce hexagonal architecture boundaries

--- a/ci/github/boundary-gate-node.yml
+++ b/ci/github/boundary-gate-node.yml
@@ -1,0 +1,85 @@
+# boundary-gate-node.yml
+#
+# PURPOSE: Architecture boundary enforcement for the `nodejs-fastify` stack.
+# Runs `dependency-cruiser` against the hexagonal layer contract described in
+# docs/backend/architecture/BOUNDARIES.md.
+# Copy this file to .github/workflows/boundary-gate.yml.
+#
+# JOBS:
+#   boundary-check    — enforces hexagonal architecture boundaries via dependency-cruiser
+#
+# STACK-SELECTED: govkit installs this file only for `--stack nodejs-fastify`.
+# Each backend stack gets a boundary gate in a tool that can read its source;
+# see ci/README.md for the mapping.
+#
+# OPT-IN: govkit ships governance/backend/dependency-cruiser-reference.cjs as a
+# template. The contract is live only once you copy it to
+# `.dependency-cruiser.cjs`; until then this job skips so a fresh install is
+# green.
+#
+# WHY THE MODULE-COUNT CHECK: dependency-cruiser fails open in two ways, both
+# reproduced against 17.4.3. `--output-type json` reports every violation and
+# still exits 0 — so this gate uses the default reporter. And with TypeScript 7
+# installed, dependency-cruiser 17 cruises 0 modules and exits 0, because it
+# uses the TypeScript 5.x compiler API. A green run that analysed nothing is
+# indistinguishable from a clean one unless the module count is checked, so
+# this job checks it and fails loudly.
+#
+# REQUIRED SECRETS: none.
+
+name: Boundary Gate (Node)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  boundary-check:
+    name: Architecture boundary enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect dependency-cruiser config
+        id: contract
+        run: |
+          if [ -f .dependency-cruiser.cjs ] || [ -f .dependency-cruiser.js ] \
+             || [ -f .dependency-cruiser.json ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No dependency-cruiser config found. Copy governance/backend/dependency-cruiser-reference.cjs to .dependency-cruiser.cjs to enable boundary enforcement."
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.contract.outputs.found == 'true'
+        with:
+          node-version: '22'
+
+      - name: Install project dependencies
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          # The project's own TypeScript is what dependency-cruiser parses with.
+          if [ -f package-lock.json ]; then npm ci; else npm install; fi
+
+      - name: Run boundary checks
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          # Default (err) reporter — `--output-type json` always exits 0.
+          if ! output=$(npx --yes dependency-cruiser@^17 src --config .dependency-cruiser.cjs 2>&1); then
+            echo "$output"
+            echo "::error::Architecture boundary violations found."
+            exit 1
+          fi
+          echo "$output"
+
+          summary=$(printf '%s' "$output" | grep -oE '[0-9]+ modules?, [0-9]+ dependenc' | head -1)
+          modules=$(printf '%s' "$summary" | grep -oE '^[0-9]+' || echo 0)
+          if [ -z "$summary" ] || [ "$modules" -eq 0 ]; then
+            echo "::error::dependency-cruiser cruised ${modules:-no} modules. The boundary check analysed nothing, so it would pass no matter what the code does. Check that your sources are under src/, and that the project's TypeScript is 5.x — dependency-cruiser 17 cannot parse with TypeScript 7."
+            exit 1
+          fi
+          echo "Boundary check analysed $modules modules."

--- a/governance/backend/dependency-cruiser-reference.cjs
+++ b/governance/backend/dependency-cruiser-reference.cjs
@@ -1,0 +1,153 @@
+/*
+ * dependency-cruiser reference configuration for hexagonal architecture
+ * enforcement on the `nodejs-fastify` stack.
+ *
+ * Copy this file to `.dependency-cruiser.cjs` in your repository root — the
+ * filename cli/stacks/nodejs-fastify/TECH_STACK.md already names. No
+ * placeholders to replace: the rules are keyed on layer folder names, not on
+ * your package name.
+ *
+ * Install: npm install --save-dev dependency-cruiser
+ * Run:     npx depcruise src --config .dependency-cruiser.cjs
+ *
+ * This configuration enforces the layering rules defined in:
+ *   docs/backend/architecture/ARCH_CONTRACT.md
+ *   docs/backend/architecture/BOUNDARIES.md
+ *
+ * It is the Node equivalent of governance/backend/importlinter-reference.toml
+ * and expresses the same contract: `api` and `adapters` are independent
+ * siblings above `services`, above `ports`, above `models`, above `common`,
+ * with `api -> services` forbidden outright.
+ *
+ * ---------------------------------------------------------------------------
+ * TWO WAYS THIS TOOL PASSES WITHOUT CHECKING ANYTHING. Both were reproduced
+ * against dependency-cruiser 17.4.3; both fail *open*, so neither announces
+ * itself.
+ *
+ * 1. `--output-type json` prints every violation and still exits 0. Use the
+ *    default (`err`) reporter in CI. A gate built on the JSON reporter is
+ *    green on a repo that breaches every boundary.
+ *
+ * 2. With **TypeScript 7** installed, dependency-cruiser 17 cruises
+ *    0 modules and exits 0 — it uses the TypeScript 5.x compiler API, which
+ *    TypeScript 7 replaced. The run looks identical to a clean one.
+ *
+ * After copying this in, confirm the output reports a NON-ZERO module count:
+ *
+ *     no dependency violations found (7 modules, 8 dependencies cruised)
+ *                                     ^^^^^^^^^
+ *
+ * "0 modules cruised" means the analysis found nothing, however green the
+ * result. ci/<flavour>/boundary-gate-node.yml asserts this for you.
+ * ---------------------------------------------------------------------------
+ *
+ * LAYOUT. The rules accept both source layouts the payload describes:
+ *
+ *   src/<layer>/...              flat — cli/stacks/nodejs-fastify/LAYER_IMPLEMENTATION.md
+ *   src/<package>/<layer>/...    nested — docs/backend/architecture/REPO_STRUCTURE_README.md
+ *
+ * COMPOSITION ROOT. Whatever wires adapters into services at startup
+ * necessarily imports both, so it must live outside the six layer folders —
+ * `src/app.ts` or `src/container.ts`, as LAYER_IMPLEMENTATION.md prescribes.
+ * A composition root placed inside `api/` or `adapters/` trips the sibling
+ * rule below.
+ */
+
+// Each layer matches at both depths: `src/api/` and `src/<package>/api/`.
+// Expressed as an array rather than one regex with an optional group —
+// dependency-cruiser rejects `^src/(?:[^/]+/)?api/` as ReDoS-unsafe.
+const layer = (...names) => {
+  const group = names.length > 1 ? `(${names.join('|')})` : names[0];
+  return [`^src/${group}/`, `^src/[^/]+/${group}/`];
+};
+
+module.exports = {
+  forbidden: [
+    {
+      // BOUNDARIES.md section 2: the API invokes behaviour through
+      // `ports/inbound/` only. Importing entities from `models/` is allowed —
+      // inbound port signatures carry them.
+      name: 'api-not-to-services',
+      comment: 'api/ must reach the domain through ports/inbound/, never directly',
+      severity: 'error',
+      from: { path: layer('api') },
+      to: { path: layer('services') },
+    },
+    {
+      // `api` and `adapters` are both adapters in the pattern — inbound and
+      // outbound. Neither may import the other; they meet at the composition
+      // root. This pair is the equivalent of import-linter's `api | adapters`.
+      name: 'api-not-to-adapters',
+      comment: 'api/ and adapters/ are independent siblings',
+      severity: 'error',
+      from: { path: layer('api') },
+      to: { path: layer('adapters') },
+    },
+    {
+      name: 'adapters-not-to-api',
+      comment: 'api/ and adapters/ are independent siblings',
+      severity: 'error',
+      from: { path: layer('adapters') },
+      to: { path: layer('api') },
+    },
+    {
+      // The single most important forbidden edge — ARCH_CONTRACT.md section 3,
+      // BOUNDARIES.md section 2. The domain depends on port interfaces; the
+      // adapters implement them.
+      name: 'services-not-to-adapters-or-api',
+      comment: 'the domain must not import infrastructure',
+      severity: 'error',
+      from: { path: layer('services') },
+      to: { path: layer('api', 'adapters') },
+    },
+    {
+      // ports/ sits *below* services/: it holds interfaces and may reference
+      // entities, while services imports the ports it depends on. Granting the
+      // reverse as well would create the cycle BOUNDARIES.md forbids.
+      name: 'ports-not-upward',
+      comment: 'ports/ is interface-only and depends on models/ and common/ alone',
+      severity: 'error',
+      from: { path: layer('ports') },
+      to: { path: layer('api', 'adapters', 'services') },
+    },
+    {
+      name: 'models-not-upward',
+      comment: 'domain entities stay ignorant of behaviour and interfaces',
+      severity: 'error',
+      from: { path: layer('models') },
+      to: { path: layer('api', 'adapters', 'services', 'ports') },
+    },
+    {
+      name: 'common-not-upward',
+      comment: 'common/ is cross-cutting and must stay dependency-free',
+      severity: 'error',
+      from: { path: layer('common') },
+      to: { path: layer('api', 'adapters', 'services', 'ports', 'models') },
+    },
+    {
+      // Multi-service repositories. The layer rules above apply *within* each
+      // service and say nothing about service-to-service edges —
+      // orders/services importing billing/services passes all of them.
+      //
+      // Unlike import-linter's `independence` contract, which has to be
+      // uncommented deliberately, this one ships enabled: the pattern requires
+      // a `src/<service>/<layer>/` segment, so it matches nothing in a flat
+      // single-service repo and starts enforcing the moment one grows a
+      // service package.
+      name: 'services-are-independent',
+      comment: 'one service must not import another; talk over a port',
+      severity: 'error',
+      from: { path: '^src/([^/]+)/(api|ports|services|models|adapters|common)/' },
+      to: {
+        path: '^src/([^/]+)/(api|ports|services|models|adapters|common)/',
+        pathNot: '^src/$1/',
+      },
+    },
+  ],
+  options: {
+    // Follow `import type` as well as value imports. A type-only import still
+    // couples the layers, and ARCH_CONTRACT.md's boundaries are about coupling.
+    tsPreCompilationDeps: true,
+    doNotFollow: { path: 'node_modules' },
+  },
+};

--- a/tests/test_boundary_gate_dispatch.py
+++ b/tests/test_boundary_gate_dispatch.py
@@ -31,12 +31,27 @@ BACKEND_TYPES = ("api", "cli")
 LEVELS = ("3", "4", "5")
 
 PYTHON_STACK = "python-fastapi"
+
+# Stacks whose boundary tool govkit ships enforcement for, and the gate file
+# each receives. Grows by one per increment of the per-stack plan.
+STACK_GATES = {
+    "python-fastapi": "boundary-gate-python.yml",
+    "nodejs-fastify": "boundary-gate-node.yml",
+}
 STACKS_WITHOUT_A_GATE = (
     "dotnet-aspnet",
     "java-spring-boot",
-    "nodejs-fastify",
     "go-gin",
 )
+
+# The reference contract each gate tells the team to copy in. It has to ship
+# with the gate: a gate whose notice names a file the install never received
+# is a dead end.
+STACK_REFERENCES = {
+    "python-fastapi": "governance/backend/importlinter-reference.toml",
+    "nodejs-fastify": "governance/backend/dependency-cruiser-reference.cjs",
+}
+_ALL_REFERENCES = set(STACK_REFERENCES.values())
 
 _AZ_STAGE = re.compile(r"^\s*- stage:\s*([A-Za-z0-9_]+)\s*$", re.MULTILINE)
 
@@ -72,20 +87,21 @@ def _azure_stages(rel_path: str) -> set[str]:
 
 
 class TestPythonBoundaryGateDispatch:
-    """A python-fastapi backend install receives the Python boundary gate."""
+    """A backend install receives exactly its own stack's boundary gate."""
 
     @pytest.mark.parametrize("agent", AGENTS)
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
     @pytest.mark.parametrize("project_type", BACKEND_TYPES)
     @pytest.mark.parametrize("level", LEVELS)
-    def test_python_fastapi_receives_the_python_boundary_gate(
-        self, agent, ci, project_type, level,
+    @pytest.mark.parametrize("stack, gate", sorted(STACK_GATES.items()))
+    def test_stack_receives_its_own_boundary_gate(
+        self, agent, ci, project_type, level, stack, gate,
     ):
-        governed = _governed(agent, ci, project_type, level, PYTHON_STACK)
+        governed = _governed(agent, ci, project_type, level, stack)
 
-        assert f"ci/{ci}/boundary-gate-python.yml" in governed, (
-            f"{agent} {project_type} L{level} ({ci}, {PYTHON_STACK}) must receive "
-            f"the Python boundary gate; got {_boundary_gates(governed, ci)}"
+        assert _boundary_gates(governed, ci) == [f"ci/{ci}/{gate}"], (
+            f"{agent} {project_type} L{level} ({ci}, {stack}) must receive "
+            f"exactly {gate}; got {_boundary_gates(governed, ci)}"
         )
 
     @pytest.mark.parametrize("agent", AGENTS)
@@ -137,18 +153,69 @@ class TestPythonBoundaryGateDispatch:
         )
 
 
+class TestBoundaryReferenceDispatch:
+    """The reference contract follows the same stack selection as the gate.
+
+    Caught by a real `govkit apply`, not by the dispatch assertions above: a
+    `nodejs-fastify` install received `boundary-gate-node.yml`, whose notice
+    says to copy `governance/backend/dependency-cruiser-reference.cjs`, while
+    the install actually shipped `importlinter-reference.toml` — a Python
+    contract the Node gate cannot use, and no `.cjs` anywhere.
+    """
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    @pytest.mark.parametrize("project_type", BACKEND_TYPES)
+    @pytest.mark.parametrize("level", LEVELS)
+    @pytest.mark.parametrize("stack, reference", sorted(STACK_REFERENCES.items()))
+    def test_stack_receives_only_its_own_reference(
+        self, agent, ci, project_type, level, stack, reference,
+    ):
+        governed = set(_governed(agent, ci, project_type, level, stack))
+
+        assert governed & _ALL_REFERENCES == {reference}, (
+            f"{agent} {project_type} L{level} ({ci}, {stack}) must receive "
+            f"{reference} and no other boundary reference; got "
+            f"{sorted(governed & _ALL_REFERENCES)}"
+        )
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    @pytest.mark.parametrize("project_type", BACKEND_TYPES)
+    @pytest.mark.parametrize("level", LEVELS)
+    @pytest.mark.parametrize("stack", STACKS_WITHOUT_A_GATE)
+    def test_stack_without_a_gate_receives_no_reference(
+        self, agent, ci, project_type, level, stack,
+    ):
+        """A Go team receiving a Python import-linter contract is the same
+        defect as receiving a Python linter job."""
+        governed = set(_governed(agent, ci, project_type, level, stack))
+
+        assert governed & _ALL_REFERENCES == set(), (
+            f"{agent} {project_type} L{level} ({ci}, {stack}) must receive no "
+            f"boundary reference; got {sorted(governed & _ALL_REFERENCES)}"
+        )
+
+    @pytest.mark.parametrize("reference", sorted(_ALL_REFERENCES))
+    def test_reference_file_exists(self, reference):
+        assert (paths.REPO_ROOT / reference).is_file()
+
+
 class TestBoundaryGateExtraction:
     """The job moved out of the shared L3 gate — it is not defined in both."""
 
+    @pytest.mark.parametrize("gate", sorted(STACK_GATES.values()))
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
-    def test_the_python_boundary_gate_file_exists(self, ci):
-        assert (paths.REPO_ROOT / f"ci/{ci}/boundary-gate-python.yml").is_file()
+    def test_the_boundary_gate_file_exists(self, ci, gate):
+        assert (paths.REPO_ROOT / f"ci/{ci}/{gate}").is_file()
 
-    def test_github_boundary_gate_defines_only_the_boundary_job(self):
-        assert _github_jobs("ci/github/boundary-gate-python.yml") == {"boundary-check"}
+    @pytest.mark.parametrize("gate", sorted(STACK_GATES.values()))
+    def test_github_boundary_gate_defines_only_the_boundary_job(self, gate):
+        assert _github_jobs(f"ci/github/{gate}") == {"boundary-check"}
 
-    def test_azure_boundary_gate_defines_only_the_boundary_stage(self):
-        assert _azure_stages("ci/azure/boundary-gate-python.yml") == {"BoundaryCheck"}
+    @pytest.mark.parametrize("gate", sorted(STACK_GATES.values()))
+    def test_azure_boundary_gate_defines_only_the_boundary_stage(self, gate):
+        assert _azure_stages(f"ci/azure/{gate}") == {"BoundaryCheck"}
 
     def test_github_l3_gate_no_longer_defines_the_boundary_job(self):
         jobs = _github_jobs("ci/github/l3-quality-gate.yml")
@@ -208,8 +275,60 @@ class TestBoundaryGateContent:
         for fragment in required:
             assert fragment in text, f"{rel_path} lost {fragment!r} in the move"
 
+    @pytest.mark.parametrize("stack, gate", sorted(STACK_GATES.items()))
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
-    def test_gate_names_the_python_stack_it_is_selected_for(self, ci):
+    def test_gate_names_the_stack_it_is_selected_for(self, ci, stack, gate):
         """The file is stack-selected, so a reader opening it must be able to
         tell which stack it belongs to without consulting the manifest."""
-        assert "python-fastapi" in _gate_text(f"ci/{ci}/boundary-gate-python.yml")
+        assert stack in _gate_text(f"ci/{ci}/{gate}")
+
+
+class TestNodeBoundaryGateContent:
+    """dependency-cruiser has two silent-pass modes. The gate must close both.
+
+    Verified against dependency-cruiser 17.4.3 while building the reference:
+
+    - `--output-type json` reports every violation and still **exits 0**. A
+      gate built on it goes green on a repo that breaches every boundary.
+    - With TypeScript 7 installed, it cruises **0 modules** and exits 0 —
+      a green gate analysing nothing. TypeScript 5.x cruises normally.
+
+    Both fail open, so the gate has to assert a non-zero module count rather
+    than trusting the exit code alone.
+    """
+
+    @staticmethod
+    def _executable(rel_path: str) -> str:
+        """The gate with comment lines dropped.
+
+        Both failure modes are *described* in these files' header comments, so
+        a plain substring search over the whole text cannot tell an
+        explanation from an invocation."""
+        return "\n".join(
+            line for line in _gate_text(rel_path).splitlines()
+            if not line.lstrip().startswith("#")
+        )
+
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    def test_gate_does_not_use_the_json_reporter(self, ci):
+        body = self._executable(f"ci/{ci}/boundary-gate-node.yml")
+
+        assert "--output-type" not in body, (
+            "the json reporter always exits 0 — every violation would be "
+            "printed and the gate would still pass"
+        )
+        assert "depcruise" in body or "dependency-cruiser" in body
+
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    def test_gate_fails_on_a_zero_module_count(self, ci):
+        body = self._executable(f"ci/{ci}/boundary-gate-node.yml")
+
+        assert "modules" in body, (
+            "the gate must parse the 'N modules, M dependencies cruised' "
+            "summary — a run that analyses nothing exits 0"
+        )
+        assert '"$modules" -eq 0' in body, (
+            "the gate must fail when the module count is zero, not merely "
+            "report it"
+        )
+        assert "exit 1" in body

--- a/tests/test_dependency_cruiser_reference.py
+++ b/tests/test_dependency_cruiser_reference.py
@@ -1,0 +1,249 @@
+"""The shipped dependency-cruiser reference must actually enforce BOUNDARIES.md.
+
+The Node counterpart of tests/test_importlinter_reference.py, and held to the
+same standard: run the real linter against generated skeletons rather than
+asserting on the config's text. A config that parses is not a config that
+enforces.
+
+dependency-cruiser fails **open** in two ways, both found while building this
+reference against dependency-cruiser 17.4.3:
+
+1. `--output-type json` prints every violation and still exits 0. A gate
+   built on it is green on a repo that breaches every boundary.
+2. With TypeScript 7 installed it cruises 0 modules and exits 0 — the
+   TS 5.x parser API it uses is gone. Nothing in the output says the analysis
+   was empty unless you read the module count.
+
+So every assertion here checks the module count too. A green run that cruised
+nothing proves nothing, which is the same trap `root_package = "src"` set for
+the import-linter reference.
+
+Marked `e2e` — these shell out to `depcruise` and are excluded from the fast
+loop. They skip when Node is unavailable; CI asserts the toolchain is present
+so a skip cannot pass for a pass there.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REFERENCE = REPO_ROOT / "governance" / "backend" / "dependency-cruiser-reference.cjs"
+
+LAYERS = ("api", "ports", "services", "models", "adapters", "common")
+
+_NPM = shutil.which("npm") or shutil.which("npm.cmd")
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(_NPM is None, reason="Node/npm not installed"),
+]
+
+_CRUISED = re.compile(r"(\d+) modules?, (\d+) dependenc\w* cruised")
+
+# dependency-cruiser's TypeScript analysis needs the 5.x compiler API.
+_TYPESCRIPT = "typescript@^5.9"
+_DEPCRUISE = "dependency-cruiser@^17"
+
+
+def _layer_files(prefix: str) -> dict[str, str]:
+    """A conforming hexagonal service, rooted at `src/<prefix>`.
+
+    Imports exercise every *allowed* edge, so a rule that over-forbids shows
+    up as a failing conforming case rather than passing unnoticed.
+    """
+    return {
+        f"{prefix}common/index.ts": "export const noop = (): void => {};\n",
+        f"{prefix}models/index.ts": "export class Entity { id = '1'; }\n",
+        f"{prefix}ports/index.ts": (
+            "import type { Entity } from '../models';\n"
+            "export interface Port { get(): Entity; }\n"
+        ),
+        f"{prefix}services/core.ts": (
+            "import type { Port } from '../ports';\n"
+            "import type { Entity } from '../models';\n"
+            "export const run = (p: Port): Entity => p.get();\n"
+        ),
+        f"{prefix}adapters/db.ts": (
+            "import type { Port } from '../ports';\n"
+            "import { run } from '../services/core';\n"
+            "export const use = (p: Port) => run(p);\n"
+        ),
+        f"{prefix}api/routes.ts": (
+            "import type { Port } from '../ports';\n"
+            "export const handler = (p: Port) => p.get();\n"
+        ),
+    }
+
+
+def _build(root: Path, layout: str, extra: tuple[str, str] | None = None) -> None:
+    """Write a skeleton in one of the three layouts the reference supports.
+
+    `flat` is what cli/stacks/nodejs-fastify/LAYER_IMPLEMENTATION.md documents
+    (`src/services/`); `nested` is what REPO_STRUCTURE_README.md prescribes
+    (`src/<package>/services/`). The reference has to handle both, because the
+    payload currently describes both.
+    """
+    src = root / "src"
+    if src.exists():
+        shutil.rmtree(src)
+    if layout == "flat":
+        tree = _layer_files("")
+        tree["app.ts"] = "import { use } from './adapters/db';\nexport const boot = () => use;\n"
+    elif layout == "nested":
+        tree = _layer_files("svc/")
+        tree["app.ts"] = (
+            "import { use } from './svc/adapters/db';\nexport const boot = () => use;\n"
+        )
+    else:
+        tree = {**_layer_files("orders/"), **_layer_files("billing/")}
+        tree["app.ts"] = (
+            "import { use } from './orders/adapters/db';\n"
+            "import { use as u2 } from './billing/adapters/db';\n"
+            "export const boot = () => [use, u2];\n"
+        )
+    for rel, body in tree.items():
+        path = src / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    if extra:
+        rel, statement = extra
+        path = src / rel
+        path.write_text(statement + path.read_text(encoding="utf-8"), encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def node_project(tmp_path_factory) -> Path:
+    """One npm install shared by every case — it is the slow part."""
+    root = tmp_path_factory.mktemp("depcruise")
+    (root / "package.json").write_text(
+        json.dumps({"name": "boundary-fixture", "version": "1.0.0", "private": True}),
+        encoding="utf-8",
+    )
+    (root / "tsconfig.json").write_text(
+        json.dumps({
+            "compilerOptions": {
+                "target": "ES2022", "module": "ESNext",
+                "moduleResolution": "bundler", "strict": True,
+            },
+            "include": ["src/**/*.ts"],
+        }),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [_NPM, "install", "--no-audit", "--no-fund", "--silent",
+         _DEPCRUISE, _TYPESCRIPT],
+        cwd=root, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", shell=os.name == "nt",
+    )
+    if result.returncode != 0:
+        # Locally, an offline machine should skip rather than fail. In CI the
+        # toolchain is guaranteed by the workflow, so a failed install means
+        # these tests silently stopped covering the reference — the exact
+        # vacuous-pass this module exists to prevent.
+        message = f"npm install failed: {result.stderr[:300]}"
+        if os.environ.get("CI"):
+            pytest.fail(message)
+        pytest.skip(f"{message} (offline?)")
+    shutil.copyfile(REFERENCE, root / ".dependency-cruiser.cjs")
+    return root
+
+
+def _cruise(root: Path) -> tuple[int, str, int]:
+    """Run the real `depcruise` with the default reporter.
+
+    Deliberately not `--output-type json`: that reporter always exits 0, so
+    every assertion below would pass on a repo that violates everything.
+    """
+    result = subprocess.run(
+        ["npx", "--no-install", "depcruise", "src",
+         "--config", ".dependency-cruiser.cjs"],
+        cwd=root, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", shell=os.name == "nt",
+    )
+    out = (result.stdout or "") + (result.stderr or "")
+    assert out.strip(), "depcruise produced no output — it did not run"
+    match = _CRUISED.search(out)
+    assert match, f"no 'N modules, M dependencies cruised' summary:\n{out}"
+    return result.returncode, out, int(match.group(1))
+
+
+def _assert_analysed_something(modules: int, out: str) -> None:
+    """A run that cruises zero modules reports no violations and exits 0.
+
+    That is how a TypeScript 7 project behaves with dependency-cruiser 17:
+    the gate is green and enforces nothing. Any clean verdict has to prove
+    the tool saw the source first.
+    """
+    assert modules > 0, (
+        f"cruised {modules} modules — the config resolved nothing, so a clean "
+        f"verdict is meaningless:\n{out}"
+    )
+
+
+class TestSingleService:
+    @pytest.mark.parametrize("layout", ["flat", "nested"])
+    def test_conforming_repo_passes(self, node_project, layout):
+        _build(node_project, layout)
+        code, out, modules = _cruise(node_project)
+        _assert_analysed_something(modules, out)
+        assert code == 0, f"conforming {layout} repo rejected:\n{out}"
+
+    @pytest.mark.parametrize(
+        ("label", "where", "statement"),
+        [
+            ("api -> services", "api/routes.ts", "import '../services/core';\n"),
+            ("api -> adapters", "api/routes.ts", "import '../adapters/db';\n"),
+            ("adapters -> api", "adapters/db.ts", "import '../api/routes';\n"),
+            ("services -> adapters", "services/core.ts", "import '../adapters/db';\n"),
+            ("services -> api", "services/core.ts", "import '../api/routes';\n"),
+            ("ports -> services", "ports/index.ts", "import '../services/core';\n"),
+            ("ports -> adapters", "ports/index.ts", "import '../adapters/db';\n"),
+            ("models -> services", "models/index.ts", "import '../services/core';\n"),
+            ("models -> ports", "models/index.ts", "import '../ports';\n"),
+            ("common -> models", "common/index.ts", "import '../models';\n"),
+            ("common -> services", "common/index.ts", "import '../services/core';\n"),
+        ],
+    )
+    def test_forbidden_edge_is_rejected(self, node_project, label, where, statement):
+        _build(node_project, "flat", extra=(where, statement))
+        code, out, modules = _cruise(node_project)
+        _assert_analysed_something(modules, out)
+        assert code != 0, f"{label} was permitted:\n{out}"
+
+
+class TestMultiService:
+    def test_two_conforming_services_pass(self, node_project):
+        _build(node_project, "multi")
+        code, out, modules = _cruise(node_project)
+        _assert_analysed_something(modules, out)
+        assert code == 0, f"conforming multi-service repo rejected:\n{out}"
+
+    def test_cross_service_import_is_rejected(self, node_project):
+        """Unlike the import-linter reference, whose `independence` contract
+        ships commented out, this rule can ship enabled: its pattern requires
+        a `src/<service>/<layer>/` segment, so it is inert on the flat layout
+        and active as soon as a repo grows a service package."""
+        _build(
+            node_project, "multi",
+            extra=("orders/services/core.ts", "import '../../billing/services/core';\n"),
+        )
+        code, out, modules = _cruise(node_project)
+        _assert_analysed_something(modules, out)
+        assert code != 0, f"cross-service import was permitted:\n{out}"
+        assert "services-are-independent" in out, (
+            f"a rule other than independence caught it:\n{out}"
+        )
+
+
+def test_reference_covers_every_canonical_layer():
+    """Structural guard that runs in the fast loop, so a reference which
+    silently drops a layer fails even without Node installed."""
+    text = REFERENCE.read_text(encoding="utf-8")
+    for name in LAYERS:
+        assert name in text, f"reference never mentions the {name!r} layer"


### PR DESCRIPTION
Increment 3 of `plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md`. #93 stays open — Go, JVM and .NET follow.

`dependency-cruiser` was already named as this stack's boundary tool by [TECH_STACK.md:176](cli/stacks/nodejs-fastify/TECH_STACK.md#L176), `LAYER_IMPLEMENTATION.md` and `TESTING.md`. Nothing shipped it. Node installs now get a gate, a reference config, and tests that run the real linter.

> **Merge #103 first.** This branch is off `main` and deliberately does **not** touch the plan file, which #103 rewrites. I'll add increment 3's status entry once #103 lands rather than manufacture a conflict.

## Built against the tool, not its docs

Three decisions changed once I ran `dependency-cruiser` 17.4.3 for real:

- **Layer paths ship as arrays of two regexes**, not one with an optional group. `^src/(?:[^/]+/)?api/` is rejected as ReDoS-unsafe and the tool *bails out entirely*. The pair also lets one config serve both layouts the payload describes — flat `src/<layer>/` (the Node stack's `LAYER_IMPLEMENTATION.md`) and `src/<package>/<layer>/` (`REPO_STRUCTURE_README.md`). Both are covered by fixtures.
- **The independence rule ships enabled**, where import-linter's equivalent ships commented out. Its pattern requires a `src/<service>/<layer>/` segment, so it matches nothing in a flat single-service repo and starts enforcing the moment one grows a service package. Verified both ways.
- **`.cjs`, not `.js`** — the filename `TECH_STACK.md:186` already promises.

## Two silent-pass modes, both reproduced

| Mode | Behaviour |
|---|---|
| `--output-type json` | prints every violation, **exits 0** |
| TypeScript 7 installed | cruises **0 modules**, exits 0 |

The second is the nasty one: dependency-cruiser 17 uses the TypeScript 5.x compiler API, so a project upgrading to TypeScript 7 gets a green boundary gate that analyses nothing and says nothing. I hit it by accident — `npm install typescript` pulled 7.0.2 and my first conforming run "passed" with 0 modules.

So the gate uses the default reporter and **fails the build on a zero module count**, naming TypeScript 7 in the error text. Every fixture assertion checks the module count too.

## The bug end-to-end verification caught

The manifest assertions were green while a real `govkit apply` produced this:

```
node-l3   nodejs-fastify   gate=[boundary-gate-node.yml]  reference=[importlinter-reference.toml]
```

The Node gate's notice says to copy `dependency-cruiser-reference.cjs`. The install shipped a Python contract instead, and no `.cjs` anywhere — a gate pointing at a file that isn't there.

The reference now lives in the same `by_stack` block as its gate. That also stops shipping `importlinter-reference.toml` to `go-gin`, `java-spring-boot` and `dotnet-aspnet` — the same defect as the Python linter job those stacks used to receive. After the fix:

```
node-l3   nodejs-fastify     gate=[boundary-gate-node.yml]   reference=[dependency-cruiser-reference.cjs]
node-l5   nodejs-fastify     gate=[boundary-gate-node.yml]   reference=[dependency-cruiser-reference.cjs]
node-az   nodejs-fastify     gate=[boundary-gate-node.yml]   reference=[dependency-cruiser-reference.cjs]
py-l4     python-fastapi     gate=[boundary-gate-python.yml] reference=[importlinter-reference.toml]
go-l4     go-gin             gate=[]                         reference=[]
java-l5   java-spring-boot   gate=[]                         reference=[]
```

The **installed** `.cjs` — not the repo copy — was then run through `dependency-cruiser` across all three layouts and every forbidden edge.

## Tests

`tests/test_dependency_cruiser_reference.py` mirrors `test_importlinter_reference.py`: conforming flat and `src/<package>/` skeletons pass, 11 forbidden edges are each rejected, two services pass, and a cross-service import is rejected by the independence rule *specifically* rather than incidentally.

CI gains `actions/setup-node` **plus an explicit assertion that `node` and `npm` resolve** — the fixture skips when Node is missing, and a skip is indistinguishable from a pass in the CI summary. If `npm install` fails inside the fixture, it fails rather than skips when `$CI` is set.

`./full_test`: 1921 fast + 101 e2e passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
