### PR TITLE
feat(ci): boundary enforcement for java-spring-boot (#93)

### DIFF
--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -399,7 +399,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "cli":        {
@@ -407,7 +408,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -460,7 +462,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "cli": {
@@ -476,7 +479,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "ui-react": { "governed": [
@@ -518,7 +522,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "cli":        {
@@ -526,7 +531,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -579,7 +585,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "cli": {
@@ -595,7 +602,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -421,7 +421,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "cli":        {
@@ -429,7 +430,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -482,7 +484,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "cli": {
@@ -498,7 +501,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "ui-react": { "governed": [
@@ -540,7 +544,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "cli":        {
@@ -548,7 +553,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -601,7 +607,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "cli": {
@@ -617,7 +624,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -403,7 +403,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "cli":        {
@@ -411,7 +412,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -464,7 +466,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "cli": {
@@ -480,7 +483,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "ui-react": { "governed": [
@@ -522,7 +526,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "cli":        {
@@ -530,7 +535,8 @@
             "by_stack": {
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+              "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -583,7 +589,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "cli": {
@@ -599,7 +606,8 @@
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
-                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] }
+                "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
               }
             },
             "ui-react": { "governed": [

--- a/ci/README.md
+++ b/ci/README.md
@@ -35,6 +35,7 @@ Copy the relevant templates for your project type:
 | `boundary-gate-python.yml` | `python-fastapi` | `python-fastapi` | — | — |
 | `boundary-gate-node.yml` | `nodejs-fastify` | `nodejs-fastify` | — | — |
 | `boundary-gate-go.yml` | `go-gin` | `go-gin` | — | — |
+| `boundary-gate-jvm.yml` | `java-spring-boot` | `java-spring-boot` | — | — |
 | `ui-quality-gate.yml` | — | — | ✓ | — |
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
@@ -68,7 +69,14 @@ part of the shared quality gate. govkit installs a boundary gate chosen by
 | `python-fastapi` | `boundary-gate-python.yml` | `import-linter` | `governance/backend/importlinter-reference.toml` |
 | `nodejs-fastify` | `boundary-gate-node.yml` | `dependency-cruiser` | `governance/backend/dependency-cruiser-reference.cjs` |
 | `go-gin` | `boundary-gate-go.yml` | `go-arch-lint` | `governance/backend/go-arch-lint-reference.yml` |
-| `java-spring-boot`, `dotnet-aspnet` | *none yet* | tracked separately | — |
+| `java-spring-boot` | `boundary-gate-jvm.yml` | ArchUnit | `governance/backend/ArchitectureTest.java.template` |
+| `dotnet-aspnet` | *none yet* | tracked separately | — |
+
+**The JVM gate has a different shape.** Python, Node and Go get a config file
+and a linter binary. On the JVM the rules *are* test code: govkit ships a
+template you copy into your own test tree, and it runs with `mvn test` /
+`gradle test`. The gate installs no linter — it runs your build, then reads
+the test reports to confirm the architecture test actually executed.
 
 A stack with no gate receives **no boundary workflow at all**, rather than one
 that silently skips. Shipping a Python linter to a Go repo enforces nothing
@@ -93,9 +101,14 @@ Each logs a notice telling you how to enable it.
   Keep your composition root at `cmd/<binary>/main.go`; if you use
   `internal/app/` instead, declare an `app` component (the reference explains
   how, and why it cannot ship one pre-declared).
+- **JVM** — copy `governance/backend/ArchitectureTest.java.template` to
+  `src/test/java/<base>/architecture/ArchitectureTest.java`, drop the
+  `.template` suffix, set your base package, and add `archunit-junit5` as a
+  test dependency.
 
-**Confirm your gate analysed something.** All three linters report success on
-an empty analysis, so a misconfigured contract looks exactly like a clean repo:
+**Confirm your gate analysed something.** Every one of these tools reports
+success on an empty analysis, so a misconfigured contract looks exactly like a
+clean repo:
 
 - `import-linter` prints `Analyzed N files, 0 dependencies` and reports every
   contract KEPT when the package name is wrong.
@@ -104,10 +117,25 @@ an empty analysis, so a misconfigured contract looks exactly like a clean repo:
   dependency-cruiser 17 uses the TypeScript 5.x compiler API.
 - `go-arch-lint` prints `OK - No warnings found` and exits 0 on Go it cannot
   parse, so a syntax error anywhere turns the boundary check green.
+- **ArchUnit** rules that the build never executes — wrong source set, a class
+  name outside the test include pattern, a module missing from the reactor —
+  leave a green build that checked no boundary at all.
 
-Each gate closes its own hole: the Node gate fails on a zero module count, and
-the Go gate runs `go build ./...` before checking and fails when no file
-attached to a component. If you adapt these gates, keep those checks.
+Each gate closes its own hole: the Node gate fails on a zero module count, the
+Go gate runs `go build ./...` first and fails when no file attached to a
+component, and the JVM gate reads the test reports and fails unless
+`ArchitectureTest` actually ran with a non-zero rule count. If you adapt these
+gates, keep those checks.
+
+**One caveat specific to the JVM.** govkit's own CI runs the real linter
+against generated skeletons for the Python, Node and Go contracts. It does not
+do that for the ArchUnit template — that needs a JVM and Maven on every run,
+for a file that changes rarely — so the template is checked *structurally*:
+that it names all six layers, forbids every edge `BOUNDARIES.md` forbids, and
+keeps one consistent placeholder package. An ArchUnit API misuse that compiles
+and passes vacuously would not be caught. When you adopt it, verify it once
+yourself: introduce a deliberate `api → services` import and confirm the build
+fails.
 
 ---
 
@@ -126,6 +154,7 @@ in its own stack-selected `boundary-gate-*.yml`, which also ships from L3.
 | `boundary-gate-python.yml` | Architecture boundary enforcement (`python-fastapi`) | — |
 | `boundary-gate-node.yml` | Architecture boundary enforcement (`nodejs-fastify`) | — |
 | `boundary-gate-go.yml` | Architecture boundary enforcement (`go-gin`) | — |
+| `boundary-gate-jvm.yml` | Architecture boundary enforcement (`java-spring-boot`) | — |
 | `quality-gate.yml` | — | Schema validation, contract compatibility, governance artifacts (5) |
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |

--- a/ci/azure/boundary-gate-jvm.yml
+++ b/ci/azure/boundary-gate-jvm.yml
@@ -1,0 +1,97 @@
+# Azure DevOps pipeline — architecture boundary enforcement for the
+# `java-spring-boot` stack. Runs ArchUnit rules that live in your own test
+# suite, against the hexagonal layer contract described in
+# docs/backend/architecture/BOUNDARIES.md.
+#
+# STAGES:
+#   BoundaryCheck    — runs the project's tests and confirms the ArchUnit
+#                      architecture test among them actually executed
+#
+# STACK-SELECTED: govkit installs this file only for `--stack java-spring-boot`.
+# See ci/README.md for the per-stack mapping.
+#
+# DIFFERENT SHAPE FROM THE OTHER GATES. Python, Node and Go get a config file
+# and a linter binary. On the JVM the rules ARE test code: govkit ships
+# governance/backend/ArchitectureTest.java.template, you copy it into your test
+# tree, and it runs with `mvn test` / `gradle test`. This stage therefore
+# installs no linter — it runs your build and then checks the reports.
+#
+# OPT-IN: skips until an ArchitectureTest is present in the test tree.
+#
+# WHY IT READS THE TEST REPORTS: a test class the build never executes is this
+# stack's silent-pass mode — wrong source set, a name outside the include
+# pattern, a module missing from the reactor. The build goes green having
+# checked no boundary at all, exactly as a linter that analysed zero files
+# would. Passing is not enough; the stage confirms the test ran.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: BoundaryCheck
+    displayName: Architecture boundary enforcement
+    dependsOn: []
+    jobs:
+      - job: BoundaryCheck
+        displayName: Run ArchUnit architecture tests
+        steps:
+          - checkout: self
+
+          - script: |
+              if ! find . -path ./target -prune -o -name 'ArchitectureTest.java' -print | grep -q .; then
+                echo "##vso[task.logissue type=warning]No ArchitectureTest.java found. Copy governance/backend/ArchitectureTest.java.template into src/test/java/<base>/architecture/ArchitectureTest.java and set your base package to enable boundary enforcement."
+                echo "##vso[task.setvariable variable=archTestFound]false"
+              else
+                echo "##vso[task.setvariable variable=archTestFound]true"
+              fi
+            displayName: Detect ArchUnit architecture test
+
+          - task: JavaToolInstaller@0
+            condition: eq(variables['archTestFound'], 'true')
+            displayName: Use Java 21
+            inputs:
+              versionSpec: '21'
+              jdkArchitectureOption: 'x64'
+              jdkSourceOption: 'PreInstalled'
+
+          - script: |
+              set -euo pipefail
+              if [ -f pom.xml ]; then
+                ./mvnw --batch-mode test || mvn --batch-mode test
+              elif [ -f build.gradle ] || [ -f build.gradle.kts ]; then
+                ./gradlew test
+              else
+                echo "##vso[task.logissue type=error]Neither pom.xml nor build.gradle found — cannot run the architecture test."
+                exit 1
+              fi
+            condition: eq(variables['archTestFound'], 'true')
+            displayName: Run tests
+
+          - script: |
+              set -euo pipefail
+              # Maven writes target/surefire-reports/, Gradle build/test-results/test/.
+              reports=$(find . \( -path '*/surefire-reports/*' -o -path '*/test-results/*' \) \
+                        -name '*ArchitectureTest*.xml' -print)
+              if [ -z "$reports" ]; then
+                echo "##vso[task.logissue type=error]The build passed but produced no test report for ArchitectureTest. The architecture rules did not run, so no boundary was checked. Confirm the class is under the test source set and matches your build's test include pattern."
+                exit 1
+              fi
+              total=0
+              for report in $reports; do
+                count=$(grep -oE 'tests="[0-9]+"' "$report" | head -1 | grep -oE '[0-9]+' || echo 0)
+                total=$((total + count))
+              done
+              if [ "$total" -eq 0 ]; then
+                echo "##vso[task.logissue type=error]ArchitectureTest ran 0 tests. The rules are not being picked up — check that they are @ArchTest fields and that archunit-junit5 is on the test classpath."
+                exit 1
+              fi
+              echo "ArchitectureTest executed $total architecture rules."
+            condition: eq(variables['archTestFound'], 'true')
+            displayName: Confirm the architecture test actually ran

--- a/ci/github/boundary-gate-jvm.yml
+++ b/ci/github/boundary-gate-jvm.yml
@@ -1,0 +1,98 @@
+# boundary-gate-jvm.yml
+#
+# PURPOSE: Architecture boundary enforcement for the `java-spring-boot` stack.
+# Runs ArchUnit rules that live in your own test suite, against the hexagonal
+# layer contract described in docs/backend/architecture/BOUNDARIES.md.
+# Copy this file to .github/workflows/boundary-gate.yml.
+#
+# JOBS:
+#   boundary-check    — runs the project's tests and confirms the ArchUnit
+#                       architecture test among them actually executed
+#
+# STACK-SELECTED: govkit installs this file only for `--stack java-spring-boot`.
+# See ci/README.md for the per-stack mapping.
+#
+# DIFFERENT SHAPE FROM THE OTHER GATES. Python, Node and Go get a config file
+# and a linter binary. On the JVM the rules ARE test code: govkit ships
+# governance/backend/ArchitectureTest.java.template, you copy it into your test
+# tree, and it runs with `mvn test` / `gradle test`. This job therefore installs
+# no linter — it runs your build and then checks the reports.
+#
+# OPT-IN: skips until an ArchitectureTest is present in the test tree.
+#
+# WHY IT READS THE TEST REPORTS: a test class the build never executes is this
+# stack's silent-pass mode — wrong source set, a name outside the include
+# pattern, a module missing from the reactor. The build goes green having
+# checked no boundary at all, exactly as a linter that analysed zero files
+# would. Passing is not enough; the gate confirms the test ran.
+#
+# REQUIRED SECRETS: none.
+
+name: Boundary Gate (JVM)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  boundary-check:
+    name: Architecture boundary enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect ArchUnit architecture test
+        id: contract
+        run: |
+          if find . -path ./target -prune -o -name 'ArchitectureTest.java' -print \
+             | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No ArchitectureTest.java found. Copy governance/backend/ArchitectureTest.java.template into src/test/java/<base>/architecture/ArchitectureTest.java and set your base package to enable boundary enforcement."
+          fi
+
+      - uses: actions/setup-java@v4
+        if: steps.contract.outputs.found == 'true'
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Run tests
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          if [ -f pom.xml ]; then
+            ./mvnw --batch-mode test || mvn --batch-mode test
+          elif [ -f build.gradle ] || [ -f build.gradle.kts ]; then
+            ./gradlew test
+          else
+            echo "::error::Neither pom.xml nor build.gradle found — cannot run the architecture test."
+            exit 1
+          fi
+
+      - name: Confirm the architecture test actually ran
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          # Maven writes target/surefire-reports/, Gradle build/test-results/test/.
+          reports=$(find . \( -path '*/surefire-reports/*' -o -path '*/test-results/*' \) \
+                    -name '*ArchitectureTest*.xml' -print)
+          if [ -z "$reports" ]; then
+            echo "::error::The build passed but produced no test report for ArchitectureTest. The architecture rules did not run, so no boundary was checked. Confirm the class is under the test source set and matches your build's test include pattern."
+            exit 1
+          fi
+          # A report with zero tests means the class was discovered but empty.
+          total=0
+          for report in $reports; do
+            count=$(grep -oE 'tests="[0-9]+"' "$report" | head -1 | grep -oE '[0-9]+' || echo 0)
+            total=$((total + count))
+          done
+          if [ "$total" -eq 0 ]; then
+            echo "::error::ArchitectureTest ran 0 tests. The rules are not being picked up — check that they are @ArchTest fields and that archunit-junit5 is on the test classpath."
+            exit 1
+          fi
+          echo "ArchitectureTest executed $total architecture rules."

--- a/governance/backend/ArchitectureTest.java.template
+++ b/governance/backend/ArchitectureTest.java.template
@@ -1,0 +1,146 @@
+/*
+ * ArchUnit reference test for hexagonal architecture enforcement on the
+ * `java-spring-boot` stack.
+ *
+ * Copy this file into your own test tree, drop the `.template` suffix, and
+ * replace `com.example.myservice` with your base package:
+ *
+ *     src/test/java/<your>/<base>/architecture/ArchitectureTest.java
+ *
+ * Unlike the Python, Node and Go stacks, there is no config file here. On the
+ * JVM the architecture rules ARE test code: they live in your suite, compile
+ * with it, and run with `mvn test` / `gradle test`. govkit ships the rules; it
+ * does not run them for you.
+ *
+ * Dependency:
+ *   Maven   <dependency><groupId>com.tngtech.archunit</groupId>
+ *           <artifactId>archunit-junit5</artifactId>
+ *           <version>1.3.0</version><scope>test</scope></dependency>
+ *   Gradle  testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'
+ *
+ * This test enforces the layering rules defined in:
+ *   docs/backend/architecture/ARCH_CONTRACT.md
+ *   docs/backend/architecture/BOUNDARIES.md
+ *
+ * It expresses the same contract as
+ * governance/backend/importlinter-reference.toml (Python),
+ * dependency-cruiser-reference.cjs (Node) and go-arch-lint-reference.yml (Go):
+ * `api` and `adapters` are independent siblings above `services`, above
+ * `ports`, above `models`, above `common`, with `api -> services` forbidden.
+ *
+ * -----------------------------------------------------------------------------
+ * HOW THIS FILE IS VERIFIED, AND HOW IT IS NOT.
+ *
+ * govkit's own CI runs the real linter against generated skeletons for the
+ * Python, Node and Go contracts, so those cannot claim enforcement they do not
+ * deliver. It does NOT do that here: running ArchUnit needs a JVM and Maven on
+ * every CI run, for a template that changes rarely.
+ *
+ * What govkit checks is **structural** — that this file names all six layers,
+ * forbids every edge BOUNDARIES.md forbids, and keeps one consistent
+ * placeholder package. What it cannot catch is an ArchUnit API misuse that
+ * compiles and passes without checking anything.
+ *
+ * So verify it yourself, once, when you adopt it: introduce a deliberate
+ * violation — have a class in `api` import one from `services` — and confirm
+ * the build fails. If it passes, your base package or source set is wrong,
+ * not your architecture.
+ * -----------------------------------------------------------------------------
+ *
+ * COMPOSITION ROOT. Whatever wires adapters into services imports both, so it
+ * cannot sit in any layer. Spring configuration belongs in `config/`, which
+ * LAYER_IMPLEMENTATION.md already places outside the six layers and which
+ * these rules deliberately do not constrain.
+ */
+package com.example.myservice.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "com.example.myservice")
+class ArchitectureTest {
+
+    /*
+     * A wrong base package above imports zero classes, and a rule with nothing
+     * to check is a rule that cannot fail. That is the JVM equivalent of
+     * import-linter reporting "Analyzed N files, 0 dependencies" while every
+     * contract shows as KEPT.
+     *
+     * ArchUnit's own empty-should handling covers most of this, but it is
+     * configurable and defaults have changed across versions, so this asserts
+     * it directly rather than relying on the framework's current default.
+     */
+    @ArchTest
+    static void the_base_package_resolves_to_classes(JavaClasses classes) {
+        if (classes.isEmpty()) {
+            throw new AssertionError(
+                "ArchUnit imported no classes. The @AnalyzeClasses package does not "
+                + "match this project, so every rule below would pass without "
+                + "checking anything. Set it to your base package.");
+        }
+    }
+
+    /*
+     * BOUNDARIES.md section 2: the API invokes behaviour through
+     * ports/inbound only. Depending on `models` is allowed — inbound port
+     * signatures carry entities.
+     */
+    @ArchTest
+    static final ArchRule api_must_not_depend_on_services =
+        noClasses().that().resideInAPackage("..api..")
+            .should().dependOnClassesThat().resideInAnyPackage("..services..");
+
+    /*
+     * `api` and `adapters` are both adapters in the pattern — inbound and
+     * outbound. Neither may import the other; they meet at the composition
+     * root in `config/`.
+     */
+    @ArchTest
+    static final ArchRule api_must_not_depend_on_adapters =
+        noClasses().that().resideInAPackage("..api..")
+            .should().dependOnClassesThat().resideInAnyPackage("..adapters..");
+
+    @ArchTest
+    static final ArchRule adapters_must_not_depend_on_api =
+        noClasses().that().resideInAPackage("..adapters..")
+            .should().dependOnClassesThat().resideInAnyPackage("..api..");
+
+    /*
+     * The single most important forbidden edge — ARCH_CONTRACT.md section 3.
+     * The domain depends on port interfaces; adapters implement them.
+     */
+    @ArchTest
+    static final ArchRule services_must_not_depend_on_adapters_or_api =
+        noClasses().that().resideInAPackage("..services..")
+            .should().dependOnClassesThat().resideInAnyPackage("..adapters..", "..api..");
+
+    /*
+     * `ports` sits below `services`: it holds interfaces and may reference
+     * entities, while services imports the ports it depends on. Granting the
+     * reverse would create the cycle BOUNDARIES.md forbids.
+     */
+    @ArchTest
+    static final ArchRule ports_must_not_depend_on_upper_layers =
+        noClasses().that().resideInAPackage("..ports..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("..services..", "..adapters..", "..api..");
+
+    /* Domain entities stay ignorant of behaviour and interfaces. */
+    @ArchTest
+    static final ArchRule models_must_not_depend_on_upper_layers =
+        noClasses().that().resideInAPackage("..models..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("..ports..", "..services..", "..adapters..", "..api..");
+
+    /* `common` is cross-cutting and must stay dependency-free. */
+    @ArchTest
+    static final ArchRule common_must_not_depend_on_any_layer =
+        noClasses().that().resideInAPackage("..common..")
+            .should().dependOnClassesThat()
+            .resideInAnyPackage("..models..", "..ports..", "..services..",
+                                "..adapters..", "..api..");
+}

--- a/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
+++ b/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
@@ -1,10 +1,10 @@
 # Per-Stack Boundary Enforcement Plan
 
-**Status:** In progress — 2026-08-01. Increments 1-4 are done: stack-selected
-dispatch (#102), stack-agnostic doc wording (#103), Node (#105), and Go. Three
-of five stacks now have boundary enforcement in a tool that can read them.
-Remaining: increment 5 (JVM) and 6 (.NET), both template-and-structural-
-assertion shaped. Covers #93, which closes when increment 6 lands.
+**Status:** In progress — 2026-08-01. Increments 1-5 are done: stack-selected
+dispatch (#102), stack-agnostic doc wording (#103), Node (#105), Go (#106),
+and the JVM. Four of five stacks now have boundary enforcement in a tool that
+can read them. Remaining: increment 6 (.NET), the same template-and-structural
+-assertion shape as the JVM. Covers #93, which closes when it lands.
 
 Every linter adopted so far reports success on an empty analysis, each in its
 own way, and none of them says so. That pattern is now the first thing to test
@@ -292,19 +292,32 @@ Two config constraints worth recording, both discovered by running it:
 
 Commit: `feat(ci): boundary enforcement for go-gin (#93)`
 
-### 5. JVM — ArchUnit template
+### 5. JVM — ArchUnit template — done
 
-1. Failing structural test: the template names all six layers, expresses
-   `api → services` as forbidden, and its layer order matches
-   `BOUNDARIES.md`.
-2. `governance/backend/ArchitectureTest.java.template`, gate file, wiring.
-3. The gate runs the project's existing test command — it does not install
-   a separate linter.
+1. `tests/test_archunit_template.py`: the template names all six layers,
+   forbids every edge `BOUNDARIES.md` forbids (all 17, parametrized), keeps
+   one consistent placeholder base package, carries its own
+   imported-nothing guard, and discloses in the file that govkit checks it
+   structurally rather than by running it.
+2. `governance/backend/ArchitectureTest.java.template`, both gate files, the
+   manifest wiring.
+3. The gate runs the project's existing test command — it installs no linter.
 
-Structural assertions only — a Python test suite cannot run a JVM fixture
-without a JVM in CI, which is not worth adding for a template that changes
-rarely. `ci/README.md` must say so plainly rather than implying parity with
-the fixture-verified stacks.
+**Structural assertions only, and the docs say so.** A Python test suite
+cannot run a JVM fixture without a JVM in CI, which is not worth adding for a
+template that changes rarely. What that costs is real and stated in
+`ci/README.md` and in the template's own header: an ArchUnit API misuse that
+compiles and passes vacuously would not be caught. Adopters are told to verify
+once, by introducing a deliberate `api → services` import.
+
+The gate's own check is not weakened by this, and it is the part that matters
+most. This stack's silent-pass mode is **a test class the build never
+executes** — wrong source set, a name outside the include pattern, a module
+missing from the reactor — which leaves a green build that checked nothing.
+The gate reads `surefire-reports/` (Maven) or `test-results/` (Gradle),
+fails when no `ArchitectureTest` report exists, and fails again when one
+exists reporting zero tests. That assertion needs no JVM to write and is
+pinned by `tests/test_boundary_gate_dispatch.py`.
 
 Commit: `feat(ci): boundary enforcement for java-spring-boot (#93)`
 
@@ -337,6 +350,7 @@ Commit: `feat(ci): boundary enforcement for dotnet-aspnet (#93)`
   | import-linter | `root_package` names a directory, not a package — 0 dependencies, all contracts KEPT | adopters told to check the analysed count |
   | dependency-cruiser | `--output-type json` (always exits 0); TypeScript 7 installed (0 modules) | default reporter + fail on zero modules |
   | go-arch-lint | source does not parse — "OK - No warnings found" | `go build ./...` first + fail on zero mapped files |
+  | ArchUnit | the test class is never executed by the build | read the test reports; fail unless it ran with a non-zero rule count |
 
   Assume the next one has such a mode and go looking for it. A gate that
   cannot fail is worse than no gate, because it reports that the boundary

--- a/tests/test_archunit_template.py
+++ b/tests/test_archunit_template.py
@@ -1,0 +1,160 @@
+"""The shipped ArchUnit template must express BOUNDARIES.md.
+
+**This is a weaker guarantee than the other three references get, and the
+difference is deliberate.** `test_importlinter_reference.py`,
+`test_dependency_cruiser_reference.py` and `test_go_arch_lint_reference.py`
+each run the real linter against generated skeletons, so those contracts
+cannot claim an enforcement they do not deliver. Doing the same here needs a
+JVM and Maven in every CI run, for a template that changes rarely — the plan
+weighs that trade and chooses structural assertions.
+
+So these tests check that the template *says* the right thing, not that it
+*does* the right thing. They will not catch an ArchUnit API misuse that
+compiles and passes vacuously. What they do catch is the failure mode that
+actually recurs in this repo: a contract drifting out of step with
+BOUNDARIES.md — a layer dropped, a forbidden edge quietly removed, the
+placeholder package renamed in one place but not another.
+
+Two structural guards stand in for what execution would prove:
+
+- the template carries its own "did any class get imported" check, because a
+  wrong base package is the JVM equivalent of import-linter's zero dependency
+  count;
+- the gate asserts the architecture test actually *ran*, since a test class
+  the build never executes is the JVM equivalent of a linter that analysed
+  nothing. That assertion is checked in tests/test_boundary_gate_dispatch.py.
+
+If the template starts changing often, revisit and add a JVM to CI.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE = REPO_ROOT / "governance" / "backend" / "ArchitectureTest.java.template"
+BOUNDARIES = REPO_ROOT / "docs" / "backend" / "architecture" / "BOUNDARIES.md"
+
+LAYERS = ("api", "ports", "services", "models", "adapters", "common")
+
+# Every edge BOUNDARIES.md forbids, as (source layer, forbidden target).
+# Mirrors the rule set in governance/backend/go-arch-lint-reference.yml and
+# dependency-cruiser-reference.cjs so all four contracts stay comparable.
+FORBIDDEN_EDGES = [
+    ("api", "services"),
+    ("api", "adapters"),
+    ("adapters", "api"),
+    ("services", "adapters"),
+    ("services", "api"),
+    ("ports", "services"),
+    ("ports", "adapters"),
+    ("ports", "api"),
+    ("models", "services"),
+    ("models", "ports"),
+    ("models", "adapters"),
+    ("models", "api"),
+    ("common", "api"),
+    ("common", "adapters"),
+    ("common", "services"),
+    ("common", "ports"),
+    ("common", "models"),
+]
+
+
+@pytest.fixture(scope="module")
+def template() -> str:
+    assert TEMPLATE.is_file(), f"{TEMPLATE} does not exist"
+    return TEMPLATE.read_text(encoding="utf-8")
+
+
+def test_template_names_every_canonical_layer(template):
+    for layer in LAYERS:
+        assert f"..{layer}.." in template, (
+            f"template never references the {layer!r} layer as an ArchUnit "
+            f"package identifier (`..{layer}..`)"
+        )
+
+
+@pytest.mark.parametrize("source, target", FORBIDDEN_EDGES)
+def test_template_forbids_every_edge_boundaries_forbids(template, source, target):
+    """Each forbidden edge must appear as a rule whose `that()` names the
+    source layer and whose `dependOnClassesThat()` names the target."""
+    rules = re.findall(
+        r"noClasses\(\)(.*?);", template, re.DOTALL,
+    )
+    assert rules, "template declares no `noClasses()` rules"
+    matched = any(
+        f'resideInAPackage("..{source}..")' in rule
+        and re.search(
+            r"dependOnClassesThat\(\)\s*\.resideInAnyPackage\(([^)]*)\)"
+            r"|dependOnClassesThat\(\)\s*\.resideInAPackage\(([^)]*)\)",
+            rule,
+            re.DOTALL,
+        )
+        and f'"..{target}.."' in rule.split("dependOnClassesThat")[-1]
+        for rule in rules
+    )
+    assert matched, (
+        f"no rule forbids {source} -> {target}; BOUNDARIES.md forbids it and "
+        "the other three reference contracts express it"
+    )
+
+
+def test_template_guards_against_an_unresolved_base_package(template):
+    """A wrong `@AnalyzeClasses` package imports zero classes — the JVM
+    equivalent of import-linter's `Analyzed N files, 0 dependencies`. The
+    template must notice rather than report every rule satisfied."""
+    assert "@AnalyzeClasses" in template, "template does not declare @AnalyzeClasses"
+    assert "JavaClasses" in template, (
+        "template has no rule receiving JavaClasses, so it cannot check that "
+        "the base package resolved to anything"
+    )
+    assert re.search(r"isEmpty\(\)", template), (
+        "template never checks that the imported class set is non-empty"
+    )
+
+
+def test_template_placeholder_package_is_consistent(template):
+    """Adopters replace one placeholder. Two base packages means half a
+    rename, and the half that stays behind points ArchUnit at nothing.
+
+    Subpackages of the base are fine — the file's own `package` declaration is
+    one — so the check is that every placeholder shares the base, not that
+    they are all identical.
+    """
+    base = "com.example.myservice"
+    placeholders = set(re.findall(r"com\.example\.[a-z0-9_.]+", template))
+    assert placeholders, "template declares no com.example.* placeholder package"
+
+    strays = {p for p in placeholders if p != base and not p.startswith(f"{base}.")}
+    assert not strays, (
+        f"template uses a placeholder outside the {base!r} base package: "
+        f"{sorted(strays)} — an adopter renaming the base would miss these"
+    )
+    assert f'packages = "{base}"' in template, (
+        "@AnalyzeClasses must point at the base package itself, not a subpackage"
+    )
+
+
+def test_template_tells_the_reader_it_is_not_executed_by_govkit(template):
+    """The honesty this plan exists to protect: the other three contracts are
+    verified against their real linter, this one is not, and a reader must be
+    able to learn that from the file itself."""
+    lowered = template.lower()
+    assert "structural" in lowered or "not executed" in lowered, (
+        "template does not disclose that govkit checks it structurally rather "
+        "than by running ArchUnit"
+    )
+
+
+def test_boundaries_still_forbids_what_the_template_forbids():
+    """Anti-drift in the other direction: if BOUNDARIES.md ever grants one of
+    these edges, this test set is what makes the contradiction visible."""
+    text = BOUNDARIES.read_text(encoding="utf-8")
+    section = re.search(r"### Forbidden:\n((?:.*\n)+?)\n", text)
+    assert section, "could not locate BOUNDARIES.md's Forbidden list"
+    forbidden = section.group(1)
+    assert "`api` importing `services`" in forbidden
+    assert re.search(r"`services`.*importing any adapter", forbidden)
+    assert re.search(r"`models` importing `ports` or `services`", forbidden)

--- a/tests/test_boundary_gate_dispatch.py
+++ b/tests/test_boundary_gate_dispatch.py
@@ -38,10 +38,10 @@ STACK_GATES = {
     "python-fastapi": "boundary-gate-python.yml",
     "nodejs-fastify": "boundary-gate-node.yml",
     "go-gin": "boundary-gate-go.yml",
+    "java-spring-boot": "boundary-gate-jvm.yml",
 }
 STACKS_WITHOUT_A_GATE = (
     "dotnet-aspnet",
-    "java-spring-boot",
 )
 
 # The reference contract each gate tells the team to copy in. It has to ship
@@ -51,6 +51,7 @@ STACK_REFERENCES = {
     "python-fastapi": "governance/backend/importlinter-reference.toml",
     "nodejs-fastify": "governance/backend/dependency-cruiser-reference.cjs",
     "go-gin": "governance/backend/go-arch-lint-reference.yml",
+    "java-spring-boot": "governance/backend/ArchitectureTest.java.template",
 }
 _ALL_REFERENCES = set(STACK_REFERENCES.values())
 
@@ -319,6 +320,30 @@ class TestNodeBoundaryGateContent:
             "printed and the gate would still pass"
         )
         assert "depcruise" in body or "dependency-cruiser" in body
+
+    @pytest.mark.parametrize("ci", CI_FLAVOURS)
+    def test_jvm_gate_proves_the_architecture_test_actually_ran(self, ci):
+        """The JVM gate runs the project's own test command, so its silent-pass
+        mode is a test class the build never executes — wrong source set, name
+        outside the include pattern, module not in the reactor. The build goes
+        green having checked no boundary at all.
+
+        This is the JVM equivalent of the Node gate's module count, and it is
+        the one part of increment 5 that does not depend on ArchUnit
+        semantics, so it is worth pinning even though govkit cannot run the
+        template itself.
+        """
+        body = self._executable(f"ci/{ci}/boundary-gate-jvm.yml")
+
+        assert "ArchitectureTest" in body, (
+            "the gate must look for the architecture test by name in the test "
+            "report, or it cannot tell 'passed' from 'never ran'"
+        )
+        assert "exit 1" in body
+        assert "surefire" in body or "test-results" in body, (
+            "the gate must read the build's test reports (surefire for Maven, "
+            "build/test-results for Gradle) to confirm execution"
+        )
 
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
     def test_gate_fails_on_a_zero_module_count(self, ci):


### PR DESCRIPTION
Increment 5 of `plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md`. Four of five stacks now have boundary enforcement in a tool that can read them. #93 closes when .NET lands.

ArchUnit was already named as this stack's tool by [TECH_STACK.md:174](cli/stacks/java-spring-boot/TECH_STACK.md#L174), `LAYER_IMPLEMENTATION.md` and `TESTING.md`. Nothing shipped it.

## A different shape, and a new place for the silent pass

Python, Node and Go get a config file and a linter binary. On the JVM the rules **are test code** — govkit ships a template, you copy it into your test tree, and it runs with your build. The gate installs no linter.

That moves the silent-pass mode somewhere new: **a test class the build never executes.** Wrong source set, a name outside the include pattern, a module missing from the reactor — the build goes green having checked no boundary at all, exactly as a linter that analysed zero files would.

So the gate doesn't stop at a passing build. It reads `surefire-reports/` (Maven) or `test-results/` (Gradle), fails when no `ArchitectureTest` report exists, and fails again when one exists reporting zero tests. Writing that needed no JVM, and it's the part of this increment carrying the most weight.

Four linters, four different vacuous-pass modes, none documented:

| Tool | Passes vacuously when |
|---|---|
| import-linter | `root_package` names a directory, not a package |
| dependency-cruiser | `--output-type json`; or TypeScript 7 installed |
| go-arch-lint | source doesn't parse |
| **ArchUnit** | **the test class is never executed** |

The template also guards its own equivalent of a wrong package name — a rule receiving `JavaClasses` that fails when the import is empty. ArchUnit's own empty-should handling covers much of this, but it's configurable and its default has moved across versions, so the template asserts it directly rather than trusting the current setting.

## Be clear about what this PR does *not* verify

**This is the first contract govkit ships that its own CI does not execute**, and I want that flagged rather than buried. The other three run the real linter against generated skeletons. Running ArchUnit needs a JVM and Maven on every CI run for a file that changes rarely — the trade you chose when you kept Java in #93.

What's checked structurally: all six layers named, **all 17 forbidden edges** parametrized from `BOUNDARIES.md` (not spot-checked), one consistent placeholder base package, and the imported-nothing guard present.

What would slip through: an ArchUnit API misuse that compiles and passes without checking anything.

Every place a reader might assume parity now says otherwise — `ci/README.md`, the template's own header, the test module's docstring, and the plan. Adopters are told to verify once by introducing a deliberate `api → services` import and confirming the build fails.

If you'd rather close that gap, adding a JDK + Maven to CI is a contained change and I'll do it — say the word. My read is that the report-check in the gate is where the real risk was, and it's covered.

## Verification

`tests/test_archunit_template.py` — 22 structural assertions, failing first.

`./full_test`: 1960 fast + 115 e2e passed, 1 skipped.

Real `govkit apply`:

```
jvm-l3     java-spring-boot  gate=[boundary-gate-jvm.yml]  contract=[ArchitectureTest.java.template]
jvm-l5     java-spring-boot  gate=[boundary-gate-jvm.yml]  contract=[ArchitectureTest.java.template]
go-l4      go-gin            gate=[boundary-gate-go.yml]   contract=[go-arch-lint-reference.yml]
dotnet-l4  dotnet-aspnet     gate=[]                       contract=[]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
