### PR TITLE
fix(cli): derive skill_context source_root from the repo (#86)

### DIFF
--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -282,7 +282,7 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
     builds one during stack-overlay selection) can pass it in to skip a
     second walk of the target tree.
     """
-    from .detect import build_profile
+    from .detect import build_profile, detect_source_root
 
     if profile is None:
         profile = build_profile(target)
@@ -292,7 +292,11 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
     style = _infer_architecture_style(profile)
     derived = {
         "style": style,
-        "source_root": "src/",
+        # The same answer codex rule placement already uses, rather than a
+        # second notion of where the source lives. `""` means "no single
+        # root" — layers at the target root, several sibling service
+        # packages, or a layout govkit cannot read. It is not a directory.
+        "source_root": detect_source_root(target),
         # deepcopy, not a reference: handing out the module-level dict lets a
         # caller mutating the result corrupt _STYLE_LAYERS for every later
         # install in the process.
@@ -412,7 +416,10 @@ def load_skill_context(target: Path) -> SkillContext | None:
     extensions = data.get("extensions")
     return SkillContext(
         architecture_style=arch.get("style", "unknown") if isinstance(arch.get("style"), str) else "unknown",
-        source_root=arch.get("source_root", "src/") if isinstance(arch.get("source_root"), str) else "src/",
+        # Absent or malformed reads as "govkit cannot tell", the same thing
+        # the derivation's `""` means. Defaulting to a directory would have
+        # the loader invent a source root for a file that never named one.
+        source_root=arch.get("source_root") if isinstance(arch.get("source_root"), str) else "",
         detected_signals=_safe_str_list(arch.get("detected_signals")),
         layers=_safe_layers(arch.get("layers")),
         stack_id=stack.get("id") if isinstance(stack.get("id"), str) else None,

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -1,6 +1,7 @@
 # Multi-Service Skill Context Plan
 
-**Status:** Draft — 2026-08-02. Covers #86. No implementation started.
+**Status:** In progress — 2026-08-03. Covers #86. Increment 1 done
+(derived `source_root`); increments 2–4 not started.
 
 Give `.govkit/skill_context.yaml` an honest source root and a way to say
 "this repo holds several services", so a skill can scope its work to one of
@@ -180,7 +181,7 @@ multi-service repo".
 Each is independently demonstrable and starts with failing tests. Payload
 edits land for **all three agents in lockstep**; run `pytest -k parity`.
 
-### 1. Honest `source_root`
+### 1. Honest `source_root` — done
 
 1. Failing test in `tests/test_skill_context.py`: an applied install's
    `architecture.source_root` equals `detect_source_root(target)` for the
@@ -192,6 +193,33 @@ edits land for **all three agents in lockstep**; run `pytest -k parity`.
 
 No new representation — this alone makes the file stop lying, and is
 revertible on its own.
+
+Two things the increment settled beyond the plan as written:
+
+- **The loader's default moved too.** `load_skill_context` defaulted a
+  missing or malformed `source_root` to `"src/"`, which is the same
+  fabrication on the read side: a file that never says where the code lives
+  does not license the loader to name a directory. It now returns `""` —
+  the "govkit cannot tell" the derivation uses.
+- **Three of the five test layouts derive `""`**, so a table asserting only
+  `emitted == detect_source_root(target)` would pass against a derivation
+  that returned `""` unconditionally. The layouts carry written-out expected
+  values, and a completeness test asserts the table still distinguishes
+  three distinct answers rather than collapsing or emptying.
+
+Verified against real `govkit apply` runs over 5 layouts × 3 agents, diffed
+against the same runs from `main`. **The only bytes that change anywhere in
+an installed tree are the two `source_root` lines** — the live field and the
+provenance record. Rule globs, skill templating, codex's `AGENTS.md`
+placement and doctor's output are all identical, which is the
+"`rule_templating` is unchanged" item under Verification, measured rather
+than argued.
+
+The migration was checked on real installs produced by pre-change code, via
+both `apply` and `upgrade`: an untouched `src/` becomes `src/mypkg`, a
+hand-edited `services/` survives. (`upgrade` no-ops when the marker's
+version already matches the running govkit, so that check needs a marker
+recording an older version — otherwise it silently proves nothing.)
 
 Commit: `fix(cli): derive skill_context source_root from the repo (#86)`
 
@@ -242,11 +270,38 @@ Commit: `docs(backend): document the multi-service skill context (#86)`
 
 ## Open questions
 
-1. **Does `detect_services` belong in `detect.py` or should
-   `detect_source_root` return both?** They walk the same candidates and
-   currently that work is thrown away. One function returning
-   `(root, services)` avoids a second traversal at the cost of a wider
-   signature on a function `install_common` calls for one value.
+1. ~~**Does `detect_services` belong in `detect.py` or should
+   `detect_source_root` return both?**~~ **Neither — extract the shared
+   candidate walk, keep two thin public functions over it.** Answered
+   2026-08-03, before increment 1.
+
+   The question as posed prices the wrong thing. The "second traversal" is
+   `Path.iterdir()` on `src/`, `Source/` and each direct child — no
+   recursion, once per install. Increment 1 measured it at nothing
+   noticeable against a `govkit apply` that copies a hundred files. Saving
+   it is not a reason to widen a signature.
+
+   The real argument for one pass is **Unique**: the invariant binding the
+   two answers — `source_root` is `""` exactly when the candidate list does
+   not hold one entry, and `services` is populated exactly when it holds
+   more than one — has to live somewhere. Two independent walks can drift
+   on a fingerprint, a skip-dir rule, or the `Source/` sibling, and nothing
+   would notice.
+
+   A `(root, services)` tuple buys that at a real cost: `install_common`
+   wants one value, tuple returns invite positional-unpack mistakes, and
+   the existing call site changes for no benefit to itself. A private
+   `_layer_root_candidates(target) -> list[Path]` gets the same single
+   source of truth with **no** caller changing. `detect_source_root` keeps
+   its exact signature and behaviour; `detect_services` is a second thin
+   reading of the same list.
+
+   One wrinkle for increment 2 to settle: `detect_source_root` returns
+   early when the layers sit at the target root, so a repo with both
+   root-level layers *and* `src/{orders,billing}/` never builds a candidate
+   list today. The helper has to decide whether that stays true — it
+   probably should, since such a repo has no coherent answer — but it must
+   be decided rather than inherited.
 2. **Should `name` be the package name or a team-chosen label?** The package
    name is derivable and stable; a label is friendlier in skill output and
    needs somewhere to live. Recommend the package name, with the field

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -325,3 +325,28 @@ Commit: `docs(backend): document the multi-service skill context (#86)`
   closed with #93.
 - **UI and data types.** `ui-*` installs have no service packages, and the
   data types use dbt/medallion layering where "service" has no meaning.
+
+  A review of increment 1 flagged that a dbt repo now emits
+  `source_root: ""`, because `detect_source_root`'s fingerprints omit
+  `_DBT_FOLDERS` and its candidate roots omit `models/`. Checked, and left
+  alone deliberately:
+
+  - **Not a regression.** Those repos previously got `src/`, a directory most
+    dbt projects do not have. `""` — "govkit cannot tell" — is strictly more
+    honest than the value it replaces.
+  - **Not a codex-placement bug either.** `path_scoped` entries exist only
+    under `variants.type.api` and `variants.type.cli` in all three manifests,
+    so `resolve_path_scoped_dests` is a no-op for data installs and the
+    omission never reached the function's original consumer.
+  - **`""` may in fact be the right answer for dbt.** The `dbt-layered` hints
+    already carry the prefix (`models/staging/`, `models/marts/`). A
+    `source_root: models` beside them would make a consumer that joins the
+    two produce `models/models/staging/`. Whether dbt has a source root
+    *distinct from* its layer hints is a representation question for whoever
+    writes the first data consumer, not a gap to patch ahead of one.
+
+  The fix the review proposed — special-casing dbt inside
+  `build_skill_context` — is the wrong shape regardless: it would create a
+  second notion of where the source lives that disagrees with
+  `detect_source_root`, which is the exact defect increment 1 removes. If
+  `models/` ever becomes a recognised root, it belongs in that one function.

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -11,6 +11,8 @@ stack apply to call write_skill_context too. PR 5 only needs the writer.
 import json
 from pathlib import Path
 
+import pytest
+
 
 def _write_marker(target: Path, **overrides) -> dict:
     marker_dir = target / ".govkit"
@@ -798,3 +800,246 @@ class TestPiiKeywordList:
         ctx = load_skill_context(tmp_path)
         assert ctx is not None
         assert ctx.pii_keywords == ["email", "iban"]
+
+
+# ---------------------------------------------------------------------------
+# architecture.source_root — #86
+# ---------------------------------------------------------------------------
+
+BACKEND_LAYERS = ("api", "ports", "services", "models", "adapters", "common")
+
+
+def _layers_under(prefix: str) -> list[str]:
+    """Relative dirs for one hexagonal package rooted at `prefix`."""
+    base = f"{prefix}/" if prefix else ""
+    return [f"{base}{layer}" for layer in BACKEND_LAYERS]
+
+
+# (id, directories to create, expected architecture.source_root).
+#
+# Every layout govkit recognises, plus the two that resolve to "no single
+# root". Expected values are written out rather than computed, so a
+# derivation that collapsed to one answer cannot satisfy the table.
+_SOURCE_ROOT_LAYOUTS = [
+    ("flat-at-root", _layers_under(""), ""),
+    ("flat-under-src", _layers_under("src"), "src"),
+    ("documented-package", _layers_under("src/mypkg"), "src/mypkg"),
+    ("multi-service", _layers_under("src/orders") + _layers_under("src/billing"), ""),
+    ("unrecognisable", ["docs"], ""),
+]
+
+_LAYOUT_IDS = [layout_id for layout_id, _, _ in _SOURCE_ROOT_LAYOUTS]
+
+
+def _make_layout(target: Path, dirs: list[str]) -> None:
+    for rel in dirs:
+        (target / rel).mkdir(parents=True, exist_ok=True)
+
+
+def _emit_architecture(target: Path) -> dict:
+    import yaml
+
+    from cli.skill_context import write_skill_context
+
+    marker = _write_marker(target)
+    write_skill_context(target, marker)
+    data = yaml.safe_load(
+        (target / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+    )
+    return data["architecture"]
+
+
+class TestDerivedSourceRoot:
+    """`architecture.source_root` must describe the repo it is written into.
+
+    It was hardcoded to `"src/"` from the day the writer shipped, so it was
+    wrong for both layouts that are not flat-under-`src/` — including the
+    `src/<package>/` shape REPO_STRUCTURE_README.md prescribes as canonical.
+    Nothing reads the field yet, which is why the lie went unnoticed; #86
+    pins it before a consumer arrives.
+    """
+
+    @pytest.mark.parametrize(
+        "dirs, expected",
+        [(dirs, expected) for _, dirs, expected in _SOURCE_ROOT_LAYOUTS],
+        ids=_LAYOUT_IDS,
+    )
+    def test_source_root_matches_the_layout(self, tmp_path, dirs, expected):
+        _make_layout(tmp_path, dirs)
+
+        assert _emit_architecture(tmp_path)["source_root"] == expected
+
+    @pytest.mark.parametrize(
+        "dirs",
+        [dirs for _, dirs, _ in _SOURCE_ROOT_LAYOUTS],
+        ids=_LAYOUT_IDS,
+    )
+    def test_source_root_agrees_with_detect_source_root(self, tmp_path, dirs):
+        """One notion of where the source lives, not two.
+
+        `detect_source_root` already answers this question for codex rule
+        placement. The emitted value must be byte-equal to it — a near-miss
+        like `src/` beside `src` is the defect #86 reports.
+        """
+        from cli.detect import detect_source_root
+
+        _make_layout(tmp_path, dirs)
+
+        assert _emit_architecture(tmp_path)["source_root"] == detect_source_root(tmp_path)
+
+    def test_the_layout_table_still_distinguishes_three_answers(self):
+        """Guard against the table above going vacuous.
+
+        A parametrize expecting `""` everywhere would pass against the very
+        bug these tests exist to catch, and one that emptied would be
+        skipped in silence.
+        """
+        assert len(_SOURCE_ROOT_LAYOUTS) == len(set(_LAYOUT_IDS)) == 5
+        assert {expected for _, _, expected in _SOURCE_ROOT_LAYOUTS} == {
+            "", "src", "src/mypkg",
+        }
+
+    @pytest.mark.parametrize(
+        "dirs",
+        [dirs for _, dirs, _ in _SOURCE_ROOT_LAYOUTS],
+        ids=_LAYOUT_IDS,
+    )
+    def test_no_layout_emits_the_old_hardcoded_literal(self, tmp_path, dirs):
+        """`src/`, with the trailing slash, is a value no derivation
+        produces — including for the one layout it happened to describe."""
+        _make_layout(tmp_path, dirs)
+
+        assert _emit_architecture(tmp_path)["source_root"] != "src/"
+
+
+class TestSourceRootProvenanceMigration:
+    """The first tunable field whose *derived* value changes for installs
+    that already exist.
+
+    Both branches matter and they pull in opposite directions: an untouched
+    `src/` must refresh to the real root, while a hand-edited one must not.
+    Get the comparison backwards and one of the two silently does the wrong
+    thing — an untouched file freezes a value known to be wrong, or a team's
+    correction is discarded.
+    """
+
+    @staticmethod
+    def _read(target):
+        import yaml
+        return yaml.safe_load(
+            (target / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+        )
+
+    @staticmethod
+    def _write_pre_change_file(target: Path, live_source_root: str) -> None:
+        """Write the file a pre-#86 govkit produced for a hexagonal repo.
+
+        Hand-built rather than produced by `write_skill_context`: today's
+        writer records the *derived* root in the provenance block, so a file
+        it produced could never reproduce the `src/`-in-both-places state
+        this migration is about. Seeding the fixture with the real writer
+        would leave both tests passing without exercising anything.
+        """
+        import yaml
+
+        def hexagonal_layers() -> dict:
+            return {
+                "inbound": ["api/", "ports/inbound/"],
+                "outbound": ["adapters/", "ports/outbound/"],
+                "domain": ["services/", "models/"],
+            }
+
+        (target / ".govkit").mkdir(parents=True, exist_ok=True)
+        (target / ".govkit" / "skill_context.yaml").write_text(
+            yaml.safe_dump({
+                "architecture": {
+                    "style": "hexagonal",
+                    "source_root": live_source_root,
+                    "layers": hexagonal_layers(),
+                    "detected_signals": ["hexagonal-shape"],
+                },
+                "stack": {},
+                "pii": {"keyword_list": ["email"]},
+                "_govkit_generated": {
+                    "style": "hexagonal",
+                    # What the hardcoded writer recorded for every repo.
+                    "source_root": "src/",
+                    "layers": hexagonal_layers(),
+                },
+            }, sort_keys=False),
+            encoding="utf-8",
+        )
+
+    def test_untouched_pre_change_install_picks_up_the_corrected_root(self, tmp_path):
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        self._write_pre_change_file(tmp_path, live_source_root="src/")
+
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["source_root"] == "src/mypkg"
+
+    def test_hand_edited_pre_change_root_survives_the_correction(self, tmp_path):
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        self._write_pre_change_file(tmp_path, live_source_root="services/")
+
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["source_root"] == "services/"
+
+    def test_both_cases_start_from_the_same_recorded_value(self, tmp_path):
+        """Neither branch above is decided by the provenance record, which
+        reads `src/` in both. Only the live value differs — that is the
+        whole mechanism, and this pins that the fixture models it."""
+        for live in ("src/", "services/"):
+            target = tmp_path / live.strip("/").replace("/", "-")
+            target.mkdir()
+            self._write_pre_change_file(target, live_source_root=live)
+
+            data = self._read(target)
+            assert data["_govkit_generated"]["source_root"] == "src/"
+            assert data["architecture"]["source_root"] == live
+
+
+class TestLoadSkillContextSourceRoot:
+    def test_derived_root_round_trips(self, tmp_path):
+        from cli.skill_context import load_skill_context
+
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        _emit_architecture(tmp_path)
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.source_root == "src/mypkg"
+
+    def test_missing_source_root_is_empty_not_a_guess(self, tmp_path):
+        """A file that does not say where the source lives does not license
+        the loader to invent `src/`. Empty is the same "govkit cannot tell"
+        the derivation now uses."""
+        from cli.skill_context import load_skill_context
+
+        (tmp_path / ".govkit").mkdir(parents=True)
+        (tmp_path / ".govkit" / "skill_context.yaml").write_text(
+            "architecture:\n  style: hexagonal\nstack: {}\n", encoding="utf-8",
+        )
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.source_root == ""
+
+    def test_malformed_source_root_is_empty(self, tmp_path):
+        from cli.skill_context import load_skill_context
+
+        (tmp_path / ".govkit").mkdir(parents=True)
+        (tmp_path / ".govkit" / "skill_context.yaml").write_text(
+            "architecture:\n  source_root: [src]\nstack: {}\n", encoding="utf-8",
+        )
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.source_root == ""


### PR DESCRIPTION
Increment 1 of `plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md` (#86). Does not
close the issue — increments 2–4 (`services`, the skills, the docs) follow.

## The defect

`cli/skill_context.py` hardcoded `architecture.source_root = "src/"`. It was
wrong for two of the three layouts govkit supports, including the
`src/<package>/` shape `REPO_STRUCTURE_README.md` prescribes as canonical:

| Layout | before | after |
| --- | --- | --- |
| `src/{api,ports,…}` | `src/` | `src` |
| `src/mypkg/{api,ports,…}` | `src/` | `src/mypkg` |
| `src/{orders,billing}/{…}` | `src/` | `""` |
| layers at the target root | `src/` | `""` |
| unrecognisable | `src/` | `""` |

`cli/detect.py::detect_source_root` had computed the real answer all along,
for codex rule placement. The two never met. `""` now carries that
function's meaning — *no single root* — rather than being a missing value.

`load_skill_context` defaulted a missing or malformed `source_root` to
`"src/"` as well, which is the same fabrication on the read side. It returns
`""` now.

Nothing reads the field yet, which is why the wrong value went unnoticed;
the plan's point is to fix the representation before a consumer arrives.

## Provenance

No code change, but the interaction had to be pinned. This is the first
tunable field whose *derived* value changes for installs that already exist:

- untouched pre-change install (`src/` live **and** recorded) → refreshes to
  the real root
- hand-edited root (`services/` live, `src/` recorded) → survives

Both are tested from a **hand-built** pre-change file. A fixture seeded by
today's writer would record the derived value and could never reproduce the
`src/`-in-both-places state the migration is about, so the tests would pass
without exercising anything.

## Verification

Real `govkit apply` over **5 layouts × 3 agents**, diffed against the same
runs from `main`. The only bytes that differ anywhere in an installed tree
are the two `source_root` lines — live field and provenance record. Rule
globs, skill templating, codex's `AGENTS.md` placement and `govkit doctor`
output are byte-identical, which is the plan's "confirm `rule_templating` is
unchanged" item measured rather than argued.

The migration was replayed on installs produced by pre-change code through
both `apply` and `upgrade`. Note `upgrade` no-ops when the marker's version
already matches the running govkit — a migration check that skips that
detail proves nothing.

Three of the five layouts derive `""`, so a table asserting only
`emitted == detect_source_root(target)` would pass against a derivation that
returned `""` unconditionally. The layouts carry written-out expected values,
and a completeness test asserts the table still distinguishes three distinct
answers rather than collapsing or emptying out.

`./run_tests` (2017 passed) and `./full_test` (120 passed, 30 skipped — Go
and Maven toolchains absent locally, unrelated to this change) both green;
`pytest -k parity` green; `ruff check` clean on both changed files.

## Also in this PR

The plan's **open question 1** is answered: extract a private
`_layer_root_candidates()` and keep two thin public functions over it,
rather than widening `detect_source_root` to return `(root, services)`. The
traversal cost the question worries about is one `iterdir()` per candidate
and not worth a signature change; the real argument for one pass is keeping
the invariant that binds the two answers in one place, and a private helper
buys that with no caller changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
