### PR TITLE
docs(backend): keep stack-agnostic backend docs stack-neutral (#104)

### DIFF
--- a/docs/backend/architecture/ARCH_CONTRACT.md
+++ b/docs/backend/architecture/ARCH_CONTRACT.md
@@ -20,14 +20,16 @@ This codebase follows Hexagonal Architecture (also known as Ports and Adapters).
   (entities and value objects). There is no `domain/` wrapper package.
 * Use cases are expressed as inbound ports (`ports/inbound/`) and
   implemented by services — they are not a separate folder.
-* Must have no external dependencies other than standard Python and `typing`
+* Must have no external dependencies beyond your language's standard library
+  and its type system
 * All logic must be framework-agnostic and testable in isolation
 
 ### Ports
 
 * Inbound ports: defined in `ports/inbound/` (e.g., `UserServicePort`)
 * Outbound ports: defined in `ports/outbound/` (e.g., `UserRepositoryPort`)
-* All ports are pure Python interfaces (ABC or `Protocol`)
+* All ports are pure interfaces, declared with whatever your language uses for
+  them — see `LAYER_IMPLEMENTATION.md` for your stack's form
 
 ### Adapters
 
@@ -45,14 +47,14 @@ This codebase follows Hexagonal Architecture (also known as Ports and Adapters).
 
 ## 4. Dependencies
 
-* Approved libraries:
+* Approved libraries are listed per stack in `TECH_STACK.md`, which is the
+  authority on what this project may depend on. The constraint this contract
+  places on them is structural, not a list of names:
 
-  * Domain: standard Python, Pydantic (for type safety)
-  * Adapters:
-
-    * HTTP: FastAPI
-    * DB: SQLAlchemy, Redis client
-    * External APIs: `httpx`, `boto3`
+  * Domain: standard library and type-modelling only. No framework, no I/O
+    client, no ORM.
+  * Adapters: the HTTP framework, database and external-API clients your
+    stack names — confined to `adapters/` and `api/`
 * No circular imports
 * Third-party libraries in the domain layer require an ADR
 
@@ -79,7 +81,8 @@ Location: `docs/backend/architecture/ADR/`
 
 * Auth and identity are implemented in adapters
 * All JWT validation and permission checks must occur before domain logic is invoked
-* Secrets and config must use environment variables via `BaseSettings`
+* Secrets and config must come from environment variables, loaded through
+  your stack's typed settings mechanism (see `TECH_STACK.md`)
 * No logging of credentials, tokens, or PII
 
 ## 8. Observability

--- a/docs/backend/architecture/BOUNDARIES.md
+++ b/docs/backend/architecture/BOUNDARIES.md
@@ -82,7 +82,7 @@ CI will fail on:
 
 * Forbidden imports
 * Port-to-implementation coupling
-* Leaky abstractions (e.g. domain uses SQLAlchemy)
+* Leaky abstractions (e.g. the domain depending on your ORM or HTTP client)
 
 Resolution requires either:
 

--- a/docs/backend/architecture/CLI_CONVENTIONS.md
+++ b/docs/backend/architecture/CLI_CONVENTIONS.md
@@ -2,6 +2,13 @@
 
 Applies to all inbound adapter files under `/cli/**` or `/commands/**`. CLI commands are responsible for user interaction concerns only. All domain logic must be delegated to inbound ports.
 
+> **Code examples in this document are illustrative.** They are written in
+> one language to keep them concrete; the rules around them are
+> stack-agnostic and apply to every backend stack. For your stack's
+> libraries and idioms see [TECH_STACK.md](TECH_STACK.md) and
+> [LAYER_IMPLEMENTATION.md](LAYER_IMPLEMENTATION.md), which govkit installs
+> per stack.
+
 ---
 
 ## 0. Interaction with Domain
@@ -115,7 +122,7 @@ except Exception as e:
   2. **Environment variables** (`GOVKIT_OPTION=value`)
   3. **Config files** (TOML or YAML, e.g., `govkit.toml`, `.govkit.yaml`)
 
-* Use `pydantic.BaseSettings` for configuration models with env var support
+* Use a typed settings model with environment-variable support (see `TECH_STACK.md`)
 * Store secrets only in environment variables — never in config files
 * Provide a `govkit config show` or equivalent command to display resolved configuration (redacting secrets)
 * Document all configuration options and their sources

--- a/docs/backend/architecture/CROSS_CUTTING_CONCERNS.md
+++ b/docs/backend/architecture/CROSS_CUTTING_CONCERNS.md
@@ -4,6 +4,13 @@ This document defines patterns for concerns that span multiple layers of the hex
 
 See also: [ARCH_CONTRACT.md](ARCH_CONTRACT.md), [BOUNDARIES.md](BOUNDARIES.md)
 
+> **Code examples in this document are illustrative.** They are written in
+> one language to keep them concrete; the rules around them are
+> stack-agnostic and apply to every backend stack. For your stack's
+> libraries and idioms see [TECH_STACK.md](TECH_STACK.md) and
+> [LAYER_IMPLEMENTATION.md](LAYER_IMPLEMENTATION.md), which govkit installs
+> per stack.
+
 ---
 
 ## 1. Data Transfer Objects (DTOs)
@@ -20,7 +27,7 @@ See also: [ARCH_CONTRACT.md](ARCH_CONTRACT.md), [BOUNDARIES.md](BOUNDARIES.md)
 ### Rules
 
 - Request and response models are **API-layer concerns** — domain code must not import them
-- Domain models are **plain Python dataclasses or Pydantic models** with no framework dependencies
+- Domain models are **plain data types of your language** with no framework dependencies
 - Adapters convert between persistence models and domain models — this conversion lives in the adapter
 - Never pass a request model directly to a domain service — map to domain types at the API boundary
 - Never return a domain model directly as an HTTP response — map to a response model at the API boundary
@@ -41,22 +48,22 @@ HTTP Response ← Response Model (API) ← Domain Model (Service)
 
 | Validation Type | Layer | Mechanism |
 |---|---|---|
-| Request schema validation | API | Pydantic models (automatic via FastAPI) |
+| Request schema validation | API | Your framework's request-model validation |
 | Business rule validation | Domain (services) | Domain logic raises `ValidationError` |
 | Persistence constraints | Adapter | Database constraints, caught and re-raised as domain exceptions |
 
 ### Rules
 
-- Schema validation (field types, required fields, format) is handled by Pydantic at the API boundary — domain code does not re-validate these
+- Schema validation (field types, required fields, format) is handled at the API boundary — domain code does not re-validate these
 - Business rule validation (e.g., "schema version must be > previous version") lives in domain services
 - Domain services raise `ValidationError` for business rule violations (see [ERROR_MAPPING.md](ERROR_MAPPING.md))
 - Adapters catch constraint violations (unique key, foreign key) and re-raise as domain exceptions (`ConflictError`, `ValidationError`)
 
 ### Anti-patterns
 
-- Validating field types in domain services (Pydantic already did this)
+- Validating field types in domain services (the API boundary already did this)
 - Catching database constraint errors in domain services (adapter responsibility)
-- Adding business rules to Pydantic validators (leaks domain logic into API layer)
+- Adding business rules to request-schema validators (leaks domain logic into the API layer)
 
 ---
 
@@ -179,6 +186,6 @@ If audit logging is required (determined by compliance requirements):
 
 - Configuration is loaded at application startup in the composition root — not in domain services
 - Domain services receive configuration values via constructor injection
-- Use Pydantic `BaseSettings` for environment-based configuration
+- Use a typed settings model for environment-based configuration (see `TECH_STACK.md`)
 - Secrets must not appear in logs, error messages, or API responses
 - Feature flags (if used) are injected as a port — domain code calls the port, not a feature flag library

--- a/docs/backend/architecture/ERROR_MAPPING.md
+++ b/docs/backend/architecture/ERROR_MAPPING.md
@@ -4,6 +4,13 @@ This document defines how domain exceptions map to HTTP responses at the API ada
 
 See also: [API_CONVENTIONS.md](API_CONVENTIONS.md), [ARCH_CONTRACT.md](ARCH_CONTRACT.md)
 
+> **Code examples in this document are illustrative.** They are written in
+> one language to keep them concrete; the rules around them are
+> stack-agnostic and apply to every backend stack. For your stack's
+> libraries and idioms see [TECH_STACK.md](TECH_STACK.md) and
+> [LAYER_IMPLEMENTATION.md](LAYER_IMPLEMENTATION.md), which govkit installs
+> per stack.
+
 ---
 
 ## 1. Principle
@@ -101,7 +108,7 @@ async def domain_exception_handler(request: Request, exc: DomainError) -> JSONRe
 - The API layer maps domain exceptions to HTTP responses — domain code does not choose status codes
 - Every domain exception must have a corresponding entry in the mapping table above
 - New exception types require updating this document and the exception handler
-- `ValidationError` is for domain-level validation (business rules), not for request schema validation (which FastAPI handles via Pydantic)
+- `ValidationError` is for domain-level validation (business rules), not for request schema validation, which your HTTP framework handles at the boundary
 - Never expose stack traces or internal paths in error responses
 - Log the full exception (including stack trace) server-side via the observability port
 

--- a/docs/backend/architecture/REPO_STRUCTURE_README.md
+++ b/docs/backend/architecture/REPO_STRUCTURE_README.md
@@ -45,7 +45,7 @@ Where:
 
 | Folder | Purpose |
 |------|------|
-| `api/` | HTTP or inbound adapters (FastAPI, webhooks, etc.) |
+| `api/` | HTTP or inbound adapters (your web framework, webhooks, etc.) |
 | `ports/` | inbound and outbound interfaces for hexagonal architecture |
 | `services/` | domain behaviour and orchestration |
 | `models/` | domain entities and value objects |
@@ -62,7 +62,7 @@ This keeps application code isolated from governance artifacts such as:
 Benefits of the `src/<project_package_name>` layout:
 
 - prevents accidental imports from the project root
-- supports Python packaging best practices
+- supports your language's packaging conventions
 - allows multiple services to reuse the governance kit
 - keeps governance artifacts separate from runtime code
 
@@ -219,7 +219,7 @@ api/
 
 Responsibilities:
 
-- FastAPI route handlers
+- HTTP route handlers
 - authentication enforcement
 - request/response mapping
 - calling inbound ports
@@ -244,7 +244,7 @@ Inbound ports define **how the system is invoked**.
 
 Outbound ports define **external capabilities required by the domain**.
 
-Ports are pure Python interfaces.
+Ports are pure interfaces.
 
 ---
 

--- a/docs/backend/evaluation/EVAL_STACK.md
+++ b/docs/backend/evaluation/EVAL_STACK.md
@@ -170,7 +170,7 @@ LANGFUSE_HOST=...               # Self-hosted or cloud URL
 TRACELOOP_BASE_URL=...          # OTel collector endpoint
 ```
 
-Secrets must use `BaseSettings` — never hardcoded.
+Secrets must come from your stack's typed settings mechanism — never hardcoded.
 
 ---
 

--- a/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
+++ b/plans/PER_STACK_BOUNDARY_ENFORCEMENT_PLAN.md
@@ -9,8 +9,8 @@ their source, and **all five contracts are executed** against generated
 fixtures in CI — the JVM one since #109, which reversed increment 5's
 structural-only trade.
 
-Follow-up still open: **#104** (`ARCH_CONTRACT.md` ships Python-specific
-guidance to every backend stack).
+Follow-ups from this plan are all closed: **#109** (execute the ArchUnit
+template) and **#104** (stack-agnostic docs shipping Python-specific rules).
 
 Every linter adopted so far reports success on an empty analysis, each in its
 own way, and none of them says so. That pattern is now the first thing to test
@@ -499,7 +499,13 @@ Commit: `feat(ci): boundary enforcement for dotnet-aspnet (#93)`
   approved libraries as Pydantic, FastAPI, SQLAlchemy, `httpx` and `boto3`
   (`:49-54`), and secrets via Pydantic's `BaseSettings` (`:81`). A `go-gin`
   install reads all of that, and §10 tells agents to cite this contract when
-  generating code. Filed as **#104**.
+  generating code. Filed as **#104**, and **fixed there** — the audit found
+  the leak was six docs and 30 normative statements, not one doc. Rules now
+  defer to `TECH_STACK.md`; the Python code examples in
+  `CROSS_CUTTING_CONCERNS.md`, `ERROR_MAPPING.md` and `CLI_CONVENTIONS.md`
+  stay, banner-labelled as illustrations, on the principle that a rule must be
+  stack-neutral while an example may be concrete as long as it says so.
+  `tests/test_stack_neutral_docs.py` pins it.
 
 - **Retiring superseded gate files on upgrade.** Increment 1 moves
   `boundary-check` out of `l3-quality-gate.yml`; an existing install keeps

--- a/tests/test_stack_neutral_docs.py
+++ b/tests/test_stack_neutral_docs.py
@@ -1,0 +1,166 @@
+"""Backend docs that no stack overlay replaces must not state stack-specific rules.
+
+Only six architecture docs vary per stack. Everything else under
+`docs/backend/` ships byte-identical to `python-fastapi`, `nodejs-fastify`,
+`go-gin`, `java-spring-boot` and `dotnet-aspnet` alike — so a rule naming
+Pydantic, FastAPI or SQLAlchemy in one of them is wrong for four stacks out of
+five.
+
+That is not cosmetic. `ARCH_CONTRACT.md` §10 instructs AI agents to cite this
+contract when generating plans or code, and it told them the domain "must have
+no external dependencies other than standard Python", that ports are "pure
+Python interfaces", and that secrets go through Pydantic's `BaseSettings`. A Go
+team's agent, following the contract it was pointed at, would have been reading
+Python rules.
+
+**Rules versus illustrations.** A fenced code block is an illustration — the
+reader can see it is written in one language and translate. A sentence in prose
+is a rule, and the reader has no signal that it does not apply to them. So this
+module scans prose only, and code fences are permitted provided the document
+says up front that its examples are illustrative
+(`test_documents_with_code_examples_label_them`).
+
+The narrower sibling of this check is
+`test_layer_vocabulary.py::test_stack_agnostic_backend_docs_name_no_boundary_tool`,
+which pins the same property for boundary-enforcement tools specifically.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BACKEND_DOCS = REPO_ROOT / "docs" / "backend"
+ARCHITECTURE = BACKEND_DOCS / "architecture"
+
+BACKEND_STACKS = (
+    "dotnet-aspnet", "go-gin", "java-spring-boot", "nodejs-fastify", "python-fastapi",
+)
+
+# Names that identify one stack's language, framework or libraries. Both
+# directions are covered: pasting `Fastify` into a baseline doc is the same
+# defect as leaving `FastAPI` there.
+_STACK_SPECIFIC = re.compile(
+    r"\b("
+    r"Python|Pydantic|pydantic|FastAPI|fastapi|SQLAlchemy|BaseSettings|httpx|boto3|"
+    r"uvicorn|asyncio|"
+    r"Fastify|TypeScript|Node\.js|pino|Vitest|"
+    r"Gin|goroutine|"
+    r"Spring Boot|JUnit|Maven|Gradle|"
+    r"ASP\.NET|xUnit|NUnit|NuGet"
+    r")\b"
+)
+
+# `docs/backend/guides/` is excluded on purpose: those guides document specific
+# third-party tools (Guardrails AI, for one) that genuinely are Python
+# libraries. Naming Python there describes the tool, not this service's stack.
+SCANNED_DIRS = (ARCHITECTURE, BACKEND_DOCS / "evaluation")
+
+_CODE_FENCE = re.compile(r"^\s*```")
+_PY_FENCE = re.compile(r"^\s*```(python|py)\b")
+
+
+def _overlaid_doc_names() -> set[str]:
+    """Filenames at least one backend stack overlay replaces on install."""
+    names: set[str] = set()
+    for stack in BACKEND_STACKS:
+        overlay = yaml.safe_load(
+            (REPO_ROOT / "cli" / "stacks" / stack / "overlay.yaml").read_text(encoding="utf-8")
+        )
+        for entry in overlay.get("docs") or []:
+            names.add(Path(entry["dest"]).name)
+    return names
+
+
+def _stack_agnostic_docs() -> list[Path]:
+    overlaid = _overlaid_doc_names()
+    docs: list[Path] = []
+    for directory in SCANNED_DIRS:
+        if directory.exists():
+            docs.extend(p for p in sorted(directory.glob("*.md")) if p.name not in overlaid)
+    return docs
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+
+
+def _prose_lines(path: Path):
+    """Yield (line_number, text) for prose only, skipping fenced code."""
+    in_fence = False
+    for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if _CODE_FENCE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            yield number, line
+
+
+def test_the_scan_covers_the_documents_it_should():
+    """Guard against a vacuous pass: if the overlay set ever grew to cover
+    everything, or a directory moved, the checks below would silently stop
+    examining anything."""
+    docs = {p.name for p in _stack_agnostic_docs()}
+    assert docs, "no stack-agnostic backend docs found to scan"
+    for expected in ("ARCH_CONTRACT.md", "BOUNDARIES.md", "REPO_STRUCTURE_README.md"):
+        assert expected in docs, f"{expected} must be scanned; scanning {sorted(docs)}"
+
+
+@pytest.mark.parametrize("path", _stack_agnostic_docs(), ids=_rel)
+def test_stack_agnostic_doc_states_no_stack_specific_rule(path):
+    offenders = [
+        f"{_rel(path)}:{number}: {line.strip()}"
+        for number, line in _prose_lines(path)
+        if _STACK_SPECIFIC.search(line)
+    ]
+    assert not offenders, (
+        "a doc that ships identically to all five backend stacks states a rule "
+        "naming one stack's language or libraries. Defer to TECH_STACK.md or "
+        "LAYER_IMPLEMENTATION.md, which are overlaid per stack:\n"
+        + "\n".join(offenders)
+    )
+
+
+# Docs known to carry language-specific code examples. Asserted rather than
+# discovered so that removing the examples from one is a deliberate act: a
+# per-doc `pytest.skip` for "no examples here" would let this check quietly
+# shrink to nothing, which is the failure mode the rest of this suite exists
+# to prevent.
+DOCS_WITH_EXAMPLES = {
+    "CLI_CONVENTIONS.md",
+    "CROSS_CUTTING_CONCERNS.md",
+    "ERROR_MAPPING.md",
+}
+
+
+def test_documents_with_code_examples_label_them():
+    """Code fences may be written in one language — the reader can see which.
+    What they must not do is read as the required approach, so any doc
+    carrying them says so once, near the top."""
+    found, offenders = set(), []
+    for path in _stack_agnostic_docs():
+        text = path.read_text(encoding="utf-8")
+        if not any(_PY_FENCE.match(line) for line in text.splitlines()):
+            continue
+        found.add(path.name)
+        head = "\n".join(text.splitlines()[:40]).lower()
+        if "illustrative" not in head:
+            offenders.append(
+                f"{_rel(path)} carries language-specific code examples but never "
+                "says they are illustrative — a reader on another stack has no "
+                "signal that the surrounding rules are language-neutral while "
+                "the examples are not"
+            )
+        elif "tech_stack.md" not in head:
+            offenders.append(
+                f"{_rel(path)} labels its examples but does not point readers at "
+                "TECH_STACK.md for their own stack's equivalents"
+            )
+    assert not offenders, "\n".join(offenders)
+    assert found == DOCS_WITH_EXAMPLES, (
+        f"the set of docs carrying code examples changed: {sorted(found)} vs "
+        f"{sorted(DOCS_WITH_EXAMPLES)}. Update DOCS_WITH_EXAMPLES deliberately — "
+        "silently dropping to an empty set would make this check vacuous."
+    )


### PR DESCRIPTION
Closes #104.

## The issue named one doc; the audit it asked for found six

30 normative statements, not 11. `CROSS_CUTTING_CONCERNS.md` was nearly as bad as `ARCH_CONTRACT.md`, and one leak was outside `architecture/` entirely.

| Doc | Rules fixed | Python examples |
|---|---:|---:|
| `ARCH_CONTRACT.md` | 11 | 0 |
| `CROSS_CUTTING_CONCERNS.md` | 10 | 5 |
| `REPO_STRUCTURE_README.md` | 4 | 0 |
| `CLI_CONVENTIONS.md` | 2 | 5 |
| `ERROR_MAPPING.md` | 2 | 6 |
| `BOUNDARIES.md` | 1 | 0 |
| `evaluation/EVAL_STACK.md` | 1 | 0 |

`DESIGN_PRINCIPLES.md`, both `GHERKIN_*.md` and `NFRS_CONVENTIONS.md` were already clean. `docs/backend/guides/` is excluded on purpose — those guides document third-party tools that genuinely are Python libraries.

## Rules are neutralized; examples are kept and labelled

The distinction is the design decision, and it's why this isn't just a find-and-replace.

A sentence in prose carries no signal that it wasn't written for you. `ARCH_CONTRACT.md` §10 tells AI agents to cite that contract when generating code, so **"Secrets must use `BaseSettings`"** is an instruction a Go team's agent could follow. A fenced code block is visibly one language and the reader can translate it.

So every rule now defers to `TECH_STACK.md` / `LAYER_IMPLEMENTATION.md` — the docs that are overlaid per stack and already correct — while the Python examples stay, with a banner at the top of the three docs carrying them. Deleting them would have cost real guidance to fix a labelling problem.

One section changed shape rather than wording. A list of library names can't be made neutral by rewording, so the approved-libraries block now states what the contract actually constrains — the domain takes no framework, I/O client or ORM; those live in `adapters/` and `api/` — and leaves the naming to `TECH_STACK.md`.

## Verified against real installs

```
go    python-specific in PROSE (rules):   0   inside code fences (labelled): 5
jvm   python-specific in PROSE (rules):   0   inside code fences (labelled): 5
py    python-specific in PROSE (rules):  27   inside code fences (labelled): 13
```

The `python-fastapi` row is the control: its 27 prose hits are all in its own overlaid docs, which *should* name Python. Go and Java now read zero Python rules.

## Test

`tests/test_stack_neutral_docs.py` — failing first, naming all 30. Scans prose only, derives the scanned set from the overlays' own `docs` lists, and covers both directions: pasting `Fastify` into a baseline doc fails the same way `FastAPI` does.

Two guards against the check shrinking quietly. The scanned set is asserted to still contain `ARCH_CONTRACT.md`, `BOUNDARIES.md` and `REPO_STRUCTURE_README.md`. And the label check iterates rather than parametrizing with a per-doc skip, asserting the set of docs carrying examples against a named list — an empty parametrize is skipped by pytest, which is how 72 assertions went quiet during #93.

`./full_test`: 1995 fast + 149 e2e passed, 1 skipped, no new skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
