### PR TITLE
feat(ci): boundary enforcement for dotnet-aspnet (#93)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,18 @@ jobs:
       - name: Install go-arch-lint
         run: go install github.com/fe3dback/go-arch-lint@latest
 
+      # tests/test_archunitnet_template.py runs the shipped ArchUnitNET
+      # template against real fixtures. Running it caught a defect no
+      # structural check could: the first draft matched namespaces exactly, so
+      # a violation in Api.Controllers passed silently.
+      - uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # v4.3.1
+        with:
+          dotnet-version: '8.0.x'
+
       - name: Install
         run: pip install -e ".[test]"
 
-      - name: Assert the Node and Go toolchains are present
+      - name: Assert the Node, Go and .NET toolchains are present
         # The reference tests skipif their toolchain is missing, which is right
         # locally but wrong here: a broken setup step would leave the only
         # tests that prove the shipped configs work silently skipped, and CI
@@ -53,6 +61,7 @@ jobs:
           command -v node
           command -v npm
           command -v go
+          command -v dotnet
           test -x "$(go env GOPATH)/bin/go-arch-lint"
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -400,7 +400,8 @@
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "cli":        {
@@ -409,7 +410,8 @@
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -463,7 +465,8 @@
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "cli": {
@@ -480,7 +483,8 @@
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "ui-react": { "governed": [
@@ -523,7 +527,8 @@
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "cli":        {
@@ -532,7 +537,8 @@
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -586,7 +592,8 @@
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "cli": {
@@ -603,7 +610,8 @@
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -422,7 +422,8 @@
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "cli":        {
@@ -431,7 +432,8 @@
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -485,7 +487,8 @@
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "cli": {
@@ -502,7 +505,8 @@
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "ui-react": { "governed": [
@@ -545,7 +549,8 @@
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "cli":        {
@@ -554,7 +559,8 @@
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -608,7 +614,8 @@
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "cli": {
@@ -625,7 +632,8 @@
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "ui-react": { "governed": [

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -404,7 +404,8 @@
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "cli":        {
@@ -413,7 +414,8 @@
               "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/github/repo-scope-check.yml", "ci/github/l3-ui-quality-gate.yml"] },
@@ -467,7 +469,8 @@
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "cli": {
@@ -484,7 +487,8 @@
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/github/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/github/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/github/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/github/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "ui-react": { "governed": [
@@ -527,7 +531,8 @@
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "cli":        {
@@ -536,7 +541,8 @@
               "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
               "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
               "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+              "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+              "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
             }
           },
           "ui-react":   { "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/l3-ui-quality-gate.yml"] },
@@ -590,7 +596,8 @@
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "cli": {
@@ -607,7 +614,8 @@
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
                 "nodejs-fastify": { "governed": ["ci/azure/boundary-gate-node.yml", "governance/backend/dependency-cruiser-reference.cjs"] },
                 "go-gin": { "governed": ["ci/azure/boundary-gate-go.yml", "governance/backend/go-arch-lint-reference.yml"] },
-                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] }
+                "java-spring-boot": { "governed": ["ci/azure/boundary-gate-jvm.yml", "governance/backend/ArchitectureTest.java.template"] },
+                "dotnet-aspnet": { "governed": ["ci/azure/boundary-gate-dotnet.yml", "governance/backend/ArchitectureTest.cs.template"] }
               }
             },
             "ui-react": { "governed": [

--- a/ci/README.md
+++ b/ci/README.md
@@ -36,6 +36,7 @@ Copy the relevant templates for your project type:
 | `boundary-gate-node.yml` | `nodejs-fastify` | `nodejs-fastify` | — | — |
 | `boundary-gate-go.yml` | `go-gin` | `go-gin` | — | — |
 | `boundary-gate-jvm.yml` | `java-spring-boot` | `java-spring-boot` | — | — |
+| `boundary-gate-dotnet.yml` | `dotnet-aspnet` | `dotnet-aspnet` | — | — |
 | `ui-quality-gate.yml` | — | — | ✓ | — |
 | `ui-eval-gate.yml` (L4+) | — | — | ✓ | — |
 | `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
@@ -70,13 +71,16 @@ part of the shared quality gate. govkit installs a boundary gate chosen by
 | `nodejs-fastify` | `boundary-gate-node.yml` | `dependency-cruiser` | `governance/backend/dependency-cruiser-reference.cjs` |
 | `go-gin` | `boundary-gate-go.yml` | `go-arch-lint` | `governance/backend/go-arch-lint-reference.yml` |
 | `java-spring-boot` | `boundary-gate-jvm.yml` | ArchUnit | `governance/backend/ArchitectureTest.java.template` |
-| `dotnet-aspnet` | *none yet* | tracked separately | — |
+| `dotnet-aspnet` | `boundary-gate-dotnet.yml` | ArchUnitNET | `governance/backend/ArchitectureTest.cs.template` |
 
-**The JVM gate has a different shape.** Python, Node and Go get a config file
-and a linter binary. On the JVM the rules *are* test code: govkit ships a
-template you copy into your own test tree, and it runs with `mvn test` /
-`gradle test`. The gate installs no linter — it runs your build, then reads
-the test reports to confirm the architecture test actually executed.
+Every backend stack now has enforcement in a tool that can read its source.
+
+**The JVM and .NET gates have a different shape.** Python, Node and Go get a
+config file and a linter binary. On the JVM and .NET the rules *are* test
+code: govkit ships a template you copy into your own test tree, and it runs
+with `mvn test` / `gradle test` / `dotnet test`. Those gates install no
+linter — they run your build, then read the test reports to confirm the
+architecture test actually executed.
 
 A stack with no gate receives **no boundary workflow at all**, rather than one
 that silently skips. Shipping a Python linter to a Go repo enforces nothing
@@ -105,6 +109,11 @@ Each logs a notice telling you how to enable it.
   `src/test/java/<base>/architecture/ArchitectureTest.java`, drop the
   `.template` suffix, set your base package, and add `archunit-junit5` as a
   test dependency.
+- **.NET** — copy `governance/backend/ArchitectureTest.cs.template` into your
+  test project as `ArchitectureTest.cs`, set your base namespace, point
+  `LoadAssemblies` at the assembly holding your layers, and add
+  `TngTech.ArchUnitNET.xUnit` as a package reference (note the `TngTech.`
+  prefix — plain `ArchUnitNET.xUnit` does not exist on NuGet).
 
 **Confirm your gate analysed something.** Every one of these tools reports
 success on an empty analysis, so a misconfigured contract looks exactly like a
@@ -117,25 +126,33 @@ clean repo:
   dependency-cruiser 17 uses the TypeScript 5.x compiler API.
 - `go-arch-lint` prints `OK - No warnings found` and exits 0 on Go it cannot
   parse, so a syntax error anywhere turns the boundary check green.
-- **ArchUnit** rules that the build never executes — wrong source set, a class
-  name outside the test include pattern, a module missing from the reactor —
-  leave a green build that checked no boundary at all.
+- **ArchUnit / ArchUnitNET** rules that the build never executes — wrong source
+  set, a class name outside the test include pattern, a project missing from
+  the solution or reactor — leave a green build that checked no boundary at
+  all.
+- **ArchUnitNET** matches namespaces *exactly* with `ResideInNamespace`, so a
+  controller in `Api.Controllers` is not in the `Api` layer and a violation
+  there passes. The shipped template uses `ResideInNamespaceMatching` with an
+  explicit `^Base[.]Layer($|[.])` pattern; keep that if you adapt it.
 
 Each gate closes its own hole: the Node gate fails on a zero module count, the
 Go gate runs `go build ./...` first and fails when no file attached to a
-component, and the JVM gate reads the test reports and fails unless
+component, and the JVM and .NET gates read the test reports and fail unless
 `ArchitectureTest` actually ran with a non-zero rule count. If you adapt these
 gates, keep those checks.
 
-**One caveat specific to the JVM.** govkit's own CI runs the real linter
-against generated skeletons for the Python, Node and Go contracts. It does not
-do that for the ArchUnit template — that needs a JVM and Maven on every run,
-for a file that changes rarely — so the template is checked *structurally*:
-that it names all six layers, forbids every edge `BOUNDARIES.md` forbids, and
-keeps one consistent placeholder package. An ArchUnit API misuse that compiles
-and passes vacuously would not be caught. When you adopt it, verify it once
-yourself: introduce a deliberate `api → services` import and confirm the build
-fails.
+**One caveat, specific to the JVM.** govkit's own CI executes the Python,
+Node, Go and .NET contracts against generated fixtures. It does *not* execute
+the ArchUnit (Java) template — that needs a JVM and Maven on every run — so
+that one is checked *structurally*: all six layers named, every forbidden edge
+expressed, one consistent placeholder package. An ArchUnit API misuse that
+compiles and passes vacuously would not be caught there.
+
+That is not hypothetical. The .NET template's first draft used
+`ResideInNamespace`, which matches exactly, and a violation in
+`Api.Controllers` passed silently — a defect found only by running it.
+Whichever template you adopt, verify it once: introduce a deliberate
+`api → services` dependency and confirm the build fails.
 
 ---
 
@@ -155,6 +172,7 @@ in its own stack-selected `boundary-gate-*.yml`, which also ships from L3.
 | `boundary-gate-node.yml` | Architecture boundary enforcement (`nodejs-fastify`) | — |
 | `boundary-gate-go.yml` | Architecture boundary enforcement (`go-gin`) | — |
 | `boundary-gate-jvm.yml` | Architecture boundary enforcement (`java-spring-boot`) | — |
+| `boundary-gate-dotnet.yml` | Architecture boundary enforcement (`dotnet-aspnet`) | — |
 | `quality-gate.yml` | — | Schema validation, contract compatibility, governance artifacts (5) |
 | `eval-gate.yml` | — | FIRST/Virtue prediction thresholds, LLM eval |
 | `ui-quality-gate.yml` | — | Type check, ESLint, component tests, bundle size |

--- a/ci/azure/boundary-gate-dotnet.yml
+++ b/ci/azure/boundary-gate-dotnet.yml
@@ -1,0 +1,86 @@
+# Azure DevOps pipeline — architecture boundary enforcement for the
+# `dotnet-aspnet` stack. Runs ArchUnitNET rules that live in your own test
+# suite, against the hexagonal layer contract described in
+# docs/backend/architecture/BOUNDARIES.md.
+#
+# STAGES:
+#   BoundaryCheck    — runs the project's tests and confirms the ArchUnitNET
+#                      architecture test among them actually executed
+#
+# STACK-SELECTED: govkit installs this file only for `--stack dotnet-aspnet`.
+# See ci/README.md for the per-stack mapping.
+#
+# SHAPE: like the JVM gate and unlike Python/Node/Go, there is no config file
+# and no linter binary. The rules are test code — govkit ships
+# governance/backend/ArchitectureTest.cs.template, you copy it into your test
+# project, and it runs with `dotnet test`.
+#
+# OPT-IN: skips until an ArchitectureTest.cs is present.
+#
+# WHY IT READS THE TEST RESULTS: a test class the build never executes is this
+# stack's silent-pass mode — excluded project, a filter that matches nothing, a
+# test project missing from the solution. `dotnet test` reports success in all
+# three cases, having checked no boundary at all. Passing is not enough; the
+# stage confirms the architecture test ran.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+stages:
+  - stage: BoundaryCheck
+    displayName: Architecture boundary enforcement
+    dependsOn: []
+    jobs:
+      - job: BoundaryCheck
+        displayName: Run ArchUnitNET architecture tests
+        steps:
+          - checkout: self
+
+          - script: |
+              if ! find . -name 'ArchitectureTest.cs' -not -path './bin/*' -not -path './obj/*' | grep -q .; then
+                echo "##vso[task.logissue type=warning]No ArchitectureTest.cs found. Copy governance/backend/ArchitectureTest.cs.template into your test project as ArchitectureTest.cs and set your base namespace to enable boundary enforcement."
+                echo "##vso[task.setvariable variable=archTestFound]false"
+              else
+                echo "##vso[task.setvariable variable=archTestFound]true"
+              fi
+            displayName: Detect ArchUnitNET architecture test
+
+          - task: UseDotNet@2
+            condition: eq(variables['archTestFound'], 'true')
+            displayName: Use .NET 8
+            inputs:
+              packageType: 'sdk'
+              version: '8.0.x'
+
+          - script: |
+              set -euo pipefail
+              dotnet test --nologo --logger "trx;LogFileName=boundary.trx"
+            condition: eq(variables['archTestFound'], 'true')
+            displayName: Run tests
+
+          - script: |
+              set -euo pipefail
+              results=$(find . -name 'boundary.trx' -print)
+              if [ -z "$results" ]; then
+                echo "##vso[task.logissue type=error]No test results were produced. The architecture rules did not run, so no boundary was checked."
+                exit 1
+              fi
+              executed=0
+              for file in $results; do
+                count=$(grep -oE 'testName="[^"]*ArchitectureTest[^"]*"' "$file" | wc -l)
+                executed=$((executed + count))
+              done
+              if [ "$executed" -eq 0 ]; then
+                echo "##vso[task.logissue type=error]The build passed but no ArchitectureTest case appears in the test results. The architecture rules did not run, so no boundary was checked. Confirm the test project is in the solution and that no filter excludes it."
+                exit 1
+              fi
+              echo "ArchitectureTest executed $executed architecture rules."
+            condition: eq(variables['archTestFound'], 'true')
+            displayName: Confirm the architecture test actually ran

--- a/ci/github/boundary-gate-dotnet.yml
+++ b/ci/github/boundary-gate-dotnet.yml
@@ -1,0 +1,85 @@
+# boundary-gate-dotnet.yml
+#
+# PURPOSE: Architecture boundary enforcement for the `dotnet-aspnet` stack.
+# Runs ArchUnitNET rules that live in your own test suite, against the
+# hexagonal layer contract described in docs/backend/architecture/BOUNDARIES.md.
+# Copy this file to .github/workflows/boundary-gate.yml.
+#
+# JOBS:
+#   boundary-check    — runs the project's tests and confirms the ArchUnitNET
+#                       architecture test among them actually executed
+#
+# STACK-SELECTED: govkit installs this file only for `--stack dotnet-aspnet`.
+# See ci/README.md for the per-stack mapping.
+#
+# SHAPE: like the JVM gate and unlike Python/Node/Go, there is no config file
+# and no linter binary. The rules are test code — govkit ships
+# governance/backend/ArchitectureTest.cs.template, you copy it into your test
+# project, and it runs with `dotnet test`.
+#
+# OPT-IN: skips until an ArchitectureTest.cs is present.
+#
+# WHY IT READS THE TEST RESULTS: a test class the build never executes is this
+# stack's silent-pass mode — excluded project, a filter that matches nothing, a
+# test project missing from the solution. `dotnet test` reports success in all
+# three cases, having checked no boundary at all. Passing is not enough; the
+# gate confirms the architecture test ran.
+#
+# REQUIRED SECRETS: none.
+
+name: Boundary Gate (.NET)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  boundary-check:
+    name: Architecture boundary enforcement
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect ArchUnitNET architecture test
+        id: contract
+        run: |
+          if find . -name 'ArchitectureTest.cs' -not -path './bin/*' -not -path './obj/*' \
+             | grep -q .; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No ArchitectureTest.cs found. Copy governance/backend/ArchitectureTest.cs.template into your test project as ArchitectureTest.cs and set your base namespace to enable boundary enforcement."
+          fi
+
+      - uses: actions/setup-dotnet@v4
+        if: steps.contract.outputs.found == 'true'
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Run tests
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          dotnet test --nologo --logger "trx;LogFileName=boundary.trx"
+
+      - name: Confirm the architecture test actually ran
+        if: steps.contract.outputs.found == 'true'
+        run: |
+          set -euo pipefail
+          results=$(find . -name 'boundary.trx' -print)
+          if [ -z "$results" ]; then
+            echo "::error::No test results were produced. The architecture rules did not run, so no boundary was checked."
+            exit 1
+          fi
+          executed=0
+          for file in $results; do
+            count=$(grep -oE 'testName="[^"]*ArchitectureTest[^"]*"' "$file" | wc -l)
+            executed=$((executed + count))
+          done
+          if [ "$executed" -eq 0 ]; then
+            echo "::error::The build passed but no ArchitectureTest case appears in the test results. The architecture rules did not run, so no boundary was checked. Confirm the test project is in the solution and that no filter excludes it."
+            exit 1
+          fi
+          echo "ArchitectureTest executed $executed architecture rules."

--- a/governance/backend/ArchitectureTest.cs.template
+++ b/governance/backend/ArchitectureTest.cs.template
@@ -43,6 +43,11 @@
  *
  * (The JVM template does not need this. ArchUnit's `..api..` package
  * identifier is recursive by construction; ArchUnitNET's string form is not.)
+ *
+ * The flip side of using regexes: your base namespace is interpolated into
+ * them, and a real one contains dots. `Regex.Escape` below keeps them literal.
+ * Without it, a base of `Contoso.Billing` also matches `ContosoXBilling.*`,
+ * and types outside your service get judged against your layer rules.
  * -----------------------------------------------------------------------------
  *
  * VERIFY IT ONCE WHEN YOU ADOPT IT. Point `LoadAssemblies` at the assembly
@@ -57,6 +62,7 @@
  * unconstrained.
  */
 using System.Linq;
+using System.Text.RegularExpressions;
 using ArchUnitNET.Domain;
 using ArchUnitNET.Fluent;
 using ArchUnitNET.Loader;
@@ -70,27 +76,38 @@ public class ArchitectureTest
 {
     private const string BaseNamespace = "MyService";
 
+    // The layer predicates below are regular expressions, and your base
+    // namespace is interpolated into them. Real namespaces contain dots, and
+    // an unescaped `.` matches ANY character: with a base of `Contoso.Billing`,
+    // the pattern `^Contoso.Billing[.]Api($|[.])` also matches
+    // `ContosoXBilling.Api`, so unrelated types get judged as if they were in
+    // your Api layer. Escaping once here keeps every predicate literal.
+    //
+    // Must stay declared above the layer fields — static initialisers run in
+    // declaration order, and they read it.
+    private static readonly string BaseNs = Regex.Escape(BaseNamespace);
+
     private static readonly Architecture Architecture = new ArchLoader()
         .LoadAssemblies(typeof(MyService.Models.Entity).Assembly)
         .Build();
 
     private static readonly IObjectProvider<IType> ApiLayer = Types()
-        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Api($|[.])").As("Api layer");
+        .That().ResideInNamespaceMatching($"^{BaseNs}[.]Api($|[.])").As("Api layer");
 
     private static readonly IObjectProvider<IType> PortsLayer = Types()
-        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Ports($|[.])").As("Ports layer");
+        .That().ResideInNamespaceMatching($"^{BaseNs}[.]Ports($|[.])").As("Ports layer");
 
     private static readonly IObjectProvider<IType> ServicesLayer = Types()
-        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Services($|[.])").As("Services layer");
+        .That().ResideInNamespaceMatching($"^{BaseNs}[.]Services($|[.])").As("Services layer");
 
     private static readonly IObjectProvider<IType> ModelsLayer = Types()
-        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Models($|[.])").As("Models layer");
+        .That().ResideInNamespaceMatching($"^{BaseNs}[.]Models($|[.])").As("Models layer");
 
     private static readonly IObjectProvider<IType> AdaptersLayer = Types()
-        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Adapters($|[.])").As("Adapters layer");
+        .That().ResideInNamespaceMatching($"^{BaseNs}[.]Adapters($|[.])").As("Adapters layer");
 
     private static readonly IObjectProvider<IType> CommonLayer = Types()
-        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Common($|[.])").As("Common layer");
+        .That().ResideInNamespaceMatching($"^{BaseNs}[.]Common($|[.])").As("Common layer");
 
     [Fact]
     public void TheBaseNamespaceResolvesToTypes()

--- a/governance/backend/ArchitectureTest.cs.template
+++ b/governance/backend/ArchitectureTest.cs.template
@@ -1,0 +1,172 @@
+/*
+ * ArchUnitNET reference test for hexagonal architecture enforcement on the
+ * `dotnet-aspnet` stack.
+ *
+ * Copy this file into your own test project, drop the `.template` suffix, and
+ * replace `MyService` with your base namespace:
+ *
+ *     tests/<YourProject>.ArchitectureTests/ArchitectureTest.cs
+ *
+ * Like the JVM stack and unlike Python, Node and Go, there is no config file
+ * here: the architecture rules ARE test code. They live in your suite, compile
+ * with it, and run with `dotnet test`. govkit ships the rules; your build runs
+ * them.
+ *
+ * Dependency (xUnit; TngTech.ArchUnitNET.NUnit and .MSTestV2 also exist):
+ *   <PackageReference Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />
+ *
+ * Note the `TngTech.` prefix — a package called `ArchUnitNET.xUnit` does not
+ * exist on NuGet.
+ *
+ * This test enforces the layering rules defined in:
+ *   docs/backend/architecture/ARCH_CONTRACT.md
+ *   docs/backend/architecture/BOUNDARIES.md
+ *
+ * It expresses the same contract as importlinter-reference.toml (Python),
+ * dependency-cruiser-reference.cjs (Node), go-arch-lint-reference.yml (Go) and
+ * ArchitectureTest.java.template (JVM): `Api` and `Adapters` are independent
+ * siblings above `Services`, above `Ports`, above `Models`, above `Common`,
+ * with `Api -> Services` forbidden.
+ *
+ * -----------------------------------------------------------------------------
+ * WHY THE LAYERS USE ResideInNamespaceMatching AND NOT ResideInNamespace.
+ *
+ * `ResideInNamespace("MyService.Api")` matches that namespace **exactly**. A
+ * controller in `MyService.Api.Controllers` — where ASP.NET projects normally
+ * put them — is not in the Api layer as far as the rule is concerned, so a
+ * violation there passes silently.
+ *
+ * This was reproduced: a `MyService.Api.Controllers.UserController` depending
+ * on `MyService.Services.Core` left the suite green at 8/8. The regex form
+ * below covers the namespace and everything beneath it, and was verified to
+ * catch that same violation while still passing a conforming nested type.
+ *
+ * (The JVM template does not need this. ArchUnit's `..api..` package
+ * identifier is recursive by construction; ArchUnitNET's string form is not.)
+ * -----------------------------------------------------------------------------
+ *
+ * VERIFY IT ONCE WHEN YOU ADOPT IT. Point `LoadAssemblies` at the assembly
+ * holding your layers — the `typeof(...)` below must name a type that actually
+ * lives in it. Then introduce a deliberate `Api -> Services` dependency and
+ * confirm `dotnet test` fails. If it passes, your assembly or base namespace
+ * is wrong, not your architecture.
+ *
+ * COMPOSITION ROOT. Whatever wires adapters into services references both, so
+ * it cannot sit in any layer. `src/Program.cs` and `src/Config/` are where
+ * LAYER_IMPLEMENTATION.md puts it, and these rules deliberately leave both
+ * unconstrained.
+ */
+using System.Linq;
+using ArchUnitNET.Domain;
+using ArchUnitNET.Fluent;
+using ArchUnitNET.Loader;
+using ArchUnitNET.xUnit;
+using Xunit;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace MyService.ArchitectureTests;
+
+public class ArchitectureTest
+{
+    private const string BaseNamespace = "MyService";
+
+    private static readonly Architecture Architecture = new ArchLoader()
+        .LoadAssemblies(typeof(MyService.Models.Entity).Assembly)
+        .Build();
+
+    private static readonly IObjectProvider<IType> ApiLayer = Types()
+        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Api($|[.])").As("Api layer");
+
+    private static readonly IObjectProvider<IType> PortsLayer = Types()
+        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Ports($|[.])").As("Ports layer");
+
+    private static readonly IObjectProvider<IType> ServicesLayer = Types()
+        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Services($|[.])").As("Services layer");
+
+    private static readonly IObjectProvider<IType> ModelsLayer = Types()
+        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Models($|[.])").As("Models layer");
+
+    private static readonly IObjectProvider<IType> AdaptersLayer = Types()
+        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Adapters($|[.])").As("Adapters layer");
+
+    private static readonly IObjectProvider<IType> CommonLayer = Types()
+        .That().ResideInNamespaceMatching($"^{BaseNamespace}[.]Common($|[.])").As("Common layer");
+
+    [Fact]
+    public void TheBaseNamespaceResolvesToTypes()
+    {
+        var matched = Architecture.Types
+            .Count(type => type.FullName.StartsWith(BaseNamespace + "."));
+        Assert.True(matched > 0,
+            "ArchUnitNET loaded no types under " + BaseNamespace + ". The assembly or "
+            + "base namespace is wrong, so every rule below would pass without "
+            + "checking anything.");
+    }
+
+    [Fact]
+    public void ApiMustNotDependOnServices()
+    {
+        Types().That().Are(ApiLayer)
+            .Should().NotDependOnAny(ServicesLayer)
+            .Check(Architecture);
+    }
+
+    [Fact]
+    public void ApiMustNotDependOnAdapters()
+    {
+        Types().That().Are(ApiLayer)
+            .Should().NotDependOnAny(AdaptersLayer)
+            .Check(Architecture);
+    }
+
+    [Fact]
+    public void AdaptersMustNotDependOnApi()
+    {
+        Types().That().Are(AdaptersLayer)
+            .Should().NotDependOnAny(ApiLayer)
+            .Check(Architecture);
+    }
+
+    [Fact]
+    public void ServicesMustNotDependOnAdaptersOrApi()
+    {
+        Types().That().Are(ServicesLayer)
+            .Should().NotDependOnAny(AdaptersLayer).AndShould().NotDependOnAny(ApiLayer)
+            .Check(Architecture);
+    }
+
+    [Fact]
+    public void PortsMustNotDependOnUpperLayers()
+    {
+        Types().That().Are(PortsLayer)
+            .Should().NotDependOnAny(ServicesLayer)
+            .AndShould().NotDependOnAny(AdaptersLayer)
+            .AndShould().NotDependOnAny(ApiLayer)
+            .Check(Architecture);
+    }
+
+    [Fact]
+    public void ModelsMustNotDependOnUpperLayers()
+    {
+        Types().That().Are(ModelsLayer)
+            .Should().NotDependOnAny(PortsLayer)
+            .AndShould().NotDependOnAny(ServicesLayer)
+            .AndShould().NotDependOnAny(AdaptersLayer)
+            .AndShould().NotDependOnAny(ApiLayer)
+            .Check(Architecture);
+    }
+
+    [Fact]
+    public void CommonMustNotDependOnAnyLayer()
+    {
+        Types().That().Are(CommonLayer)
+            .Should().NotDependOnAny(ModelsLayer)
+            .AndShould().NotDependOnAny(PortsLayer)
+            .AndShould().NotDependOnAny(ServicesLayer)
+            .AndShould().NotDependOnAny(AdaptersLayer)
+            .AndShould().NotDependOnAny(ApiLayer)
+            .Check(Architecture);
+    }
+}
+
+

--- a/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
+++ b/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
@@ -352,6 +352,25 @@ The JVM template does not have this problem — ArchUnit's `..api..` package
 identifier is recursive by construction — but that is reasoning, not a test
 run. See Follow-ups.
 
+Moving to regex predicates then introduced a second defect, caught in review:
+the adopter's base namespace is interpolated into those regexes, and a real
+one contains dots. With a base of `Contoso.Billing`, the unescaped
+`^Contoso.Billing[.]Api($|[.])` also matches `ContosoXBilling.Api` — the `.`
+matches the `X` — so unrelated types are judged against the layer rules. The
+template now escapes once with `Regex.Escape`.
+
+The fixtures could not have caught it: they used the `MyService` placeholder,
+which contains no regex metacharacters, so escaped and unescaped behave
+identically. **A fixture that only exercises the placeholder value is a
+fixture that never tests substitution.** There is now a second project fixture
+built on a dotted base namespace, plus a look-alike namespace that only an
+unescaped pattern matches.
+
+This is specific to .NET. It is the only contract that interpolates a
+user-supplied value into a regex — Node and Go have no placeholder, Python's
+is a TOML module name, and the JVM's layer identifiers (`..api..`) carry no
+user value.
+
 Two smaller things the toolchain settled: the NuGet package is
 `TngTech.ArchUnitNET.xUnit` (a bare `ArchUnitNET.xUnit` does not exist and
 fails at restore), and `ResideInNamespace` has no two-argument overload in

--- a/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
+++ b/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
@@ -1,10 +1,17 @@
 # Per-Stack Boundary Enforcement Plan
 
-**Status:** In progress — 2026-08-01. Increments 1-5 are done: stack-selected
+**Status:** Implemented — 2026-08-02, all 6 increments. Stack-selected
 dispatch (#102), stack-agnostic doc wording (#103), Node (#105), Go (#106),
-and the JVM. Four of five stacks now have boundary enforcement in a tool that
-can read them. Remaining: increment 6 (.NET), the same template-and-structural
--assertion shape as the JVM. Covers #93, which closes when it lands.
+JVM (#107), .NET. Closes #93.
+
+All five backend stacks now have boundary enforcement in a tool that can read
+their source, and four of the five contracts are executed against generated
+fixtures in CI. The JVM template is the exception — structural assertions
+only; see Follow-ups.
+
+Follow-ups deliberately left open: **#104** (`ARCH_CONTRACT.md` ships
+Python-specific guidance to every backend stack), and the JVM verification gap
+below.
 
 Every linter adopted so far reports success on an empty analysis, each in its
 own way, and none of them says so. That pattern is now the first thing to test
@@ -321,14 +328,40 @@ pinned by `tests/test_boundary_gate_dispatch.py`.
 
 Commit: `feat(ci): boundary enforcement for java-spring-boot (#93)`
 
-### 6. .NET — ArchUnitNET template
+### 6. .NET — ArchUnitNET template — done
 
-Same shape as increment 5. ArchUnitNET, not NetArchTest — `dotnet-aspnet`'s
-overlay already names it.
+Same shape as increment 5 in what it ships, but **executed**, not merely
+asserted. A .NET SDK turned out to be cheap enough to add to CI where a JVM
+was not, so this template gets the Python/Node/Go treatment:
+`tests/test_archunitnet_template.py` runs `dotnet test` against generated
+fixtures — conforming tree, eleven forbidden edges, and both halves of the
+nested-namespace case.
 
-Also extend `tests/test_layer_vocabulary.py` so every new contract and
-template is checked against the canonical six layer names, as the
-import-linter reference already is.
+**Running it earned its keep immediately.** The first draft used
+`ResideInNamespace("MyService.Api")`, which matches that namespace
+*exactly*. A controller in `MyService.Api.Controllers` — where ASP.NET puts
+them — is not in the Api layer as far as the rule is concerned, so
+`Api.Controllers -> Services` left the suite green at 8/8. The template
+would have under-enforced in essentially every real project, and no
+structural assertion would have found it. It now uses
+`ResideInNamespaceMatching` with an explicit `^Base[.]Layer($|[.])` pattern,
+verified to catch the nested violation while still passing a conforming
+nested type.
+
+The JVM template does not have this problem — ArchUnit's `..api..` package
+identifier is recursive by construction — but that is reasoning, not a test
+run. See Follow-ups.
+
+Two smaller things the toolchain settled: the NuGet package is
+`TngTech.ArchUnitNET.xUnit` (a bare `ArchUnitNET.xUnit` does not exist and
+fails at restore), and `ResideInNamespace` has no two-argument overload in
+0.13.3.
+
+This increment also replaced two tests that had quietly stopped testing.
+`STACKS_WITHOUT_A_GATE` emptied when the last stack landed, and pytest skips
+an empty parametrize — 72 assertions silently stopped running while the
+suite stayed green. They are now completeness invariants over every backend
+stack the manifest offers, which cannot go empty.
 
 Commit: `feat(ci): boundary enforcement for dotnet-aspnet (#93)`
 
@@ -351,6 +384,11 @@ Commit: `feat(ci): boundary enforcement for dotnet-aspnet (#93)`
   | dependency-cruiser | `--output-type json` (always exits 0); TypeScript 7 installed (0 modules) | default reporter + fail on zero modules |
   | go-arch-lint | source does not parse — "OK - No warnings found" | `go build ./...` first + fail on zero mapped files |
   | ArchUnit | the test class is never executed by the build | read the test reports; fail unless it ran with a non-zero rule count |
+  | ArchUnitNET | same, **plus** `ResideInNamespace` matching exactly, so violations one namespace down pass | read the test results; template uses `ResideInNamespaceMatching` |
+
+  The ArchUnitNET row is the strongest argument for executing these
+  contracts rather than asserting their shape. It was found by running the
+  template, and nothing structural would have surfaced it.
 
   Assume the next one has such a mode and go looking for it. A gate that
   cannot fail is worse than no gate, because it reports that the boundary
@@ -386,6 +424,23 @@ Commit: `feat(ci): boundary enforcement for dotnet-aspnet (#93)`
    whether `dependency-cruiser`, `go-arch-lint`, ArchUnit and ArchUnitNET can
    is a question for each increment to answer and record. Where a tool cannot,
    say so in its reference file rather than leaving it implied.
+
+## Follow-ups
+
+- **The JVM template is the only contract govkit does not execute.** Increment
+  5 chose structural assertions because running ArchUnit needs a JVM and Maven
+  in CI. Increment 6 then found a defect in the .NET template that *only*
+  execution could reveal — `ResideInNamespace` matching exactly, so a
+  violation in `Api.Controllers` passed — which raises the prior that
+  something similar is wrong in the Java one.
+
+  The specific risk does not carry over: ArchUnit's `..api..` package
+  identifier is recursive by construction, unlike ArchUnitNET's string form.
+  But that is reasoning, not a test run, and the same was true of the .NET
+  template before it was run.
+
+  `actions/setup-java` plus a Maven fixture would close it, at roughly the
+  cost the .NET fixtures add (~50s). Worth filing.
 
 ## Out of scope
 

--- a/tests/test_archunitnet_template.py
+++ b/tests/test_archunitnet_template.py
@@ -1,0 +1,243 @@
+"""The shipped ArchUnitNET template must actually enforce BOUNDARIES.md.
+
+Unlike the JVM template — which govkit checks structurally, because running
+ArchUnit needs a JVM and Maven — this one is **executed**. `dotnet test` is
+cheap enough to run in CI, and running it earned its keep immediately:
+
+`ResideInNamespace("MyService.Api")` matches that namespace *exactly*. A
+controller in `MyService.Api.Controllers`, where ASP.NET projects normally put
+them, is not in the Api layer as far as the rule is concerned. The first draft
+of the template used it, and a `MyService.Api.Controllers.UserController`
+depending on `MyService.Services.Core` left the suite green at 8/8 — the
+template would have under-enforced in essentially every real project.
+
+No structural assertion would have caught that. It is why
+`test_nested_namespace_violation_is_rejected` below exists, and why the
+template uses `ResideInNamespaceMatching` with an explicit
+`^Base[.]Layer($|[.])` pattern.
+
+Marked `e2e` — these shell out to `dotnet` and are excluded from the fast
+loop. They skip when the SDK is absent; CI asserts it is present so a skip
+cannot pass for a pass there.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE = REPO_ROOT / "governance" / "backend" / "ArchitectureTest.cs.template"
+
+BASE = "MyService"
+LAYERS = ("Api", "Ports", "Services", "Models", "Adapters", "Common")
+
+_DOTNET = shutil.which("dotnet")
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(_DOTNET is None, reason=".NET SDK not installed"),
+]
+
+SRC_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <RootNamespace>MyService</RootNamespace>
+  </PropertyGroup>
+</Project>
+"""
+
+TEST_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TngTech.ArchUnitNET.xUnit" Version="0.13.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/MyService/MyService.csproj" />
+  </ItemGroup>
+</Project>
+"""
+
+# (layer, type name, dependency as (namespace, type)) for the conforming tree.
+CONFORMING = [
+    ("Common", "Log", []),
+    ("Models", "Entity", []),
+    ("Ports", "Repo", [("Models", "Entity")]),
+    ("Services", "Core", [("Ports", "Repo"), ("Models", "Entity")]),
+    ("Adapters", "Db", [("Ports", "Repo"), ("Services", "Core")]),
+    ("Api", "Routes", [("Ports", "Repo")]),
+]
+
+MINIMAL = [(layer, name, []) for layer, name, _ in CONFORMING]
+
+
+def _csharp(namespace: str, name: str, uses: list[tuple[str, str]]) -> str:
+    usings = "".join(f"using {BASE}.{ns};\n" for ns, _ in uses)
+    fields = "".join(f"    private readonly {t}? _{t.lower()};\n" for _, t in uses)
+    return f"{usings}\nnamespace {BASE}.{namespace};\n\npublic class {name}\n{{\n{fields}}}\n"
+
+
+def _write_tree(root: Path, layers, extra: tuple[str, str, tuple[str, str]] | None = None):
+    src = root / "src" / "MyService"
+    if src.exists():
+        shutil.rmtree(src)
+    (src).mkdir(parents=True, exist_ok=True)
+    (src / "MyService.csproj").write_text(SRC_CSPROJ, encoding="utf-8")
+    spec = {layer: (name, list(uses)) for layer, name, uses in layers}
+    if extra:
+        layer, name, dependency = extra
+        spec[layer] = (name, [dependency])
+    for layer, (name, uses) in spec.items():
+        path = src / layer / f"{name}.cs"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_csharp(layer, name, uses), encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def dotnet_project(tmp_path_factory) -> Path:
+    """One restore shared by every case — it is the slow part."""
+    root = tmp_path_factory.mktemp("archunitnet")
+    tests = root / "tests" / "MyService.ArchTests"
+    tests.mkdir(parents=True)
+    (tests / "MyService.ArchTests.csproj").write_text(TEST_CSPROJ, encoding="utf-8")
+    # The template ships with a header comment block; it is valid C# as-is.
+    (tests / "ArchitectureTest.cs").write_text(
+        TEMPLATE.read_text(encoding="utf-8"), encoding="utf-8")
+    _write_tree(root, CONFORMING)
+    result = subprocess.run(
+        [_DOTNET, "restore", "tests/MyService.ArchTests"], cwd=root,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        shell=os.name == "nt",
+    )
+    if result.returncode != 0:
+        message = f"dotnet restore failed: {result.stdout[-400:]}{result.stderr[-400:]}"
+        if os.environ.get("CI"):
+            pytest.fail(message)
+        pytest.skip(f"{message} (offline?)")
+    return root
+
+
+def _dotnet_test(root: Path) -> tuple[int, str]:
+    result = subprocess.run(
+        [_DOTNET, "test", "tests/MyService.ArchTests", "--nologo", "-v", "q"],
+        cwd=root, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", shell=os.name == "nt",
+    )
+    out = (result.stdout or "") + (result.stderr or "")
+    assert out.strip(), "dotnet test produced no output — it did not run"
+    return result.returncode, out
+
+
+def _assert_rules_ran(out: str) -> None:
+    """A run that executed zero tests proves nothing, and `dotnet test`
+    reports success when a filter matches nothing."""
+    match = re.search(r"Total:\s*(\d+)", out)
+    assert match, f"no test count in output:\n{out[-800:]}"
+    assert int(match.group(1)) > 1, (
+        f"only {match.group(1)} test(s) ran — the architecture rules were not "
+        f"picked up:\n{out[-800:]}"
+    )
+
+
+def test_conforming_repo_passes(dotnet_project):
+    _write_tree(dotnet_project, CONFORMING)
+    code, out = _dotnet_test(dotnet_project)
+    _assert_rules_ran(out)
+    assert code == 0, f"conforming repo rejected:\n{out[-1500:]}"
+
+
+@pytest.mark.parametrize(
+    ("label", "layer", "name", "dependency"),
+    [
+        ("Api -> Services", "Api", "Routes", ("Services", "Core")),
+        ("Api -> Adapters", "Api", "Routes", ("Adapters", "Db")),
+        ("Adapters -> Api", "Adapters", "Db", ("Api", "Routes")),
+        ("Services -> Adapters", "Services", "Core", ("Adapters", "Db")),
+        ("Services -> Api", "Services", "Core", ("Api", "Routes")),
+        ("Ports -> Services", "Ports", "Repo", ("Services", "Core")),
+        ("Ports -> Adapters", "Ports", "Repo", ("Adapters", "Db")),
+        ("Models -> Services", "Models", "Entity", ("Services", "Core")),
+        ("Models -> Ports", "Models", "Entity", ("Ports", "Repo")),
+        ("Common -> Models", "Common", "Log", ("Models", "Entity")),
+        ("Common -> Services", "Common", "Log", ("Services", "Core")),
+    ],
+)
+def test_forbidden_edge_is_rejected(dotnet_project, label, layer, name, dependency):
+    _write_tree(dotnet_project, MINIMAL, extra=(layer, name, dependency))
+    code, out = _dotnet_test(dotnet_project)
+    _assert_rules_ran(out)
+    assert code != 0, f"{label} was permitted:\n{out[-1200:]}"
+
+
+def test_nested_namespace_violation_is_rejected(dotnet_project):
+    """The bug this test suite exists for.
+
+    ASP.NET projects put controllers in `Api/Controllers/`, i.e. the
+    `MyService.Api.Controllers` namespace. `ResideInNamespace("MyService.Api")`
+    matches only the exact namespace, so a violation one level down passed
+    silently — 8/8 green on a repo where a controller reached into Services.
+    """
+    _write_tree(dotnet_project, CONFORMING)
+    nested = dotnet_project / "src" / "MyService" / "Api" / "Controllers"
+    nested.mkdir(parents=True, exist_ok=True)
+    (nested / "UserController.cs").write_text(
+        _csharp("Api.Controllers", "UserController", [("Services", "Core")]),
+        encoding="utf-8",
+    )
+    code, out = _dotnet_test(dotnet_project)
+    _assert_rules_ran(out)
+    assert code != 0, (
+        "a violation in a nested namespace was not caught — the layer "
+        f"predicates are matching exact namespaces only:\n{out[-1200:]}"
+    )
+
+
+def test_nested_namespace_conforming_type_still_passes(dotnet_project):
+    """The other half: covering sub-namespaces must not create false
+    positives on allowed edges."""
+    _write_tree(dotnet_project, CONFORMING)
+    nested = dotnet_project / "src" / "MyService" / "Api" / "Controllers"
+    nested.mkdir(parents=True, exist_ok=True)
+    (nested / "UserController.cs").write_text(
+        _csharp("Api.Controllers", "UserController", [("Ports", "Repo")]),
+        encoding="utf-8",
+    )
+    code, out = _dotnet_test(dotnet_project)
+    _assert_rules_ran(out)
+    assert code == 0, f"a conforming nested type was rejected:\n{out[-1200:]}"
+
+
+def test_template_uses_recursive_namespace_matching():
+    """Structural guard that runs without the SDK, so the regression above
+    is visible in the fast loop too."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    body = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("*")
+    )
+    for layer in LAYERS:
+        assert f"[.]{layer}($|[.])" in body, (
+            f"the {layer} layer predicate does not cover sub-namespaces; "
+            "an exact ResideInNamespace match misses Api.Controllers and the like"
+        )
+    assert "ResideInNamespace(" not in body, (
+        "the exact-match overload matches only the named namespace — use "
+        "ResideInNamespaceMatching with an explicit pattern"
+    )
+
+
+def test_template_names_the_real_nuget_package():
+    """`ArchUnitNET.xUnit` does not exist on NuGet; the package is published
+    under `TngTech.`. A template naming the wrong one fails at restore."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "TngTech.ArchUnitNET.xUnit" in text
+    assert not re.search(r'(?<!TngTech\.)"ArchUnitNET\.xUnit"', text)

--- a/tests/test_archunitnet_template.py
+++ b/tests/test_archunitnet_template.py
@@ -33,6 +33,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE = REPO_ROOT / "governance" / "backend" / "ArchitectureTest.cs.template"
 
 BASE = "MyService"
+# A realistic base namespace: it contains a dot, which is a regex
+# metacharacter. `MyService` does not, so it cannot exercise the escaping the
+# layer predicates rely on.
+DOTTED_BASE = "Contoso.Billing"
+# Differs from DOTTED_BASE only where its dot is — so an unescaped pattern
+# matches it and an escaped one does not.
+LOOKALIKE_NAMESPACE = "ContosoXBilling"
 LAYERS = ("Api", "Ports", "Services", "Models", "Adapters", "Common")
 
 _DOTNET = shutil.which("dotnet")
@@ -81,13 +88,26 @@ CONFORMING = [
 MINIMAL = [(layer, name, []) for layer, name, _ in CONFORMING]
 
 
-def _csharp(namespace: str, name: str, uses: list[tuple[str, str]]) -> str:
-    usings = "".join(f"using {BASE}.{ns};\n" for ns, _ in uses)
+def _csharp(namespace: str, name: str, uses: list[tuple[str, str]], base: str = BASE) -> str:
+    """A class in `<base>.<namespace>`, referencing types in sibling layers.
+
+    `uses` entries are (layer, type) relative to `base`. Pass an absolute
+    namespace by prefixing it with `!` — needed for the look-alike namespace
+    that must sit *outside* the base.
+    """
+    def resolve(ns: str) -> str:
+        return ns[1:] if ns.startswith("!") else f"{base}.{ns}"
+
+    usings = "".join(f"using {resolve(ns)};\n" for ns, _ in uses)
     fields = "".join(f"    private readonly {t}? _{t.lower()};\n" for _, t in uses)
-    return f"{usings}\nnamespace {BASE}.{namespace};\n\npublic class {name}\n{{\n{fields}}}\n"
+    full = resolve(namespace) if namespace.startswith("!") else f"{base}.{namespace}"
+    return f"{usings}\nnamespace {full};\n\npublic class {name}\n{{\n{fields}}}\n"
 
 
-def _write_tree(root: Path, layers, extra: tuple[str, str, tuple[str, str]] | None = None):
+def _write_tree(
+    root: Path, layers, extra: tuple[str, str, tuple[str, str]] | None = None,
+    base: str = BASE, decoys: list[tuple[str, str, list]] | None = None,
+):
     src = root / "src" / "MyService"
     if src.exists():
         shutil.rmtree(src)
@@ -100,20 +120,29 @@ def _write_tree(root: Path, layers, extra: tuple[str, str, tuple[str, str]] | No
     for layer, (name, uses) in spec.items():
         path = src / layer / f"{name}.cs"
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(_csharp(layer, name, uses), encoding="utf-8")
+        path.write_text(_csharp(layer, name, uses, base), encoding="utf-8")
+    for namespace, name, uses in decoys or []:
+        path = src / "_decoys" / f"{name}.cs"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(_csharp(namespace, name, uses, base), encoding="utf-8")
 
 
-@pytest.fixture(scope="module")
-def dotnet_project(tmp_path_factory) -> Path:
-    """One restore shared by every case — it is the slow part."""
-    root = tmp_path_factory.mktemp("archunitnet")
+def _make_project(tmp_path_factory, base: str, slug: str) -> Path:
+    """A restored project with the template adapted to `base`.
+
+    Substituting the placeholder is exactly the step adopters perform, so the
+    file under test is the file they would end up with.
+    """
+    root = tmp_path_factory.mktemp(slug)
     tests = root / "tests" / "MyService.ArchTests"
     tests.mkdir(parents=True)
     (tests / "MyService.ArchTests.csproj").write_text(TEST_CSPROJ, encoding="utf-8")
     # The template ships with a header comment block; it is valid C# as-is.
-    (tests / "ArchitectureTest.cs").write_text(
-        TEMPLATE.read_text(encoding="utf-8"), encoding="utf-8")
-    _write_tree(root, CONFORMING)
+    template = TEMPLATE.read_text(encoding="utf-8")
+    if base != BASE:
+        template = template.replace(BASE, base)
+    (tests / "ArchitectureTest.cs").write_text(template, encoding="utf-8")
+    _write_tree(root, CONFORMING, base=base)
     result = subprocess.run(
         [_DOTNET, "restore", "tests/MyService.ArchTests"], cwd=root,
         capture_output=True, text=True, encoding="utf-8", errors="replace",
@@ -125,6 +154,22 @@ def dotnet_project(tmp_path_factory) -> Path:
             pytest.fail(message)
         pytest.skip(f"{message} (offline?)")
     return root
+
+
+@pytest.fixture(scope="module")
+def dotnet_project(tmp_path_factory) -> Path:
+    """One restore shared by every case — it is the slow part."""
+    return _make_project(tmp_path_factory, BASE, "archunitnet")
+
+
+@pytest.fixture(scope="module")
+def dotted_project(tmp_path_factory) -> Path:
+    """A base namespace containing a dot, which is the realistic case.
+
+    `MyService` has no regex metacharacters, so the placeholder alone cannot
+    exercise the pattern-escaping the layer predicates depend on.
+    """
+    return _make_project(tmp_path_factory, DOTTED_BASE, "archunitnet-dotted")
 
 
 def _dotnet_test(root: Path) -> tuple[int, str]:
@@ -215,6 +260,74 @@ def test_nested_namespace_conforming_type_still_passes(dotnet_project):
     code, out = _dotnet_test(dotnet_project)
     _assert_rules_ran(out)
     assert code == 0, f"a conforming nested type was rejected:\n{out[-1200:]}"
+
+
+class TestDottedBaseNamespace:
+    """The layer predicates are regexes built from the adopter's namespace.
+
+    `MyService` is the placeholder, and it happens to contain no regex
+    metacharacters — so every test above passes whether or not the pattern is
+    escaped. Real base namespaces are dotted (`Contoso.Billing`,
+    `Company.Product`), and an unescaped `.` matches any character.
+    """
+
+    def test_a_real_violation_is_still_rejected(self, dotted_project):
+        """Escaping must not break enforcement for the common case."""
+        _write_tree(
+            dotted_project, MINIMAL, base=DOTTED_BASE,
+            extra=("Api", "Routes", ("Services", "Core")),
+        )
+        code, out = _dotnet_test(dotted_project)
+        _assert_rules_ran(out)
+        assert code != 0, (
+            f"Api -> Services was permitted under a dotted base namespace:\n{out[-1200:]}"
+        )
+
+    def test_a_lookalike_namespace_is_not_treated_as_a_layer(self, dotted_project):
+        """The regression this class exists for.
+
+        With base `Contoso.Billing`, an unescaped `^Contoso.Billing[.]Api($|[.])`
+        also matches `ContosoXBilling.Api` — the `.` matches the `X`. Types in
+        an unrelated namespace are then judged as if they were in the Api
+        layer, and this conforming tree fails on a boundary it does not cross.
+
+        A false positive rather than a false negative, but the same root
+        cause, and the one that is observable: it makes the gate reject repos
+        that comply.
+        """
+        _write_tree(
+            dotted_project, CONFORMING, base=DOTTED_BASE,
+            decoys=[(
+                f"!{LOOKALIKE_NAMESPACE}.Api", "Helper", [("Services", "Core")],
+            )],
+        )
+        code, out = _dotnet_test(dotted_project)
+        _assert_rules_ran(out)
+        assert code == 0, (
+            f"{LOOKALIKE_NAMESPACE}.Api was matched by the {DOTTED_BASE} layer "
+            "predicates — the namespace is being interpolated into a regex "
+            f"without Regex.Escape:\n{out[-1500:]}"
+        )
+
+
+def test_template_escapes_the_base_namespace_before_matching():
+    """Structural guard for the same defect, so it is visible in the fast loop
+    and on machines without a .NET SDK."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    body = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("*")
+    )
+    assert "Regex.Escape" in body, (
+        "the base namespace is interpolated into the layer regexes unescaped; "
+        "a dotted namespace such as Contoso.Billing then matches unintended "
+        "namespaces"
+    )
+    assert "using System.Text.RegularExpressions;" in body, (
+        "Regex.Escape needs System.Text.RegularExpressions"
+    )
+    assert not re.search(r'ResideInNamespaceMatching\(\$"\^\{BaseNamespace\}', body), (
+        "layer predicates must build on the escaped name, not BaseNamespace"
+    )
 
 
 def test_template_uses_recursive_namespace_matching():

--- a/tests/test_boundary_gate_dispatch.py
+++ b/tests/test_boundary_gate_dispatch.py
@@ -31,6 +31,9 @@ BACKEND_TYPES = ("api", "cli")
 LEVELS = ("3", "4", "5")
 
 PYTHON_STACK = "python-fastapi"
+# Offered under options.stack but not backend stacks — they use medallion/dbt
+# layering, and `data` installs receive no hexagonal boundary gate.
+DATA_STACKS = {"python-dbt", "databricks-lakehouse"}
 
 # Stacks whose boundary tool govkit ships enforcement for, and the gate file
 # each receives. Grows by one per increment of the per-stack plan.
@@ -39,10 +42,12 @@ STACK_GATES = {
     "nodejs-fastify": "boundary-gate-node.yml",
     "go-gin": "boundary-gate-go.yml",
     "java-spring-boot": "boundary-gate-jvm.yml",
+    "dotnet-aspnet": "boundary-gate-dotnet.yml",
 }
-STACKS_WITHOUT_A_GATE = (
-    "dotnet-aspnet",
-)
+# Empty since increment 6 (#93): every backend stack now has enforcement in a
+# tool that can read it. Kept so the invariant survives a new stack being
+# added without one.
+STACKS_WITHOUT_A_GATE = ()
 
 # The reference contract each gate tells the team to copy in. It has to ship
 # with the gate: a gate whose notice names a file the install never received
@@ -52,6 +57,7 @@ STACK_REFERENCES = {
     "nodejs-fastify": "governance/backend/dependency-cruiser-reference.cjs",
     "go-gin": "governance/backend/go-arch-lint-reference.yml",
     "java-spring-boot": "governance/backend/ArchitectureTest.java.template",
+    "dotnet-aspnet": "governance/backend/ArchitectureTest.cs.template",
 }
 _ALL_REFERENCES = set(STACK_REFERENCES.values())
 
@@ -108,20 +114,36 @@ class TestPythonBoundaryGateDispatch:
 
     @pytest.mark.parametrize("agent", AGENTS)
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
-    @pytest.mark.parametrize("project_type", BACKEND_TYPES)
-    @pytest.mark.parametrize("level", LEVELS)
-    @pytest.mark.parametrize("stack", STACKS_WITHOUT_A_GATE)
-    def test_a_stack_with_no_boundary_tooling_receives_no_gate(
-        self, agent, ci, project_type, level, stack,
-    ):
-        """Shipping nothing is the honest state — a Python linter pointed at
-        Go enforces nothing whether it fails or skips."""
-        governed = _governed(agent, ci, project_type, level, stack)
+    def test_every_backend_stack_is_accounted_for(self, agent, ci):
+        """Completeness, replacing the old "these stacks get nothing" test.
 
-        assert _boundary_gates(governed, ci) == [], (
-            f"{agent} {project_type} L{level} ({ci}, {stack}) must receive no "
-            f"boundary gate until {stack} has enforcement of its own"
+        That test parametrized over the stacks still awaiting a tool. Once the
+        last one landed the parameter set went empty, and pytest skips an empty
+        parametrize — 72 assertions silently stopped running while the suite
+        stayed green. An invariant that evaporates when it succeeds is the same
+        vacuous pass these gates exist to prevent.
+
+        This asserts the property that actually matters and cannot go empty:
+        every backend stack the manifest offers either has enforcement wired,
+        or is listed as deliberately without it. Adding a stack fails here
+        until one or the other is true.
+        """
+        manifest = load_manifest(agent)
+        offered = set(manifest["options"]["stack"]["choices"]) - DATA_STACKS
+
+        unaccounted = offered - set(STACK_GATES) - set(STACKS_WITHOUT_A_GATE)
+        assert not unaccounted, (
+            f"{agent}: backend stack(s) {sorted(unaccounted)} have neither a "
+            "boundary gate nor an entry in STACKS_WITHOUT_A_GATE. Wire one, or "
+            "record the gap deliberately."
         )
+
+        for stack in sorted(STACKS_WITHOUT_A_GATE):
+            governed = _governed(agent, ci, "api", "4", stack)
+            assert _boundary_gates(governed, ci) == [], (
+                f"{agent} api L4 ({ci}, {stack}) is recorded as having no "
+                f"boundary tooling but received {_boundary_gates(governed, ci)}"
+            )
 
     @pytest.mark.parametrize("agent", AGENTS)
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
@@ -183,20 +205,24 @@ class TestBoundaryReferenceDispatch:
 
     @pytest.mark.parametrize("agent", AGENTS)
     @pytest.mark.parametrize("ci", CI_FLAVOURS)
-    @pytest.mark.parametrize("project_type", BACKEND_TYPES)
-    @pytest.mark.parametrize("level", LEVELS)
-    @pytest.mark.parametrize("stack", STACKS_WITHOUT_A_GATE)
-    def test_stack_without_a_gate_receives_no_reference(
-        self, agent, ci, project_type, level, stack,
-    ):
+    def test_no_stack_receives_another_stacks_reference(self, agent, ci):
         """A Go team receiving a Python import-linter contract is the same
-        defect as receiving a Python linter job."""
-        governed = set(_governed(agent, ci, project_type, level, stack))
+        defect as receiving a Python linter job.
 
-        assert governed & _ALL_REFERENCES == set(), (
-            f"{agent} {project_type} L{level} ({ci}, {stack}) must receive no "
-            f"boundary reference; got {sorted(governed & _ALL_REFERENCES)}"
-        )
+        Stated over every backend stack rather than only the ones still
+        awaiting a tool, so it keeps testing something now that all five are
+        wired.
+        """
+        manifest = load_manifest(agent)
+        offered = sorted(set(manifest["options"]["stack"]["choices"]) - DATA_STACKS)
+
+        for stack in offered:
+            governed = set(_governed(agent, ci, "api", "4", stack))
+            expected = {STACK_REFERENCES[stack]} if stack in STACK_REFERENCES else set()
+            assert governed & _ALL_REFERENCES == expected, (
+                f"{agent} api L4 ({ci}, {stack}) received "
+                f"{sorted(governed & _ALL_REFERENCES)}, expected {sorted(expected)}"
+            )
 
     @pytest.mark.parametrize("reference", sorted(_ALL_REFERENCES))
     def test_reference_file_exists(self, reference):


### PR DESCRIPTION
Increment 6 of `plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md`, the last one. **Closes #93.**

All five backend stacks now have boundary enforcement in a tool that can read their source — closing the gap this plan opened with, where four stacks shipped `BOUNDARIES.md` and `ARCH_CONTRACT.md` while the only gate ran a Python linter.

## Executing this one caught a defect that structural checks never would

A .NET SDK turned out cheap enough to put in CI where a JVM wasn't, so this template is **executed** against fixtures rather than only asserted. It paid for itself on the first run.

The first draft used `ResideInNamespace("MyService.Api")`, which matches that namespace **exactly**. A controller in `MyService.Api.Controllers` — where ASP.NET puts them — isn't in the Api layer as far as the rule is concerned:

```
Api.Controllers.UserController  ->  Services.Core
Passed!  - Failed: 0, Passed: 8
```

A real violation, suite green. The template would have under-enforced in essentially every real .NET project, and no amount of "does it name all six layers" would have surfaced it. It now uses `ResideInNamespaceMatching` with an explicit `^Base[.]Layer($|[.])` pattern — verified to reject that nested violation *and* still accept a conforming nested type, so the fix doesn't trade a false negative for a false positive.

Two more things the toolchain settled rather than its docs: the NuGet package is **`TngTech.ArchUnitNET.xUnit`** (a bare `ArchUnitNET.xUnit` doesn't exist and fails at restore), and `ResideInNamespace` has no two-argument overload in 0.13.3.

Five tools, five distinct vacuous-pass modes, none documented:

| Tool | Passes vacuously when |
|---|---|
| import-linter | `root_package` names a directory, not a package |
| dependency-cruiser | `--output-type json`; or TypeScript 7 installed |
| go-arch-lint | source doesn't parse |
| ArchUnit | the test class is never executed |
| **ArchUnitNET** | same, **plus** exact-namespace matching missing violations one level down |

## Two tests had quietly stopped testing

`STACKS_WITHOUT_A_GATE` emptied when the last stack landed. pytest **skips an empty parametrize**, so 72 assertions silently stopped running while the suite stayed green — the same vacuous pass these gates exist to prevent, in my own test file.

Both are now completeness invariants over every backend stack the manifest offers: each must have a gate wired or be recorded as deliberately without one, and no stack may receive another stack's contract. Neither can go empty. Adding a sixth stack fails until it's accounted for.

## Verification

`tests/test_archunitnet_template.py` — 16 cases running real `dotnet test`: conforming tree, 11 forbidden edges, and both halves of the nested-namespace case. ~48s.

`./full_test`: 1979 fast + 131 e2e passed, 1 skipped, no skips in the dispatch suite.

Real `govkit apply` across all five stacks:

```
py       python-fastapi    L3 github  gate=[boundary-gate-python.yml] contract=[importlinter-reference.toml]
node     nodejs-fastify    L4 github  gate=[boundary-gate-node.yml]   contract=[dependency-cruiser-reference.cjs]
go       go-gin            L5 azure   gate=[boundary-gate-go.yml]     contract=[go-arch-lint-reference.yml]
jvm      java-spring-boot  L4 github  gate=[boundary-gate-jvm.yml]    contract=[ArchitectureTest.java.template]
dotnet   dotnet-aspnet     L3 azure   gate=[boundary-gate-dotnet.yml] contract=[ArchitectureTest.cs.template]
dotnet5  dotnet-aspnet     L5 github  gate=[boundary-gate-dotnet.yml] contract=[ArchitectureTest.cs.template]
```

## Follow-up worth filing

**The JVM template is now the only contract govkit does not execute.** The specific ArchUnitNET defect doesn't carry over — ArchUnit's `..api..` identifier is recursive by construction — but that's reasoning, and the same was true of the .NET template right up until it was run. `actions/setup-java` plus a Maven fixture closes it at roughly what the .NET fixtures cost (~50s). Recorded under Follow-ups in the plan; say the word and I'll file and do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
