### PR TITLE
feat(ci): boundary enforcement for go-gin (#93)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,18 +31,30 @@ jobs:
         with:
           node-version: '22'
 
+      # tests/test_go_arch_lint_reference.py does the same for the shipped
+      # go-arch-lint contract.
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version: 'stable'
+
+      - name: Install go-arch-lint
+        run: go install github.com/fe3dback/go-arch-lint@latest
+
       - name: Install
         run: pip install -e ".[test]"
 
-      - name: Assert the Node toolchain is present
-        # The reference tests skipif npm is missing, which is right locally but
-        # wrong here: a broken setup-node step would leave the only tests that
-        # prove the shipped dependency-cruiser config works silently skipped,
-        # and CI would still be green.
+      - name: Assert the Node and Go toolchains are present
+        # The reference tests skipif their toolchain is missing, which is right
+        # locally but wrong here: a broken setup step would leave the only
+        # tests that prove the shipped configs work silently skipped, and CI
+        # would still be green.
         run: |
           set -euxo pipefail
           command -v node
           command -v npm
+          command -v go
+          test -x "$(go env GOPATH)/bin/go-arch-lint"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Run pytest
         run: pytest

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -398,14 +398,16 @@
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "cli":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -457,7 +459,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "cli": {
@@ -472,7 +475,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "ui-react": { "governed": [
@@ -513,14 +517,16 @@
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "cli":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -572,7 +578,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "cli": {
@@ -587,7 +594,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -420,14 +420,16 @@
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "cli":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -479,7 +481,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "cli": {
@@ -494,7 +497,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "ui-react": { "governed": [
@@ -535,14 +539,16 @@
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "cli":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -594,7 +600,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "cli": {
@@ -609,7 +616,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -402,14 +402,16 @@
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "cli":        {
             "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -461,7 +463,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "cli": {
@@ -476,7 +479,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "ui-react": { "governed": [
@@ -517,14 +521,16 @@
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "cli":        {
             "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-quality-gate.yml"],
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+              "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -576,7 +582,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "cli": {
@@ -591,7 +598,8 @@
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
-                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] }
+                "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
               }
             },
             "ui-react": { "governed": [

--- a/ci/README.md
+++ b/ci/README.md
@@ -34,6 +34,7 @@ Copy the relevant templates for your project type:
 | `l3-quality-gate.yml` (L3 only) | ✓ | ✓ | — | — |
 | `boundary-gate-python.yml` | `python-fastapi` | `python-fastapi` | — | — |
 | `boundary-gate-node.yml` | `nodejs-fastify` | `nodejs-fastify` | — | — |
+| `boundary-gate-go.yml` | `go-gin` | `go-gin` | — | — |
 | `ui-quality-gate.yml` | — | — | ✓ | — |
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
@@ -66,7 +67,8 @@ part of the shared quality gate. govkit installs a boundary gate chosen by
 |---|---|---|---|
 | `python-fastapi` | `boundary-gate-python.yml` | `import-linter` | `governance/backend/importlinter-reference.toml` |
 | `nodejs-fastify` | `boundary-gate-node.yml` | `dependency-cruiser` | `governance/backend/dependency-cruiser-reference.cjs` |
-| `go-gin`, `java-spring-boot`, `dotnet-aspnet` | *none yet* | tracked separately | — |
+| `go-gin` | `boundary-gate-go.yml` | `go-arch-lint` | `governance/backend/go-arch-lint-reference.yml` |
+| `java-spring-boot`, `dotnet-aspnet` | *none yet* | tracked separately | — |
 
 A stack with no gate receives **no boundary workflow at all**, rather than one
 that silently skips. Shipping a Python linter to a Go repo enforces nothing
@@ -86,18 +88,26 @@ Each logs a notice telling you how to enable it.
 - **Node** — copy `governance/backend/dependency-cruiser-reference.cjs` to
   `.dependency-cruiser.cjs`. No placeholders: the rules key on layer folder
   names, and they accept both `src/<layer>/` and `src/<package>/<layer>/`.
+- **Go** — copy `governance/backend/go-arch-lint-reference.yml` to
+  `.go-arch-lint.yml`. Components key on layer folders under `internal/`.
+  Keep your composition root at `cmd/<binary>/main.go`; if you use
+  `internal/app/` instead, declare an `app` component (the reference explains
+  how, and why it cannot ship one pre-declared).
 
-**Confirm your gate analysed something.** Both linters report success on an
-empty analysis, so a misconfigured contract looks exactly like a clean repo:
+**Confirm your gate analysed something.** All three linters report success on
+an empty analysis, so a misconfigured contract looks exactly like a clean repo:
 
 - `import-linter` prints `Analyzed N files, 0 dependencies` and reports every
   contract KEPT when the package name is wrong.
 - `dependency-cruiser` cruises `0 modules` and exits 0 when it cannot parse
   your sources — which is what happens on **TypeScript 7**, since
   dependency-cruiser 17 uses the TypeScript 5.x compiler API.
+- `go-arch-lint` prints `OK - No warnings found` and exits 0 on Go it cannot
+  parse, so a syntax error anywhere turns the boundary check green.
 
-`boundary-gate-node.yml` fails the build on a zero module count rather than
-trusting the exit code. If you adapt these gates, keep that check.
+Each gate closes its own hole: the Node gate fails on a zero module count, and
+the Go gate runs `go build ./...` before checking and fails when no file
+attached to a component. If you adapt these gates, keep those checks.
 
 ---
 
@@ -105,15 +115,17 @@ trusting the exit code. If you adapt these gates, keep that check.
 
 Levels are additive, and so are these files: an L4 install receives the L3
 gate **and** the L4 gate. `quality-gate.yml` therefore contributes only what
-`l3-quality-gate.yml` does not — boundary enforcement, SonarQube, Snyk and
-commit format come from the L3 gate at every level. Defining them in both
-files made L4+ repos run each twice on every push.
+`l3-quality-gate.yml` does not — SonarQube, Snyk and commit format come from
+the L3 gate at every level. Defining them in both files made L4+ repos run
+each twice on every push. Boundary enforcement comes from neither: it lives
+in its own stack-selected `boundary-gate-*.yml`, which also ships from L3.
 
 | Pipeline | Level 3 | Level 4 |
 |----------|---------|---------|
 | `l3-quality-gate.yml` | Governance artifacts (3), commit format, SonarQube, Snyk | — |
 | `boundary-gate-python.yml` | Architecture boundary enforcement (`python-fastapi`) | — |
 | `boundary-gate-node.yml` | Architecture boundary enforcement (`nodejs-fastify`) | — |
+| `boundary-gate-go.yml` | Architecture boundary enforcement (`go-gin`) | — |
 | `quality-gate.yml` | — | Schema validation, contract compatibility, governance artifacts (5) |
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |

--- a/ci/azure/boundary-gate-go.yml
+++ b/ci/azure/boundary-gate-go.yml
@@ -1,0 +1,68 @@
+# Azure DevOps pipeline — architecture boundary enforcement for the `go-gin`
+# stack. Runs `go-arch-lint` against the hexagonal layer contract described in
+# docs/backend/architecture/BOUNDARIES.md.
+#
+# STAGES:
+#   BoundaryCheck    — enforces hexagonal architecture boundaries via go-arch-lint
+#
+# STACK-SELECTED: govkit installs this file only for `--stack go-gin`.
+# Each backend stack gets a boundary gate in a tool that can read its source;
+# see ci/README.md for the mapping.
+#
+# OPT-IN: govkit ships governance/backend/go-arch-lint-reference.yml as a
+# template. The contract is live only once you copy it to `.go-arch-lint.yml`;
+# until then this stage skips so a fresh install is green.
+#
+# WHY IT BUILDS FIRST: go-arch-lint reports "OK - No warnings found" and exits
+# 0 on source it cannot parse, so a syntax error anywhere would turn the
+# boundary check green. Verified against go-arch-lint v1.16.0. `go build ./...`
+# runs first so unparseable code fails here rather than passing silently.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: BoundaryCheck
+    displayName: Architecture boundary enforcement
+    dependsOn: []
+    jobs:
+      - job: BoundaryCheck
+        displayName: Run go-arch-lint
+        steps:
+          - checkout: self
+
+          - task: GoTool@0
+            displayName: Use Go
+            inputs:
+              version: '1.24'
+
+          - script: |
+              if [ ! -f .go-arch-lint.yml ] && [ ! -f .go-arch-lint.yaml ]; then
+                echo "##vso[task.logissue type=warning]No go-arch-lint contract found. Copy governance/backend/go-arch-lint-reference.yml to .go-arch-lint.yml to enable boundary enforcement."
+                exit 0
+              fi
+
+              set -euo pipefail
+              export PATH="$PATH:$(go env GOPATH)/bin"
+
+              # go-arch-lint passes on source it cannot parse, so a green
+              # boundary check is only meaningful if the project compiles.
+              go build ./...
+              go install github.com/fe3dback/go-arch-lint@latest
+
+              # Confirm the contract actually matched files before trusting a pass.
+              mapped=$(go-arch-lint mapping --json | grep -oE '"[Ff]ileNames":\[[^]]*' | grep -oc '\.go' || true)
+              if [ "${mapped:-0}" -eq 0 ]; then
+                echo "##vso[task.logissue type=error]go-arch-lint attached no files to any component. The contract did not match your tree, so the check would pass regardless of the code. Confirm your layers live under internal/ and that workdir in .go-arch-lint.yml matches."
+                exit 1
+              fi
+
+              go-arch-lint check
+            displayName: Enforce hexagonal architecture boundaries

--- a/ci/github/boundary-gate-go.yml
+++ b/ci/github/boundary-gate-go.yml
@@ -1,0 +1,76 @@
+# boundary-gate-go.yml
+#
+# PURPOSE: Architecture boundary enforcement for the `go-gin` stack. Runs
+# `go-arch-lint` against the hexagonal layer contract described in
+# docs/backend/architecture/BOUNDARIES.md.
+# Copy this file to .github/workflows/boundary-gate.yml.
+#
+# JOBS:
+#   boundary-check    — enforces hexagonal architecture boundaries via go-arch-lint
+#
+# STACK-SELECTED: govkit installs this file only for `--stack go-gin`.
+# Each backend stack gets a boundary gate in a tool that can read its source;
+# see ci/README.md for the mapping.
+#
+# OPT-IN: govkit ships governance/backend/go-arch-lint-reference.yml as a
+# template. The contract is live only once you copy it to `.go-arch-lint.yml`;
+# until then this job skips so a fresh install is green.
+#
+# WHY IT BUILDS FIRST: go-arch-lint reports "OK - No warnings found" and exits
+# 0 on source it cannot parse, so a syntax error anywhere would turn the
+# boundary check green. Verified against go-arch-lint v1.16.0. `go build ./...`
+# runs first so unparseable code fails here rather than passing silently.
+#
+# REQUIRED SECRETS: none.
+
+name: Boundary Gate (Go)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  boundary-check:
+    name: Architecture boundary enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect go-arch-lint contract
+        id: contract
+        run: |
+          if [ -f .go-arch-lint.yml ] || [ -f .go-arch-lint.yaml ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No go-arch-lint contract found. Copy governance/backend/go-arch-lint-reference.yml to .go-arch-lint.yml to enable boundary enforcement."
+          fi
+
+      - uses: actions/setup-go@v5
+        if: steps.contract.outputs.found == 'true'
+        with:
+          go-version: 'stable'
+
+      - name: Build
+        # go-arch-lint passes on source it cannot parse, so a green boundary
+        # check is only meaningful if the project compiles.
+        if: steps.contract.outputs.found == 'true'
+        run: go build ./...
+
+      - name: Install go-arch-lint
+        if: steps.contract.outputs.found == 'true'
+        run: go install github.com/fe3dback/go-arch-lint@latest
+
+      - name: Run boundary checks
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          # Confirm the contract actually matched files before trusting a pass.
+          mapped=$(go-arch-lint mapping --json | grep -oE '"[Ff]ileNames":\[[^]]*' | grep -oc '\.go' || true)
+          if [ "${mapped:-0}" -eq 0 ]; then
+            echo "::error::go-arch-lint attached no files to any component. The contract did not match your tree, so the check would pass regardless of the code. Confirm your layers live under internal/ and that workdir in .go-arch-lint.yml matches."
+            exit 1
+          fi
+          go-arch-lint check

--- a/governance/backend/go-arch-lint-reference.yml
+++ b/governance/backend/go-arch-lint-reference.yml
@@ -1,0 +1,105 @@
+# go-arch-lint reference configuration for hexagonal architecture enforcement
+# on the `go-gin` stack.
+#
+# Copy this file to `.go-arch-lint.yml` in your repository root. No
+# placeholders to replace: components are keyed on layer folder names under
+# `internal/`, not on your module path.
+#
+# Install: go install github.com/fe3dback/go-arch-lint@latest
+# Run:     go-arch-lint check
+#
+# This configuration enforces the layering rules defined in:
+#   docs/backend/architecture/ARCH_CONTRACT.md
+#   docs/backend/architecture/BOUNDARIES.md
+#
+# It is the Go equivalent of governance/backend/importlinter-reference.toml
+# and expresses the same contract: `api` and `adapters` are independent
+# siblings above `services`, above `ports`, above `models`, above `common`,
+# with `api -> services` forbidden.
+#
+# -----------------------------------------------------------------------------
+# RUN `go build ./...` FIRST. go-arch-lint reports "OK - No warnings found" and
+# exits 0 on source it cannot parse — a syntax error anywhere makes the
+# boundary check pass. Verified against go-arch-lint v1.16.0.
+# ci/<flavour>/boundary-gate-go.yml builds before it checks for this reason.
+#
+# Two things that are *not* silent, and are worth relying on:
+#
+#   - A package under `internal/` that no component claims is reported as
+#     "not attached to any component" and fails the check. go-arch-lint does
+#     not quietly skip code inside its workdir.
+#   - `go-arch-lint mapping --json` lists which files each component matched.
+#     Use it to confirm the config resolved your tree.
+# -----------------------------------------------------------------------------
+#
+# COMPOSITION ROOT. Whatever wires adapters into services imports both, so it
+# cannot sit inside any layer. Put it at `cmd/<binary>/main.go`, outside
+# `internal/` and therefore outside the scanned workdir — the first location
+# LAYER_IMPLEMENTATION.md gives.
+#
+# If you instead use `internal/app/`, you must add it here yourself:
+#
+#     components:
+#       app: { in: app/** }
+#     deps:
+#       app:
+#         mayDependOn: [api, adapters, services, ports, models, common]
+#
+# This file cannot ship that entry pre-declared: go-arch-lint errors out on a
+# component whose folder does not exist, which would break every project that
+# keeps its composition root under cmd/.
+#
+# NOTE ON IMPORT CYCLES. Go's own compiler rejects import cycles, so several
+# layering violations — `services -> adapters` in a repo where adapters
+# already imports services, for instance — fail at `go build` before this
+# linter sees them. The rules below still matter: they catch the acyclic
+# violations the compiler accepts, such as `api -> services` and
+# `api -> adapters`.
+
+version: 3
+
+# Only the hexagonal layers are governed. cmd/ holds the composition root and
+# is deliberately outside this scope.
+workdir: internal
+
+allow:
+  # Third-party imports are governed by TECH_STACK.md, not by this contract.
+  depOnAnyVendor: true
+
+components:
+  api:      { in: api/** }
+  ports:    { in: ports/** }
+  services: { in: services/** }
+  models:   { in: models/** }
+  adapters: { in: adapters/** }
+  common:   { in: common/** }
+
+deps:
+  # Inbound adapters. May reach the domain only through ports/inbound; entity
+  # types are allowed because inbound port signatures carry them. `adapters`
+  # is absent deliberately — api and adapters are independent siblings that
+  # meet at the composition root.
+  api:
+    mayDependOn: [ports, models, common]
+
+  # Outbound adapters implement ports and are wired into services.
+  adapters:
+    mayDependOn: [ports, services, models, common]
+
+  # Domain behaviour. Depends on port interfaces, never on implementations.
+  services:
+    mayDependOn: [ports, models, common]
+
+  # Interfaces only. Sits below services so services can import the ports it
+  # depends on without a cycle.
+  ports:
+    mayDependOn: [models, common]
+
+  # Domain entities, ignorant of behaviour and interfaces.
+  models:
+    mayDependOn: [common]
+
+  # `common` has no entry on purpose. It must be dependency-free, and
+  # go-arch-lint rejects an explicit `mayDependOn: []` with "should have ref
+  # in 'mayDependOn'/'canUse' or at least one flag". Omitting the component
+  # from `deps` is how "depends on nothing" is expressed.

--- a/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
+++ b/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
@@ -1,11 +1,14 @@
 # Per-Stack Boundary Enforcement Plan
 
-**Status:** In progress — 2026-08-01. Increment 1 (stack-selected dispatch,
-proven with Python) landed via #102. Increment 6 (documentation) was pulled
-ahead of 2-5 and is landing now — its wording fix is correct regardless of
-which tools follow. Increments 2-5 are unblocked: open questions 1-3 are
-answered below, and 4 is scoped to a per-stack check rather than a blocker.
-Covers #93, which closes when increment 5 lands.
+**Status:** In progress — 2026-08-01. Increments 1-4 are done: stack-selected
+dispatch (#102), stack-agnostic doc wording (#103), Node (#105), and Go. Three
+of five stacks now have boundary enforcement in a tool that can read them.
+Remaining: increment 5 (JVM) and 6 (.NET), both template-and-structural-
+assertion shaped. Covers #93, which closes when increment 6 lands.
+
+Every linter adopted so far reports success on an empty analysis, each in its
+own way, and none of them says so. That pattern is now the first thing to test
+for when adding a stack — see Verification.
 
 Decisions taken 2026-08-01, after the open questions were revisited against
 the shipped payload:
@@ -235,25 +238,57 @@ to close, and the layer rules themselves are identical for every stack.
 
 Commit: `docs(backend): defer to TECH_STACK.md for the boundary tool (#93)`
 
-### 3. Node — dependency-cruiser
+### 3. Node — dependency-cruiser — done
 
-1. Failing fixture test, `e2e`-marked, modelled on
-   `tests/test_importlinter_reference.py`: a conforming `src/<pkg>/` skeleton
-   passes; each forbidden edge is rejected; **assert a non-zero module count**
-   so a config that analyses nothing cannot read as passing.
-2. `governance/backend/dependency-cruiser-reference.cjs`, the gate file, the
-   manifest wiring.
-3. `actions/setup-node` in the pytest job, **plus a CI-only assertion that
-   the binary resolves**. The existing `shutil.which` skipif is right for
-   local runs, but in CI a skip and a pass look identical — a broken setup
-   step must fail loudly rather than quietly skip the only test that proves
-   the config works.
+Landed via #105. `tests/test_dependency_cruiser_reference.py` runs the real
+linter: conforming flat and `src/<package>/` skeletons pass, eleven forbidden
+edges are each rejected, and cross-service independence is checked.
+
+Three things the tool decided for us, none of which were guessable:
+
+- Layer paths ship as **arrays of two regexes**. dependency-cruiser rejects
+  `^src/(?:[^/]+/)?api/` as ReDoS-unsafe and bails out entirely. The pair also
+  lets one config serve both layouts the payload describes.
+- The **independence rule ships enabled**, unlike import-linter's. Its pattern
+  requires a `src/<service>/<layer>/` segment, so it is inert on a flat
+  single-service repo.
+- The reference is **`.cjs`**, the filename `TECH_STACK.md:186` already names.
+
+`by_stack` had to carry the **reference contract as well as the gate**. A real
+`govkit apply` caught what the manifest tests could not: a Node install got
+`boundary-gate-node.yml`, whose notice names a `.cjs`, alongside
+`importlinter-reference.toml` and no `.cjs` at all. Fixing that also stopped
+shipping the Python contract to the stacks whose linters cannot read it.
 
 Commit: `feat(ci): boundary enforcement for nodejs-fastify (#93)`
 
-### 4. Go — go-arch-lint
+### 4. Go — go-arch-lint — done
 
-Same shape as increment 3, with `actions/setup-go`.
+Same shape, with `actions/setup-go`. `tests/test_go_arch_lint_reference.py`
+runs the real linter against generated skeletons.
+
+Two Go-specific facts changed the design:
+
+- **go-arch-lint exits 0 on source it cannot parse**, reporting
+  "OK - No warnings found". A syntax error anywhere turns the gate green, so
+  the gate runs `go build ./...` first and the fixtures assert they compile.
+- **Go itself forbids import cycles.** In a fully-wired conforming skeleton,
+  `adapters` imports `services`, so adding `services -> adapters` produces a
+  project that does not build — and per the above, go-arch-lint would then
+  pass it. Each forbidden edge is tested against a *minimal* skeleton holding
+  only that edge, so the linter is what rejects it rather than the compiler.
+
+Two config constraints worth recording, both discovered by running it:
+
+- `common: mayDependOn: []` is **rejected** ("should have ref in
+  'mayDependOn'/'canUse' or at least one flag"). Dependency-free is expressed
+  by omitting the component from `deps` entirely — which reads like an
+  oversight, so a test asserts the omission is deliberate.
+- A component whose folder does not exist is a **hard error**, so the
+  reference cannot pre-declare an `app` component for teams whose composition
+  root is `internal/app/`. It documents how to add one instead. Conversely, a
+  package under `internal/` that no component claims fails the check — the one
+  place these linters refuse to ignore code silently.
 
 Commit: `feat(ci): boundary enforcement for go-gin (#93)`
 
@@ -292,6 +327,24 @@ Commit: `feat(ci): boundary enforcement for dotnet-aspnet (#93)`
   by two gate files that ship together.
 - Regenerate smoke sandboxes for at least one backend stack per shape.
 - Confirm a stack with no gate installs cleanly rather than erroring.
+- **Find the silent-pass mode before shipping the gate.** Every boundary
+  linter adopted so far reports success on an empty analysis, and none
+  announces it. Each was found by running the tool, never by reading its
+  docs:
+
+  | Tool | Passes vacuously when | Gate closes it with |
+  | --- | --- | --- |
+  | import-linter | `root_package` names a directory, not a package — 0 dependencies, all contracts KEPT | adopters told to check the analysed count |
+  | dependency-cruiser | `--output-type json` (always exits 0); TypeScript 7 installed (0 modules) | default reporter + fail on zero modules |
+  | go-arch-lint | source does not parse — "OK - No warnings found" | `go build ./...` first + fail on zero mapped files |
+
+  Assume the next one has such a mode and go looking for it. A gate that
+  cannot fail is worse than no gate, because it reports that the boundary
+  holds.
+- **Verify the reference contract installs, not just the gate.** The Node
+  gate shipped without its `.cjs` and every manifest-level test was green;
+  only a real `govkit apply` showed the gate pointing at a file that was not
+  there.
 
 ## Open questions — resolved 2026-08-01
 

--- a/tests/test_boundary_gate_dispatch.py
+++ b/tests/test_boundary_gate_dispatch.py
@@ -37,11 +37,11 @@ PYTHON_STACK = "python-fastapi"
 STACK_GATES = {
     "python-fastapi": "boundary-gate-python.yml",
     "nodejs-fastify": "boundary-gate-node.yml",
+    "go-gin": "boundary-gate-go.yml",
 }
 STACKS_WITHOUT_A_GATE = (
     "dotnet-aspnet",
     "java-spring-boot",
-    "go-gin",
 )
 
 # The reference contract each gate tells the team to copy in. It has to ship
@@ -50,6 +50,7 @@ STACKS_WITHOUT_A_GATE = (
 STACK_REFERENCES = {
     "python-fastapi": "governance/backend/importlinter-reference.toml",
     "nodejs-fastify": "governance/backend/dependency-cruiser-reference.cjs",
+    "go-gin": "governance/backend/go-arch-lint-reference.yml",
 }
 _ALL_REFERENCES = set(STACK_REFERENCES.values())
 

--- a/tests/test_go_arch_lint_reference.py
+++ b/tests/test_go_arch_lint_reference.py
@@ -1,0 +1,245 @@
+"""The shipped go-arch-lint reference must actually enforce BOUNDARIES.md.
+
+The Go counterpart of tests/test_importlinter_reference.py and
+tests/test_dependency_cruiser_reference.py, held to the same standard: run the
+real linter against generated skeletons rather than asserting on the YAML.
+
+Two Go-specific facts shape these tests, both established by running
+go-arch-lint v1.16.0 rather than reading its documentation.
+
+**go-arch-lint exits 0 on source it cannot parse.** A fixture with a syntax
+error reports "OK - No warnings found". So every case here compiles the
+skeleton with `go build ./...` first; a violation case that does not compile
+proves nothing. The shipped gate runs `go build` for the same reason.
+
+**Go itself forbids import cycles.** In a fully-wired conforming skeleton,
+`adapters` imports `services`, so adding `services -> adapters` yields a
+project that does not compile — and, per the above, go-arch-lint would then
+pass it. Each forbidden edge is therefore tested against a *minimal* skeleton
+holding only that one edge, so the linter is what rejects it, not the
+compiler. Both give an error in real use; only one of them is this file's
+subject.
+
+Marked `e2e` — these shell out to `go` and `go-arch-lint`, and are excluded
+from the fast loop. They skip when the toolchain is absent; CI asserts it is
+present so a skip cannot pass for a pass there.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REFERENCE = REPO_ROOT / "governance" / "backend" / "go-arch-lint-reference.yml"
+
+LAYERS = ("api", "ports", "services", "models", "adapters", "common")
+MODULE = "example.com/svc"
+
+_GO = shutil.which("go")
+_ARCH_LINT = shutil.which("go-arch-lint")
+if _ARCH_LINT is None:
+    _candidate = Path(os.path.expanduser("~")) / "go" / "bin" / "go-arch-lint"
+    for suffix in ("", ".exe"):
+        if _candidate.with_suffix(suffix).exists():
+            _ARCH_LINT = str(_candidate.with_suffix(suffix))
+            break
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(
+        _GO is None or _ARCH_LINT is None,
+        reason="Go toolchain or go-arch-lint not installed "
+               "(go install github.com/fe3dback/go-arch-lint@latest)",
+    ),
+]
+
+
+def _source(package: str, imports: list[str], body: str) -> str:
+    block = "".join(f'\t_ "{MODULE}/internal/{name}"\n' for name in imports)
+    header = f"import (\n{block})\n\n" if imports else ""
+    return f"package {package}\n\n{header}{body}"
+
+
+def _conforming() -> dict[str, str]:
+    """Every *allowed* edge populated, so a rule that over-forbids shows up
+    as a failing conforming case rather than passing unnoticed."""
+    return {
+        "go.mod": f"module {MODULE}\n\ngo 1.24\n",
+        "internal/common/log.go": _source("common", [], "func Log(s string) string { return s }\n"),
+        "internal/models/entity.go": _source("models", [], "type Entity struct{ ID string }\n"),
+        "internal/ports/ports.go": _source(
+            "ports", ["models", "common"], "type Repo interface{ Get() string }\n"),
+        "internal/services/core.go": _source(
+            "services", ["ports", "models", "common"], "func Run() string { return \"\" }\n"),
+        "internal/adapters/db.go": _source(
+            "adapters", ["ports", "services", "models", "common"],
+            "func Use() string { return \"\" }\n"),
+        "internal/api/routes.go": _source(
+            "api", ["ports", "models", "common"], "func Handler() string { return \"\" }\n"),
+        # Composition root. It wires adapters into services, so it imports
+        # both — which is why it must live outside internal/, the scanned
+        # workdir. LAYER_IMPLEMENTATION.md prescribes cmd/api/main.go.
+        "cmd/api/main.go": (
+            f'package main\n\nimport (\n\t_ "{MODULE}/internal/adapters"\n'
+            f'\t_ "{MODULE}/internal/api"\n)\n\nfunc main() {{}}\n'
+        ),
+    }
+
+
+def _minimal() -> dict[str, str]:
+    """Six packages, no edges between them — the base for violation cases."""
+    files = {"go.mod": f"module {MODULE}\n\ngo 1.24\n"}
+    bodies = {
+        "common": "func Log(s string) string { return s }\n",
+        "models": "type Entity struct{ ID string }\n",
+        "ports": "type Repo interface{ Get() string }\n",
+        "services": "func Run() string { return \"\" }\n",
+        "adapters": "func Use() string { return \"\" }\n",
+        "api": "func Handler() string { return \"\" }\n",
+    }
+    for layer, body in bodies.items():
+        files[f"internal/{layer}/{layer}.go"] = _source(layer, [], body)
+    return files
+
+
+def _write(root: Path, files: dict[str, str], extra: tuple[str, str] | None = None) -> None:
+    for name in ("internal", "cmd"):
+        if (root / name).exists():
+            shutil.rmtree(root / name)
+    for rel, body in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+    if extra:
+        rel, target = extra
+        path = root / rel
+        text = path.read_text(encoding="utf-8")
+        line = f'\t_ "{MODULE}/internal/{target}"\n'
+        if "import (" in text:
+            text = text.replace("import (\n", f"import (\n{line}", 1)
+        else:
+            head, rest = text.split("\n\n", 1)
+            text = f"{head}\n\nimport (\n{line})\n\n{rest}"
+        path.write_text(text, encoding="utf-8")
+    shutil.copyfile(REFERENCE, root / ".go-arch-lint.yml")
+
+
+def _assert_compiles(root: Path) -> None:
+    """go-arch-lint reports success on source it cannot parse, so a fixture
+    that does not build would make its verdict meaningless."""
+    result = subprocess.run(
+        [_GO, "build", "./..."], cwd=root,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    assert result.returncode == 0, (
+        "fixture is not valid Go, so go-arch-lint's verdict proves nothing:\n"
+        + result.stdout + result.stderr
+    )
+
+
+def _mapped_file_count(root: Path) -> int:
+    """Files the linter attached to a component — the 'did it see anything'
+    signal, equivalent to import-linter's dependency count."""
+    result = subprocess.run(
+        [_ARCH_LINT, "mapping", "--project-path", str(root), "--json"],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return -1
+    payload = payload.get("Payload") or payload.get("payload") or {}
+    rows = payload.get("MappingGrouped") or payload.get("mappingGrouped") or []
+    return sum(len(row.get("FileNames") or row.get("fileNames") or []) for row in rows)
+
+
+def _check(root: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        [_ARCH_LINT, "check", "--project-path", str(root)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+    )
+    out = (result.stdout or "") + (result.stderr or "")
+    assert out.strip(), "go-arch-lint produced no output — it did not run"
+    return result.returncode, out
+
+
+@pytest.fixture
+def go_project(tmp_path) -> Path:
+    return tmp_path
+
+
+def test_conforming_repo_passes(go_project):
+    _write(go_project, _conforming())
+    _assert_compiles(go_project)
+    mapped = _mapped_file_count(go_project)
+    assert mapped >= len(LAYERS), (
+        f"only {mapped} files attached to a component — the config resolved "
+        "little or nothing, so a clean verdict is meaningless"
+    )
+    code, out = _check(go_project)
+    assert code == 0, f"conforming repo rejected:\n{out}"
+
+
+@pytest.mark.parametrize(
+    ("label", "where", "target"),
+    [
+        ("api -> services", "internal/api/api.go", "services"),
+        ("api -> adapters", "internal/api/api.go", "adapters"),
+        ("adapters -> api", "internal/adapters/adapters.go", "api"),
+        ("services -> adapters", "internal/services/services.go", "adapters"),
+        ("services -> api", "internal/services/services.go", "api"),
+        ("ports -> services", "internal/ports/ports.go", "services"),
+        ("ports -> adapters", "internal/ports/ports.go", "adapters"),
+        ("models -> services", "internal/models/models.go", "services"),
+        ("models -> ports", "internal/models/models.go", "ports"),
+        ("common -> models", "internal/common/common.go", "models"),
+        ("common -> services", "internal/common/common.go", "services"),
+    ],
+)
+def test_forbidden_edge_is_rejected(go_project, label, where, target):
+    _write(go_project, _minimal(), extra=(where, target))
+    _assert_compiles(go_project)
+    code, out = _check(go_project)
+    assert code != 0, f"{label} was permitted:\n{out}"
+
+
+def test_undeclared_package_inside_workdir_is_reported(go_project):
+    """go-arch-lint refuses to silently ignore code under its workdir.
+
+    Worth pinning: it is the one thing keeping a mis-scoped config from
+    passing vacuously, and it constrains where the composition root may live.
+    A team putting theirs at internal/app/ must declare an `app` component —
+    the reference cannot pre-declare one, because go-arch-lint errors on a
+    component whose folder does not exist.
+    """
+    _write(go_project, _conforming())
+    stray = go_project / "internal" / "app" / "app.go"
+    stray.parent.mkdir(parents=True, exist_ok=True)
+    stray.write_text(_source("app", ["services"], "func Boot() {}\n"), encoding="utf-8")
+
+    code, out = _check(go_project)
+    assert code != 0, f"an undeclared package under internal/ was ignored:\n{out}"
+    assert "not attached to any component" in out
+
+
+def test_reference_declares_every_canonical_layer():
+    """Structural guard that runs without a Go toolchain."""
+    import yaml
+
+    config = yaml.safe_load(REFERENCE.read_text(encoding="utf-8"))
+    assert set(config["components"]) == set(LAYERS), (
+        f"components are {sorted(config['components'])}, expected {sorted(LAYERS)}"
+    )
+    # `common` must depend on nothing. go-arch-lint rejects an explicit empty
+    # `mayDependOn: []`, so the contract is expressed by omitting the entry —
+    # which reads like an oversight unless it is asserted somewhere.
+    assert "common" not in config["deps"], (
+        "common must have no deps entry: go-arch-lint rejects `mayDependOn: []`, "
+        "so absence is how 'depends on nothing' is expressed"
+    )
+    for layer in ("api", "services", "ports", "models", "adapters"):
+        assert layer in config["deps"], f"{layer} has no deps entry"


### PR DESCRIPTION
Increment 4 of `plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md`. Three of five stacks now have boundary enforcement in a tool that can read them. #93 stays open — JVM and .NET remain.

`go-arch-lint` was already named as this stack's tool by [TECH_STACK.md:172](cli/stacks/go-gin/TECH_STACK.md#L172), `LAYER_IMPLEMENTATION.md` and `TESTING.md`. Nothing shipped it.

Also carries the plan status entry for increment 3 that I owed you — #105 deliberately left it out to avoid colliding with #103.

## The third silent-pass mode

Three linters, three different ways to report success while checking nothing, none of them documented:

| Tool | Passes vacuously when | Gate closes it with |
|---|---|---|
| import-linter | `root_package` names a directory, not a package | adopters told to check the analysed count |
| dependency-cruiser | `--output-type json`; or TypeScript 7 installed | default reporter + fail on zero modules |
| **go-arch-lint** | **source does not parse** — prints `OK - No warnings found` | `go build ./...` first + fail on zero mapped files |

I hit the Go one directly. My first fixture mutation appended an import *after* a declaration — a Go syntax error — and all eleven forbidden edges "passed". They were passing because the linter couldn't read the file, not because it caught anything. A `go build` assertion now guards every fixture, and the shipped gate builds before it checks.

The plan's Verification section now carries this as a standing instruction: assume the next linter has such a mode and go looking for it before shipping the gate.

## Go forbids import cycles, which changes what can be tested

In a fully-wired conforming skeleton `adapters` imports `services`, so adding `services -> adapters` produces a project that doesn't compile — and per the above, go-arch-lint would then *pass* it. Each forbidden edge is therefore tested against a minimal skeleton holding only that edge, so the linter is what rejects it rather than the compiler.

Worth knowing for real repos: several layering violations fail at `go build` before the linter runs. The rules still earn their place — they catch the acyclic ones the compiler accepts, `api -> services` and `api -> adapters` among them.

## Two config constraints the docs don't mention

- **`common: mayDependOn: []` is rejected** — "should have ref in 'mayDependOn'/'canUse' or at least one flag". Dependency-free is expressed by omitting the component from `deps` entirely. That reads like an oversight, so a test asserts the omission is deliberate.
- **A component whose folder doesn't exist is a hard error.** So the reference can't pre-declare an `app` component for teams whose composition root is `internal/app/` — it documents how to add one, and recommends `cmd/<binary>/main.go`, outside the scanned workdir, which is what `LAYER_IMPLEMENTATION.md` lists first.

Conversely — and this one is a *strength* — a package under `internal/` that no component claims fails the check. It's the one place these three linters refuse to ignore code silently, and it's pinned by a test.

## Verification

`tests/test_go_arch_lint_reference.py`: conforming skeleton passes with every allowed edge populated, 11 forbidden edges rejected, undeclared-package detection pinned, plus a structural test that runs without a Go toolchain.

`./full_test`: 1929 fast + 115 e2e passed, 1 skipped.

Real `govkit apply` across agent × flavour × level:

```
go-l3      go-gin           gate=[boundary-gate-go.yml]     reference=[go-arch-lint-reference.yml]
go-l5      go-gin           gate=[boundary-gate-go.yml]     reference=[go-arch-lint-reference.yml]
node-l4    nodejs-fastify   gate=[boundary-gate-node.yml]   reference=[dependency-cruiser-reference.cjs]
py-l4      python-fastapi   gate=[boundary-gate-python.yml] reference=[importlinter-reference.toml]
dotnet-l4  dotnet-aspnet    gate=[]                         reference=[]
```

The **installed** reference — not the repo copy — was then run through `go-arch-lint` against the conforming skeleton and all eleven forbidden edges.

CI gains `actions/setup-go` and a `go-arch-lint` install; the toolchain assertion now covers `node`, `npm`, `go` and the `go-arch-lint` binary.

## Doc corrections this change forced

`ci/README.md` still said boundary enforcement came from the L3 gate — it's had its own file since #102 — and said "both linters" where there are now three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
