### PR TITLE
feat: multi-service repo support end to end (#86)

### DIFF
--- a/agents/claude-code/skills/backend/implementation-plan/SKILL.md
+++ b/agents/claude-code/skills/backend/implementation-plan/SKILL.md
@@ -7,6 +7,37 @@ description: Generate an ordered implementation checklist with evaluation compli
 
 You are writing an evaluation-driven implementation plan for a feature. Determine the feature name from the user's request; if it is not provided, ask before proceeding.
 
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
 ## Inputs
 
 Read these artifacts before planning:

--- a/agents/claude-code/skills/backend/spec-planning/SKILL.md
+++ b/agents/claude-code/skills/backend/spec-planning/SKILL.md
@@ -7,6 +7,37 @@ description: Generate a feature plan (plan.md) and eval_criteria.yaml from NFRs 
 
 Plan the implementation of the named feature. When invoked, determine the feature name from the user's request; if it is not provided, ask before proceeding.
 
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
 ## Inputs to read
 
 Feature specs:

--- a/agents/codex/skills/backend/implementation-plan/SKILL.md
+++ b/agents/codex/skills/backend/implementation-plan/SKILL.md
@@ -7,6 +7,37 @@ description: Generate an ordered implementation checklist with evaluation compli
 
 You are writing an evaluation-driven implementation plan for a feature. Determine the feature name from the user's request; if it is not provided, ask before proceeding.
 
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
 ## Inputs
 
 Read these artifacts before planning:

--- a/agents/codex/skills/backend/spec-planning/SKILL.md
+++ b/agents/codex/skills/backend/spec-planning/SKILL.md
@@ -7,6 +7,37 @@ description: Generate a feature plan (plan.md) and eval_criteria.yaml from NFRs 
 
 Plan the implementation of the named feature. When invoked, determine the feature name from the user's request; if it is not provided, ask before proceeding.
 
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
 ## Inputs to read
 
 Feature specs:

--- a/agents/copilot/skills/backend/implementation-plan/SKILL.md
+++ b/agents/copilot/skills/backend/implementation-plan/SKILL.md
@@ -7,6 +7,37 @@ description: Generate an ordered implementation checklist with evaluation compli
 
 You are writing an evaluation-driven implementation plan for a feature. Determine the feature name from the user's request; if it is not provided, ask before proceeding.
 
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
 ## Inputs
 
 Read these artifacts before planning:

--- a/agents/copilot/skills/backend/spec-planning/SKILL.md
+++ b/agents/copilot/skills/backend/spec-planning/SKILL.md
@@ -5,6 +5,37 @@ description: Generate a feature plan (plan.md) and eval_criteria.yaml from NFRs 
 
 Plan the implementation of the named feature. When invoked, determine the feature name from the user's request; if it is not provided, ask before proceeding.
 
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
 ## Inputs to read
 
 Feature specs:

--- a/cli/detect.py
+++ b/cli/detect.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 
 from .fs import read_text_or_none
+from .headers import GOVKIT_BLOCK_BEGIN, GOVKIT_BLOCK_END
 
 # ---------------------------------------------------------------------------
 # Signal definitions
@@ -469,6 +470,46 @@ def _source_folder_sets(target: Path) -> list[set[str]]:
 _PACKAGE_ROOTS = ("src", "Source")
 
 
+def _is_govkit_authored_folder(path: Path) -> bool:
+    """True when `path` holds nothing but a govkit-authored `AGENTS.md`.
+
+    govkit creates layer folders in exactly one place: the target root, when
+    it could not detect a source root and codex's path-scoped destinations
+    stayed root-relative. Everywhere else it writes into folders the team
+    already had — that is how the source root was detected in the first
+    place.
+
+    Counting those folders as evidence of an architecture is what made a
+    multi-service repo permanently unreadable: the first install wrote
+    `api/AGENTS.md` and friends at the root, and every later run then saw
+    layers at the root and reported a flat single-service repo. The damage
+    was self-perpetuating, so neither the per-service fan-out nor doctor's
+    D018 could ever fire on the installs that needed them.
+
+    A folder the team owns is never discounted: one holding their own
+    `AGENTS.md` with govkit's block appended below, or any other file
+    alongside it, is theirs.
+    """
+    try:
+        entries = list(path.iterdir())
+    except OSError:
+        return False
+    if len(entries) != 1:
+        return False
+    only = entries[0]
+    if not only.is_file() or only.name != "AGENTS.md":
+        return False
+    body = read_text_or_none(only)
+    if body is None or GOVKIT_BLOCK_BEGIN not in body:
+        return False
+    # Govkit's block and nothing else — no content the team contributed.
+    begin = body.find(GOVKIT_BLOCK_BEGIN)
+    end = body.find(GOVKIT_BLOCK_END)
+    if end < begin:
+        return False
+    return body[:begin].strip() == "" and body[end + len(GOVKIT_BLOCK_END):].strip() == ""
+
+
 def _layer_root_candidates(target: Path) -> list[Path]:
     """Every directory under `target` that looks like a set of architecture
     layers.
@@ -492,11 +533,18 @@ def _layer_root_candidates(target: Path) -> list[Path]:
     """
     fingerprints = (_HEXAGONAL_FOLDERS, _LAYERED_FOLDERS, _CLEAN_FOLDERS)
 
-    def _matches(root: Path) -> bool:
+    def _matches(root: Path, discount_govkit: bool = False) -> bool:
         names = _child_dir_names(root)
+        if discount_govkit:
+            names = {n for n in names if not _is_govkit_authored_folder(root / n)}
         return any(len(fp & names) >= 2 for fp in fingerprints)
 
-    if _matches(target):
+    # Only the target root discounts govkit's own folders — see
+    # `_is_govkit_authored_folder`. Applying it to `src/<pkg>/` would drop
+    # the source root of a greenfield install whose layer folders are empty
+    # but for the rules govkit just wrote, sending the next run's rules back
+    # to the repo root.
+    if _matches(target, discount_govkit=True):
         return [target]
 
     candidates: list[Path] = []

--- a/cli/detect.py
+++ b/cli/detect.py
@@ -109,6 +109,13 @@ class RepoProfile:
     detected_api_style: str | None = None
     detected_llm_signals: list[str] = field(default_factory=list)
     detected_architecture_signals: list[str] = field(default_factory=list)
+    # Where the layers live, observed at the same moment as the signals
+    # above. Callers that write these into a file must use the profile
+    # rather than re-deriving from the target: `apply` modifies the tree it
+    # is describing (codex creates a layer folder per path-scoped rule), so
+    # a second reading afterwards is a reading of govkit's own output.
+    detected_source_root: str = ""
+    detected_services: list[tuple[str, str]] = field(default_factory=list)
     # Internal: how many signals matched per language (drives confidence).
     _language_signal_counts: dict[str, int] = field(default_factory=dict)
 
@@ -459,17 +466,29 @@ def _source_folder_sets(target: Path) -> list[set[str]]:
     return sets
 
 
-def detect_source_root(target: Path) -> str:
-    """POSIX-relative directory holding the architecture layer folders.
+_PACKAGE_ROOTS = ("src", "Source")
 
-    `""` when the layers sit at the target root, when no layout is
-    recognisable, or when several sibling packages each look like a service
-    — callers then fall back to root-relative destinations rather than
-    guessing which service a rule belongs to.
 
-    Used to place codex's path-scoped `AGENTS.md` rules next to the code
-    they govern. claude-code and copilot need no equivalent: their rules
-    carry `**/<layer>/**` globs that match at any depth.
+def _layer_root_candidates(target: Path) -> list[Path]:
+    """Every directory under `target` that looks like a set of architecture
+    layers.
+
+    The single walk behind both `detect_source_root` and `detect_services`.
+    They ask different questions of the same list — "is there exactly one?"
+    and "which of these are service packages?" — and keeping the list in one
+    place is what stops the two answers disagreeing. Splitting it would let
+    a fingerprint, a skip-dir rule or the `Source/` sibling drift into one
+    function and not the other, and `skill_context.yaml` would then claim a
+    single source root *and* a set of services.
+
+    Returns `[target]` when the layers sit at the target root, and stops
+    there: a repo with both root-level layers and `src/<pkg>/` packages has
+    no coherent answer, so the root wins and nothing further is collected.
+    That is the behaviour `detect_source_root` has always had, preserved
+    deliberately rather than inherited.
+
+    Direct children only — `iterdir()` on `src/`, `Source/` and each of
+    their packages. Cost is fixed regardless of repo size.
     """
     fingerprints = (_HEXAGONAL_FOLDERS, _LAYERED_FOLDERS, _CLEAN_FOLDERS)
 
@@ -478,10 +497,10 @@ def detect_source_root(target: Path) -> str:
         return any(len(fp & names) >= 2 for fp in fingerprints)
 
     if _matches(target):
-        return ""
+        return [target]
 
     candidates: list[Path] = []
-    for root in (target / "src", target / "Source"):
+    for root in (target / name for name in _PACKAGE_ROOTS):
         if not root.is_dir():
             continue
         if _matches(root):
@@ -495,10 +514,56 @@ def detect_source_root(target: Path) -> str:
             p for p in packages
             if not p.name.startswith(".") and p.name not in _SKIP_DIRS and _matches(p)
         )
+    return candidates
 
-    if len(candidates) != 1:
+
+def detect_source_root(target: Path) -> str:
+    """POSIX-relative directory holding the architecture layer folders.
+
+    `""` when the layers sit at the target root, when no layout is
+    recognisable, or when several sibling packages each look like a service
+    — callers then fall back to root-relative destinations rather than
+    guessing which service a rule belongs to.
+
+    Used to place codex's path-scoped `AGENTS.md` rules next to the code
+    they govern, and written to `skill_context.yaml` so a skill knows where
+    the code lives. claude-code and copilot need no equivalent for rules:
+    those carry `**/<layer>/**` globs that match at any depth.
+    """
+    candidates = _layer_root_candidates(target)
+    # `[target]` is the layers-at-the-root case, whose relative path is "."
+    # rather than "". Both mean "no prefix", and only one of them is a value
+    # a caller can join onto a destination.
+    if len(candidates) != 1 or candidates[0] == target:
         return ""
     return candidates[0].relative_to(target).as_posix()
+
+
+def detect_services(target: Path) -> list[tuple[str, str]]:
+    """`(name, root)` for each service package, or `[]` when there is one.
+
+    A *service* is a package under `src/` or `Source/` that holds its own
+    architecture layers — the `src/{orders,billing}/` shape. `src/` holding
+    the layers directly is a source root, not a service, so it is never
+    named; a repo whose only service is `src/mypkg` is the documented
+    single-service layout and is described by `detect_source_root` alone.
+
+    `name` is the package name: derivable, stable, and what the code
+    already calls itself. Teams that want a friendlier label edit
+    `architecture.services` in skill_context.yaml, which the provenance
+    mechanism preserves like every other tunable.
+
+    Packages that do not conform — `src/legacy/` next to two real services —
+    are omitted. That omission is silent here by design; it is the emitted
+    file, not this function, that has to make it visible.
+    """
+    package_roots = {target / name for name in _PACKAGE_ROOTS}
+    services = [
+        c for c in _layer_root_candidates(target) if c.parent in package_roots
+    ]
+    if len(services) < 2:
+        return []
+    return [(c.name, c.relative_to(target).as_posix()) for c in services]
 
 
 def _detect_architecture(target: Path, prof: RepoProfile) -> None:
@@ -636,5 +701,7 @@ def build_profile(target: Path) -> RepoProfile:
     _detect_frameworks(target, prof)
     _detect_ci(target, prof)
     _detect_architecture(target, prof)
+    prof.detected_source_root = detect_source_root(target)
+    prof.detected_services = detect_services(target)
     _detect_llm_signals(target, prof)
     return prof

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -29,6 +29,7 @@ from typing import Literal
 # ---------------------------------------------------------------------------
 from .agent_layout import AGENT_LAYOUTS
 from .fs import read_text_or_none
+from .headers import GOVKIT_BLOCK_BEGIN, GOVKIT_BLOCK_END
 from .marker import MARKER_DIRNAME, MARKER_FILENAME, read_govkit_marker
 
 Severity = Literal["error", "warning", "info"]
@@ -836,6 +837,113 @@ def _check_ui_framework_matches_type(
             f"--type {declared}` only if it matches this application"
         ),
     )]
+
+
+@_register_check("D018")
+def _check_stale_path_scoped_rules(
+    target: Path, marker: dict,
+) -> list[ValidationFinding]:
+    """D018 — a path-scoped rule sits where govkit no longer writes one.
+
+    In a multi-service repo govkit installs codex's layer rules inside each
+    service (`src/orders/api/AGENTS.md`). An earlier govkit put a single
+    copy at the repo root, where codex — which resolves AGENTS.md upward
+    from the file being edited — never reaches it from service code. Those
+    root copies govern nothing, and the folders holding them make the repo
+    read as flat single-service, which erases `architecture.services`.
+
+    Reported, never removed. Two reasons, in order of importance: the file
+    may be one the team authored, with govkit's block appended below their
+    content; and even when it is govkit's own, a stale copy here is inert
+    rather than contradictory. `reconcile_legacy_instruction_files` deletes
+    because leaving its file makes the agent load governance *twice* — a
+    different hazard with a different remedy.
+
+    Silent for claude-code and copilot: their rules are globs matching at
+    any depth, so they declare no path-scoped entries at all.
+    """
+    services = _detected_services(target)
+    if not services:
+        return []
+
+    agent = marker.get("agent")
+    if not agent:
+        return []
+    try:
+        from .manifest import load_manifest, resolve_variant_files
+
+        manifest = load_manifest(agent)
+        options = {**(marker.get("options") or {}), "level": marker.get("level", "3")}
+        files, _shared, _governed = resolve_variant_files(manifest, options)
+    except (OSError, ValueError, KeyError, SystemExit):
+        # Doctor never fails the run over an unreadable manifest; other
+        # checks (D010) already speak to a broken install.
+        return []
+
+    live_roots = ", ".join(root for _name, root in services)
+    findings: list[ValidationFinding] = []
+    for entry in files:
+        if not entry.get("path_scoped"):
+            continue
+        dest = entry.get("dest")
+        if not dest:
+            continue
+        stale = target / dest
+        body = read_text_or_none(stale)
+        # No govkit block means govkit never wrote here — it is simply the
+        # team's file, and none of govkit's business.
+        if body is None or GOVKIT_BLOCK_BEGIN not in body:
+            continue
+        team_authored = body.strip() != _govkit_block_only(body).strip()
+        if team_authored:
+            action = (
+                f"leave the file as it is — govkit did not author it. The govkit "
+                f"block inside it is no longer refreshed; the live layer rules are "
+                f"now under each service ({live_roots}). Delete just the block "
+                f"between the BEGIN/END GOVKIT GOVERNANCE markers if you no longer "
+                f"want it."
+            )
+        else:
+            action = (
+                f"safe to delete {dest} — it holds only govkit's block, and the "
+                f"live layer rules are now under each service ({live_roots})"
+            )
+        findings.append(ValidationFinding(
+            id="D018",
+            severity="warning",
+            category="stale-path-scoped-rule",
+            file=dest,
+            message=(
+                f"{dest} governs no code in this multi-service repo — {agent} "
+                f"resolves AGENTS.md upward from the file being edited and never "
+                f"reaches the repo root from service code"
+            ),
+            suggested_action=action,
+        ))
+    return findings
+
+
+def _govkit_block_only(body: str) -> str:
+    """The govkit-delimited block of `body`, or `""` when there is none.
+
+    Used to tell govkit's own orphan from a file the team wrote and govkit
+    appended to: if the block is the whole file, nobody else contributed.
+    """
+    begin = body.find(GOVKIT_BLOCK_BEGIN)
+    end = body.find(GOVKIT_BLOCK_END)
+    if begin == -1 or end == -1 or end < begin:
+        return ""
+    return body[begin:end + len(GOVKIT_BLOCK_END)]
+
+
+def _detected_services(target: Path) -> list[tuple[str, str]]:
+    """`detect_services` with doctor's never-raise contract."""
+    try:
+        from .detect import detect_services
+
+        return detect_services(target)
+    except OSError:
+        return []
 
 
 # D002 (rule body mentions an absent folder name) is intentionally deferred.

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -119,22 +119,52 @@ def resolve_path_scoped_dests(files: list[dict], target: Path) -> list[dict]:
     a repo laid out as `src/<package>/services/` would get an empty
     root-level folder holding guidance codex never applies.
 
-    When no source root can be determined — a greenfield repo, or several
-    sibling service packages with no single root — destinations are left
+    When several sibling packages each look like a service there is no
+    single root, so each path-scoped entry is written once **per service** —
+    `src/orders/api/AGENTS.md` and `src/billing/api/AGENTS.md` rather than
+    one copy at the repo root. Codex resolves AGENTS.md upward from the file
+    being edited, so a root copy would be reached only by code directly
+    under a root-level `api/`, which a multi-service repo does not have: the
+    rules governed nothing. The empty root folders it created also made
+    every later reading of the repo see a flat single-service layout, which
+    is what erased `architecture.services` from skill_context on upgrade.
+
+    When no source root and no services can be determined — a greenfield
+    repo, or layers already at the target root — destinations are left
     exactly as the manifest declares them, so no existing install changes.
 
+    Nothing is ever removed. Re-rooting only changes where the *next* write
+    goes; a file the team authored at either location keeps its content,
+    because `write_managed_agent_block` appends govkit's block below it.
+    Rules left at a location govkit no longer writes are reported by doctor
+    (D018) rather than deleted.
+
     claude-code and copilot need no equivalent: `rule_templating` gives
-    their rules `**/<layer>/**` globs, which match at any depth.
+    their rules `**/<layer>/**` globs, which match at any depth — and so
+    match inside every service already.
     """
-    from .detect import detect_source_root
+    from .detect import detect_services, detect_source_root
 
     source_root = detect_source_root(target)
-    if not source_root:
+    if source_root:
+        return [
+            {**e, "dest": f"{source_root}/{e['dest']}"} if e.get("path_scoped") else e
+            for e in files
+        ]
+
+    services = detect_services(target)
+    if not services:
         return files
-    return [
-        {**e, "dest": f"{source_root}/{e['dest']}"} if e.get("path_scoped") else e
-        for e in files
-    ]
+
+    fanned: list[dict] = []
+    for entry in files:
+        if not entry.get("path_scoped"):
+            fanned.append(entry)
+            continue
+        fanned.extend(
+            {**entry, "dest": f"{root}/{entry['dest']}"} for _name, root in services
+        )
+    return fanned
 
 
 def reconcile_legacy_instruction_files(

--- a/cli/skill_context.py
+++ b/cli/skill_context.py
@@ -83,6 +83,17 @@ _CI_NAME = {"github": "github-actions", "azure": "azure-pipelines"}
 _DEFAULT_PII_KEYWORDS = ["email", "phone", "ssn", "dob", "birth", "address", "name"]
 
 
+@dataclass(frozen=True)
+class ServiceRef:
+    """One service package in a multi-service repo.
+
+    `root` is POSIX-relative to the target, so a consumer can join it onto
+    a layer hint (`src/orders` + `services/`) without knowing the layout.
+    """
+    name: str
+    root: str
+
+
 @dataclass
 class SkillContext:
     """Typed view of .govkit/skill_context.yaml for skill consumers (PR 6b/c).
@@ -109,6 +120,9 @@ class SkillContext:
     llm: bool
     pii_keywords: list[str] = field(default_factory=list)
     extensions: list[dict] = field(default_factory=list)
+    # Empty for a single-service repo, so `if ctx.services:` reads as "is
+    # this a multi-service repo".
+    services: list[ServiceRef] = field(default_factory=list)
 
 
 def _infer_architecture_style(profile) -> str:
@@ -163,7 +177,11 @@ def _extension_facts(target: Path) -> list[dict]:
 #
 # `detected_signals` is deliberately absent: it is an observation of the
 # repo, never a preference, so it always refreshes.
-_TEAM_TUNABLE_ARCHITECTURE = ("style", "source_root", "layers")
+#
+# `services` differs from the other three in one way that matters: govkit
+# writes it only for a multi-service repo, so a live `services` with no
+# record entry is a list the team added themselves. See _preserve_team_edits.
+_TEAM_TUNABLE_ARCHITECTURE = ("style", "source_root", "layers", "services")
 
 # Where govkit records what it derived, so a later run can tell a team's
 # edit from a value it wrote itself. Leading underscore marks it as
@@ -197,6 +215,13 @@ def _preserve_team_edits(existing: dict, architecture: dict) -> dict:
     so they rewrite as they always did — the edit is lost once, then
     protected from the next run onward.
 
+    A record that exists but does not mention a key is a third case, and it
+    reads the same way: govkit did not write that key, so a live value for
+    it came from somewhere else and is kept. `services` needs this — govkit
+    emits it only for a multi-service repo, so a team listing services in a
+    repo govkit reads as single-service has no record entry to differ from.
+    Without it their list would be dropped on the next write.
+
     `layers` describes `style`, so the two are kept coherent: a team that
     corrects only the style gets hints reseeded from the style they chose.
     Without that, the file would claim one architecture while scoping rules
@@ -211,9 +236,9 @@ def _preserve_team_edits(existing: dict, architecture: dict) -> dict:
 
     preserved: set[str] = set()
     for key in _TEAM_TUNABLE_ARCHITECTURE:
-        if key not in live or key not in recorded:
+        if key not in live:
             continue
-        if live[key] != recorded[key]:
+        if key not in recorded or live[key] != recorded[key]:
             architecture[key] = live[key]
             preserved.add(key)
 
@@ -282,7 +307,7 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
     builds one during stack-overlay selection) can pass it in to skip a
     second walk of the target tree.
     """
-    from .detect import build_profile, detect_source_root
+    from .detect import build_profile
 
     if profile is None:
         profile = build_profile(target)
@@ -296,12 +321,24 @@ def build_skill_context(target: Path, marker: dict, profile: RepoProfile | None 
         # second notion of where the source lives. `""` means "no single
         # root" — layers at the target root, several sibling service
         # packages, or a layout govkit cannot read. It is not a directory.
-        "source_root": detect_source_root(target),
+        #
+        # Read off the profile, never re-derived from `target`: cmd_apply
+        # builds the profile before it writes anything, and codex's
+        # path-scoped rules create a folder per layer. Re-deriving here
+        # would describe govkit's own output instead of the team's repo.
+        "source_root": profile.detected_source_root,
         # deepcopy, not a reference: handing out the module-level dict lets a
         # caller mutating the result corrupt _STYLE_LAYERS for every later
         # install in the process.
         "layers": deepcopy(_STYLE_LAYERS.get(style, _STYLE_LAYERS["unknown"])),
     }
+    # Only for the case the flat fields cannot express. Absent — not an
+    # empty list — for a single-service repo, so every file written before
+    # #86 stays valid and `source_root: ""` with no `services` still reads
+    # as "govkit could not tell" rather than "there are zero services".
+    services = profile.detected_services
+    if services:
+        derived["services"] = [{"name": name, "root": root} for name, root in services]
     existing = _read_existing_context(target)
     # Independent copies. Sharing one object between the live block and the
     # provenance record makes yaml.safe_dump emit an anchor and an alias, so
@@ -389,6 +426,27 @@ def _safe_layers(value: object) -> dict[str, list[str]]:
     return normalized
 
 
+def _safe_services(value: object) -> list[ServiceRef]:
+    """Normalize `architecture.services` to a list of ServiceRef.
+
+    Every hand-edit that is not a list of two-string mappings degrades to
+    fewer services rather than raising: `services: orders` would splat into
+    characters under `list()`, a mapping iterates its keys, and an entry
+    missing `root` is a reference a consumer cannot act on. Half an entry is
+    worse than none — a skill would scope work to a service with no path.
+    """
+    if not isinstance(value, list):
+        return []
+    refs: list[ServiceRef] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        name, root = entry.get("name"), entry.get("root")
+        if isinstance(name, str) and name and isinstance(root, str) and root:
+            refs.append(ServiceRef(name=name, root=root))
+    return refs
+
+
 def load_skill_context(target: Path) -> SkillContext | None:
     """Read .govkit/skill_context.yaml and return a typed SkillContext.
 
@@ -436,4 +494,5 @@ def load_skill_context(target: Path) -> SkillContext | None:
         llm=bool(data.get("llm")),
         pii_keywords=_safe_str_list(_safe_dict(data.get("pii")).get("keyword_list")),
         extensions=[e for e in extensions if isinstance(e, dict)] if isinstance(extensions, list) else [],
+        services=_safe_services(arch.get("services")),
     )

--- a/docs/backend/architecture/REPO_STRUCTURE_README.md
+++ b/docs/backend/architecture/REPO_STRUCTURE_README.md
@@ -22,7 +22,7 @@ Projects created using this kit should place their application code in a package
 
 Recommended structure for adopting projects:
 ```
-src/<project_pacakage_name>/
+src/<project_package_name>/
 ├── api/
 ├── ports/
 ├── services/
@@ -65,6 +65,61 @@ Benefits of the `src/<project_package_name>` layout:
 - supports your language's packaging conventions
 - allows multiple services to reuse the governance kit
 - keeps governance artifacts separate from runtime code
+
+## Several services in one repo
+
+One repo may hold more than one service package, each with its own layers:
+
+```
+src/orders/{api,ports,services,models,adapters,common}/
+src/billing/{api,ports,services,models,adapters,common}/
+```
+
+Every service under one install shares that install's project type, stack
+and maturity level — that is what makes a single set of governance artifacts
+correct for all of them. Services that need to differ in any of those need
+**separate installs**, each with its own `.govkit/`.
+
+### What govkit records about the shape
+
+`.govkit/skill_context.yaml` describes the layout it found:
+
+| Layout | `architecture.source_root` | `architecture.services` |
+|---|---|---|
+| `src/<package>/{api,…}` | `src/<package>` | absent |
+| `src/{api,…}` | `src` | absent |
+| `src/{orders,billing}/{…}` | `""` | one entry per service |
+| layers at the repo root | `""` | absent |
+| nothing recognisable | `""` | absent |
+
+`source_root: ""` means *no single root*. It is not a directory and not a
+failure — read it together with `services`. Present means govkit found
+several services; absent means it could not tell which shape this is. Each
+`services` entry carries a `name` (the package name) and a `root` (a path
+relative to the repo).
+
+Both fields are yours to correct. Edit them in `skill_context.yaml` and the
+change survives every later `apply`, `upgrade`, `stack apply` and
+`calibrate` — govkit only reseeds values it wrote itself.
+
+### What follows from a multi-service layout
+
+- **Planning skills ask which service.** With more than one entry and a
+  request that names none, `govkit-spec-planning` and
+  `govkit-implementation-plan` list the service names and ask before
+  planning, then prefix every path in their output with that service's
+  `root`.
+- **Agent rules land inside each service.** Agents that scope guidance by
+  file location get a copy per service (`src/orders/api/`,
+  `src/billing/api/`), because such an agent resolves its guidance from the
+  file being edited upward. Agents that scope by glob need nothing extra —
+  patterns like `**/api/**` already match inside every service.
+- **Boundary contracts name each service.** The reference contract under
+  `governance/backend/` takes one entry per service package rather than a
+  bare `src`, and ships a rule for forbidding cross-service imports so a
+  change in one service cannot quietly reach into another. See
+  `TECH_STACK.md` for the tool this stack uses and the reference file to
+  copy.
 
 ---
 

--- a/governance/backend/importlinter-reference.toml
+++ b/governance/backend/importlinter-reference.toml
@@ -50,6 +50,13 @@ root_package = "myservice"
 #                     (with root_packages = ["orders", "billing"] above)
 # The layer list is identical either way — only the container list grows.
 #
+# You do not have to work the names out by hand. `.govkit/skill_context.yaml`
+# records what govkit detected under `architecture.services` — one entry per
+# service, each carrying the package `name` to use here and its `root`. An
+# empty `architecture.source_root` alongside that list is govkit saying this
+# repo has no single source root because it holds several services. See
+# docs/backend/architecture/REPO_STRUCTURE_README.md.
+#
 # Violations are blocking — they indicate a boundary breach.
 [[tool.importlinter.contracts]]
 name = "Hexagonal Architecture"

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -1,13 +1,12 @@
 # Multi-Service Skill Context Plan
 
-**Status:** In progress — 2026-08-03. Covers #86. Increments 1–2 done
-(derived `source_root`, `services`); increments 3–4 not started.
+**Status:** In progress — 2026-08-03. Covers #86. Increments 1, 2 and 2b done
+(derived `source_root`, `services`, per-service codex rules + doctor D018);
+increments 3–4 not started.
 
-**Increment 3 is blocked** on a decision recorded under Follow-ups: codex's
-own path-scoped rules make a multi-service repo look single-service, so the
-`services` list survives `apply` but not a later `upgrade`. Teaching the
-skills to read a field that erases itself would be worse than not shipping
-it.
+Increment 2b unblocked increment 3: codex's path-scoped rules now fan out per
+service, so they govern the code they describe and no longer make a
+multi-service repo read as single-service.
 
 Give `.govkit/skill_context.yaml` an honest source root and a way to say
 "this repo holds several services", so a skill can scope its work to one of
@@ -285,6 +284,81 @@ two agents on every layout.
 
 Commit: `feat(cli): describe multi-service repos in skill_context (#86)`
 
+### 2b. Codex rules scope to each service — done
+
+Not in the original plan. Increment 2's end-to-end run surfaced two defects
+in codex's path-scoped rule placement, and the second of them would have
+made increment 3 unsafe.
+
+1. Failing tests in `tests/test_path_scoped_rules.py`: a multi-service
+   install puts every path-scoped rule under each service and none at the
+   repo root; single-source-root and unrecognisable layouts install exactly
+   as before; the service list survives an `upgrade`.
+2. `resolve_path_scoped_dests` gains one branch — no single root **and**
+   services detected → one destination per service.
+3. Doctor **D018** names rules left where govkit no longer writes them.
+4. `_layer_root_candidates` stops counting govkit's own folders at the
+   target root.
+
+**What the rules were doing before.** In a `src/{orders,billing}/` repo
+there is no single source root, so destinations stayed root-relative and
+`apply` wrote `api/AGENTS.md`, `ports/AGENTS.md`, `services/AGENTS.md`,
+`adapters/AGENTS.md` and `security/AGENTS.md` at the repo root. Codex
+resolves `AGENTS.md` upward from the file being edited, so
+`src/orders/api/handlers.py` reaches the top-level `AGENTS.md` and never the
+root `api/AGENTS.md`. Verified on a real install: **no `AGENTS.md` anywhere
+under either service.** Five files governing nothing — the same defect
+`resolve_path_scoped_dests` was written to fix for `src/<package>/`, left
+unfixed for the multi-service shape.
+
+**Nothing is removed.** `write_managed_agent_block` already replaces a file
+wholesale only when it can prove the file is govkit's own — byte-identical
+to the body, or untouched since `applied_at` — and otherwise appends its
+block below the team's content. Confirmed with a real apply against a
+hand-written root `AGENTS.md` and a hand-written root `api/AGENTS.md`: both
+kept their content, each with one govkit block. Fan-out changes only where
+the *next* write goes, and adds no delete path.
+
+D018 reports what is left behind, with different advice per case, because
+govkit cannot know which it is until it looks:
+
+| Left at the root | Advice |
+| --- | --- |
+| holds only govkit's block | safe to delete, and names the live locations |
+| holds the team's content too | leave the file; the block inside it is stale |
+
+This deliberately does **not** follow `reconcile_legacy_instruction_files`,
+which deletes. That function deletes because leaving its file makes the
+agent load governance *twice* — actively contradictory. A stale root
+`api/AGENTS.md` here governs nothing, so it is inert clutter. Different
+hazard, different remedy.
+
+**The migration was the part that nearly shipped broken.** The first draft
+fixed fresh installs and did nothing for existing ones: the root folders an
+earlier govkit created made `_layer_root_candidates` match at the target
+root, so `detect_services` returned `[]` for ever. The fan-out could never
+fire on the installs that needed it, and **D018 could never fire at all** —
+a check that cannot fail, which is the thing this repo has learned to look
+for. Only the end-to-end replay of a pre-fan-out install caught it; every
+unit test was green.
+
+The fix is that a folder holding nothing but a govkit-authored `AGENTS.md`
+is govkit's artifact, not a source layer — discounted **only at the target
+root**. That scoping is load-bearing. govkit creates layer folders in
+exactly one place: the root, when it could not detect a source root.
+Everywhere else it writes into folders the team already had. Discounting at
+`src/<pkg>/` would drop the source root of a greenfield install whose layer
+folders hold only the rules govkit just wrote, sending the next run's rules
+back to the repo root — pinned by
+`test_a_greenfield_package_layout_does_not_relocate_itself`.
+
+Verified: `apply` twice is idempotent on all four layouts; a pre-fan-out
+install upgrades to per-service rules, keeps its team-authored root file
+intact, keeps its service list, and gets one D018 per stale location with
+the right advice for each.
+
+Commit: `fix(cli): scope codex path-scoped rules to each service (#86)`
+
 ### 3. Skills ask which service
 
 1. Failing test in `tests/test_agent_skills.py`: `spec-planning` and
@@ -373,60 +447,28 @@ Commit: `docs(backend): document the multi-service skill context (#86)`
 
 ## Follow-ups
 
-### Codex's path-scoped rules break multi-service repos — blocks increment 3
+### ~~Codex's path-scoped rules break multi-service repos~~ — closed by 2b
 
-Two defects with one cause, both found by running `govkit apply` rather than
-by reading code. Neither is created by this plan; increment 2 is what made
-them visible.
+Both defects are fixed: the rules fan out per service, and govkit no longer
+reads its own root-level folders as architecture. Doctor D018 names what an
+earlier install left behind. Kept as a pointer because the reasoning that
+found them is worth keeping: unit tests were green across every layout while
+codex, one of three agents, got none of the feature.
 
-**1. The rules govern nothing.** In a `src/{orders,billing}/` repo,
-`detect_source_root` returns `""`, so `resolve_path_scoped_dests` leaves
-codex's destinations root-relative and `apply` writes `api/AGENTS.md`,
-`ports/AGENTS.md`, `services/AGENTS.md`, `adapters/AGENTS.md` and
-`security/AGENTS.md` at the repo root. Verified on a real install: there is
-**no `AGENTS.md` anywhere under `src/orders` or `src/billing`**. Codex
-resolves `AGENTS.md` upward from the file being edited, so a file at
-`src/orders/api/handlers.py` finds the top-level `AGENTS.md` and never the
-root `api/AGENTS.md`. Those five files govern no code at all.
+### Should doctor name skipped sibling packages?
 
-This is the same defect `resolve_path_scoped_dests` was written to fix for
-the `src/<package>/` layout, left unfixed for the multi-service one.
+Open question 3's remaining half, deliberately left out of 2b. A team reading
+`services: [orders, billing]` cannot tell whether that is the whole repo.
 
-**2. They then hide the services.** Those root-level folders make
-`_layer_root_candidates` match at the target root, so every later reading of
-the repo sees a flat single-service layout. Increment 2 fixed `apply` by
-observing before writing, but the folders are on disk permanently, so a
-later `upgrade` — which builds its profile after the install — derives no
-services and the list is dropped. Measured:
+The obvious version is wrong: flagging every unlisted directory under `src/`
+would fire on `src/utils/`, `src/config/` and every shared package, which is
+noise, not honesty. A useful check needs a definition of "near miss" —
+plausibly a package holding *at least one* architecture-layer folder but too
+few to match a fingerprint, which is the case where govkit almost listed it
+and a team would be surprised it did not.
 
-| Agent | after `apply` | after `upgrade` |
-| --- | --- | --- |
-| claude-code | 2 services | 2 services |
-| codex | 2 services | **0** |
-| copilot | 2 services | 2 services |
-
-Nothing reads `services` yet, so the practical impact today is zero. That
-stops being true at increment 3, which is why it blocks it: a skill taught
-to read a field that erases itself on the next `upgrade` is worse than a
-skill that does not know about services.
-
-**Recommended fix: fan the path-scoped rules out per service.**
-`src/orders/api/AGENTS.md` and `src/billing/api/AGENTS.md` rather than one
-root copy. It puts the rules where codex will actually resolve them, and it
-creates no root-level layer folders, so the detection problem disappears
-with the defect that caused it. `detect_services` — which increment 2 adds —
-is exactly what makes it expressible; `resolve_path_scoped_dests` grows one
-branch. claude-code and copilot need no change: their `**/<layer>/**` globs
-already match at any depth, which is the accident recorded in Motivation §3.
-
-Two alternatives, both weaker. *Drop the path-scoped rules entirely for a
-multi-service repo* — smaller, and removes only files that demonstrably do
-nothing, but it leaves those services with no codex layer guidance. *Leave
-it* — increment 3 then has to treat `services` as unreliable on one agent.
-
-Either way, an install that already has the stale root folders keeps them:
-govkit does not delete files it did not write in the user's tree. Worth
-deciding whether `doctor` should name them.
+That definition needs deciding before the check is written, which is why 2b
+shipped without it.
 
 ## Out of scope
 

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -1,7 +1,13 @@
 # Multi-Service Skill Context Plan
 
-**Status:** In progress — 2026-08-03. Covers #86. Increment 1 done
-(derived `source_root`); increments 2–4 not started.
+**Status:** In progress — 2026-08-03. Covers #86. Increments 1–2 done
+(derived `source_root`, `services`); increments 3–4 not started.
+
+**Increment 3 is blocked** on a decision recorded under Follow-ups: codex's
+own path-scoped rules make a multi-service repo look single-service, so the
+`services` list survives `apply` but not a later `upgrade`. Teaching the
+skills to read a field that erases itself would be worse than not shipping
+it.
 
 Give `.govkit/skill_context.yaml` an honest source root and a way to say
 "this repo holds several services", so a skill can scope its work to one of
@@ -223,7 +229,7 @@ recording an older version — otherwise it silently proves nothing.)
 
 Commit: `fix(cli): derive skill_context source_root from the repo (#86)`
 
-### 2. `services` in the emitted context
+### 2. `services` in the emitted context — done
 
 1. Failing test: the multi-service layout emits two `services` entries with
    the right names and roots; single-service layouts emit none.
@@ -233,6 +239,49 @@ Commit: `fix(cli): derive skill_context source_root from the repo (#86)`
    defensive coercion the other fields get — a hand-edited `services:` that
    is a scalar, or holds non-dict entries, must not crash
    `load_skill_context`.
+
+Built on `_layer_root_candidates()`, per open question 1's answer: one walk,
+two readings. `detect_services` filters that list to candidates whose parent
+is `src/` or `Source/`, which is what stops `src/` itself — a source root
+holding the layers directly — from being reported as a service named "src".
+
+Three things the increment settled:
+
+- **Provenance needed a third case.** It compared a live value against the
+  record and preserved it when they differed, skipping any key the record
+  did not hold. `services` is the first field govkit writes only
+  *sometimes*, so a team listing services in a repo govkit reads as
+  single-service had no record entry to differ from, and their list was
+  dropped on the next write. A live key with no record entry now reads as
+  "govkit did not write this", which is the general form of the rule the
+  other three fields never needed.
+- **`services` is absent, never `[]`.** An empty list would erase the
+  distinction between "three services" and "govkit could not read this
+  repo", which both otherwise carry `source_root: ""`.
+- **Non-conforming siblings are omitted** — open question 3, answered by
+  doing: `src/legacy/` beside two real services is not listed, and one
+  conforming package beside a non-conforming one is the single-service case.
+  The omission is still silent, which is the part left open.
+
+**The end-to-end run found a defect the unit tests could not.** Codex places
+a path-scoped `AGENTS.md` inside each layer folder, and for a multi-service
+repo — where there is no single source root — those destinations stay
+root-relative, so `apply` *creates* root-level `api/`, `ports/`, `services/`
+and `adapters/`. `write_skill_context` runs after that, so re-deriving read
+the repo as flat single-service and emitted no services at all. Codex, one
+of three agents, silently got none of this feature.
+
+The cause is that `source_root` and `services` were observed at a different
+moment from `style` and `detected_signals`, which come from a `RepoProfile`
+built during stack selection, before a byte is written. Both now live on
+that profile, so all four facts describe the same repo — the team's, not the
+one govkit just modified. Increment 1 had the same split and got away with
+it: its value was `""` before and after.
+
+Verified with real `govkit apply` over **7 layouts × 3 agents**, diffed
+against the same runs from `main`: the only bytes that differ anywhere in
+an installed tree are the `services` block, and codex now matches the other
+two agents on every layout.
 
 Commit: `feat(cli): describe multi-service repos in skill_context (#86)`
 
@@ -308,9 +357,76 @@ Commit: `docs(backend): document the multi-service skill context (#86)`
    tunable like everything else in the architecture block.
 3. **Does anything need to stop a multi-service repo from having services
    with different shapes?** `src/orders/{api,…}` beside `src/legacy/` that is
-   not hexagonal at all. Detection would list only the conforming ones, which
-   is probably right, but it is a silent omission — the kind this repo has
-   learned to distrust.
+   not hexagonal at all. **Half-answered by increment 2:** detection lists
+   only the conforming packages, and that is right — `src/legacy/` is not a
+   service govkit can say anything useful about, and one conforming package
+   beside a non-conforming one is correctly the single-service case. Both are
+   tested.
+
+   What is still open is the part the original question worried about: the
+   omission is silent. Nothing in the emitted file or in `doctor` says
+   "there is a `src/legacy/` here that govkit did not list". A team reading
+   `services: [orders, billing]` has no way to tell whether that is the whole
+   repo. `doctor` is the natural place — it already reports what it examined
+   — and this should be settled before increment 3 teaches skills to plan
+   against the list.
+
+## Follow-ups
+
+### Codex's path-scoped rules break multi-service repos — blocks increment 3
+
+Two defects with one cause, both found by running `govkit apply` rather than
+by reading code. Neither is created by this plan; increment 2 is what made
+them visible.
+
+**1. The rules govern nothing.** In a `src/{orders,billing}/` repo,
+`detect_source_root` returns `""`, so `resolve_path_scoped_dests` leaves
+codex's destinations root-relative and `apply` writes `api/AGENTS.md`,
+`ports/AGENTS.md`, `services/AGENTS.md`, `adapters/AGENTS.md` and
+`security/AGENTS.md` at the repo root. Verified on a real install: there is
+**no `AGENTS.md` anywhere under `src/orders` or `src/billing`**. Codex
+resolves `AGENTS.md` upward from the file being edited, so a file at
+`src/orders/api/handlers.py` finds the top-level `AGENTS.md` and never the
+root `api/AGENTS.md`. Those five files govern no code at all.
+
+This is the same defect `resolve_path_scoped_dests` was written to fix for
+the `src/<package>/` layout, left unfixed for the multi-service one.
+
+**2. They then hide the services.** Those root-level folders make
+`_layer_root_candidates` match at the target root, so every later reading of
+the repo sees a flat single-service layout. Increment 2 fixed `apply` by
+observing before writing, but the folders are on disk permanently, so a
+later `upgrade` — which builds its profile after the install — derives no
+services and the list is dropped. Measured:
+
+| Agent | after `apply` | after `upgrade` |
+| --- | --- | --- |
+| claude-code | 2 services | 2 services |
+| codex | 2 services | **0** |
+| copilot | 2 services | 2 services |
+
+Nothing reads `services` yet, so the practical impact today is zero. That
+stops being true at increment 3, which is why it blocks it: a skill taught
+to read a field that erases itself on the next `upgrade` is worse than a
+skill that does not know about services.
+
+**Recommended fix: fan the path-scoped rules out per service.**
+`src/orders/api/AGENTS.md` and `src/billing/api/AGENTS.md` rather than one
+root copy. It puts the rules where codex will actually resolve them, and it
+creates no root-level layer folders, so the detection problem disappears
+with the defect that caused it. `detect_services` — which increment 2 adds —
+is exactly what makes it expressible; `resolve_path_scoped_dests` grows one
+branch. claude-code and copilot need no change: their `**/<layer>/**` globs
+already match at any depth, which is the accident recorded in Motivation §3.
+
+Two alternatives, both weaker. *Drop the path-scoped rules entirely for a
+multi-service repo* — smaller, and removes only files that demonstrably do
+nothing, but it leaves those services with no codex layer guidance. *Leave
+it* — increment 3 then has to treat `services` as unreliable on one agent.
+
+Either way, an install that already has the stale root folders keeps them:
+govkit does not delete files it did not write in the user's tree. Worth
+deciding whether `doctor` should name them.
 
 ## Out of scope
 

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -1,12 +1,14 @@
 # Multi-Service Skill Context Plan
 
-**Status:** In progress — 2026-08-03. Covers #86. Increments 1, 2 and 2b done
-(derived `source_root`, `services`, per-service codex rules + doctor D018);
-increments 3–4 not started.
+**Status:** Implemented — 2026-08-03, all increments. Derived `source_root`
+(#117), `services` + per-service codex rules + doctor D018 (#118), planning
+skills that ask which service, and the docs. Closes #86.
 
-Increment 2b unblocked increment 3: codex's path-scoped rules now fan out per
-service, so they govern the code they describe and no longer make a
-multi-service repo read as single-service.
+One increment was not in the plan. **2b** came out of increment 2's
+end-to-end run, which found that codex's path-scoped rules governed no code
+in a multi-service repo and that the folders they created made every later
+reading of the repo see a flat single-service layout. That would have made
+increment 3 unsafe — a skill taught to read a field that erases itself.
 
 Give `.govkit/skill_context.yaml` an honest source root and a way to say
 "this repo holds several services", so a skill can scope its work to one of
@@ -359,7 +361,7 @@ the right advice for each.
 
 Commit: `fix(cli): scope codex path-scoped rules to each service (#86)`
 
-### 3. Skills ask which service
+### 3. Skills ask which service — done
 
 1. Failing test in `tests/test_agent_skills.py`: `spec-planning` and
    `implementation-plan` instruct the agent to check
@@ -367,14 +369,43 @@ Commit: `fix(cli): scope codex path-scoped rules to each service (#86)`
    names none, to ask before planning.
 2. Edit the three agents' copies in lockstep; frontmatter stays byte-identical.
 
+Two things beyond the plan as written:
+
+- **Naming the service is not enough.** The section also requires the
+  chosen service's `root` to prefix every path in the output. Without it a
+  plan says `services/pricing.py`, which is a folder that does not exist in
+  a repo whose only services folders are `src/orders/services/` and
+  `src/billing/services/`. Pinned by a test asserting the section shows a
+  scoped path.
+- **Placed before the inputs section, not appended.** The question has to be
+  resolved before planning starts. That position also keeps the block
+  extractable for the parity test — the next heading is `## `, so the
+  comparison covers the section and nothing after it. Appending would have
+  swallowed the trailing `### Data projects` note in the spec-planning
+  files, and the parity test would have failed for a reason that had
+  nothing to do with the section.
+
+UI copies deliberately untouched, with a test asserting they stay that way.
+
 Commit: `feat(skills): scope planning to one service in multi-service repos (#86)`
 
-### 4. Documentation
+### 4. Documentation — done
 
 1. `docs/backend/architecture/REPO_STRUCTURE_README.md`: the multi-service
    shape and what `skill_context` says about it.
 2. Cross-reference the import-linter reference's `containers` guidance, which
    already documents the same layout from the enforcement side.
+
+The cross-reference runs both ways: the reference file now points at
+`architecture.services` as the place the container names are already
+recorded, so an adopter copies them rather than working them out.
+
+`REPO_STRUCTURE_README.md` is **stack-agnostic**, so it must not name a
+boundary tool — `tests/test_layer_vocabulary.py` enforces that and the doc
+is in its scanned set. The boundary bullet therefore describes what the
+reference contract does and defers to `TECH_STACK.md` for which tool this
+stack uses, per the convention #104 established. Worth recording because
+the obvious draft named the tool and would have failed the check.
 
 Commit: `docs(backend): document the multi-service skill context (#86)`
 

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -208,3 +208,101 @@ def test_ui_nextjs_skill_content_parity(skill: str):
     assert all(text == texts[0] for text in texts[1:]), (
         f"{skill} drifted across agents"
     )
+
+
+# ---------------------------------------------------------------------------
+# Multi-service planning — #86 increment 3
+# ---------------------------------------------------------------------------
+
+PLANNING_SKILL_PATHS = [
+    REPO_ROOT / "agents" / agent / "skills" / "backend" / skill / "SKILL.md"
+    for agent in ("claude-code", "codex", "copilot")
+    for skill in ("spec-planning", "implementation-plan")
+]
+
+SERVICES_HEADING = "## Multi-service repos"
+
+
+def _planning_id(p: Path) -> str:
+    return f"{p.parent.parent.parent.parent.name}/{p.parent.name}"
+
+
+def test_the_planning_skill_set_is_what_we_think_it_is():
+    """Six files: two planning skills across three agents. If a path moved,
+    the parametrized tests below would silently cover fewer files."""
+    assert len(PLANNING_SKILL_PATHS) == 6
+    missing = [p for p in PLANNING_SKILL_PATHS if not p.is_file()]
+    assert not missing, f"planning skills not found: {missing}"
+
+
+@pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
+def test_planning_skills_have_a_multi_service_section(skill_path: Path):
+    text = skill_path.read_text(encoding="utf-8")
+    assert SERVICES_HEADING in text, (
+        f"{skill_path.relative_to(REPO_ROOT)} missing '{SERVICES_HEADING}'"
+    )
+
+
+@pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
+def test_multi_service_section_tells_the_agent_to_ask(skill_path: Path):
+    """#86's third question: several services, and the request names none.
+    The answer is to ask, not to guess and not to plan across all of them."""
+    section = _extract_section(skill_path.read_text(encoding="utf-8"), SERVICES_HEADING)
+    required = [
+        "architecture.services",   # the field to read
+        "architecture.source_root",  # the single-service fallback
+        "root",                    # each service carries one
+        "ask",                     # the required behaviour when ambiguous
+    ]
+    missing = [p for p in required if p not in section]
+    assert not missing, (
+        f"{skill_path.relative_to(REPO_ROOT)} multi-service section missing: {missing}"
+    )
+
+
+@pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
+def test_multi_service_section_forbids_guessing(skill_path: Path):
+    section = _extract_section(
+        skill_path.read_text(encoding="utf-8"), SERVICES_HEADING,
+    ).lower()
+    assert "do not guess" in section
+    assert "do not plan across" in section
+
+
+@pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
+def test_multi_service_section_scopes_output_paths_to_the_service(skill_path: Path):
+    """Naming the service is not enough — the plan's file paths have to land
+    inside it, or the agent writes `services/x.py` into a repo where that
+    folder only exists as `src/orders/services/`."""
+    section = _extract_section(skill_path.read_text(encoding="utf-8"), SERVICES_HEADING)
+    assert "src/orders/services/" in section, (
+        f"{skill_path.relative_to(REPO_ROOT)} does not show a path scoped to a service root"
+    )
+
+
+def test_multi_service_section_parity_across_agents():
+    """Byte-identical across all six files, per [[feedback_agent_parity]]."""
+    sections = {
+        _planning_id(p): _extract_section(p.read_text(encoding="utf-8"), SERVICES_HEADING)
+        for p in PLANNING_SKILL_PATHS
+    }
+    assert all(sections.values()), (
+        f"empty section in: {[k for k, v in sections.items() if not v]}"
+    )
+    distinct = set(sections.values())
+    assert len(distinct) == 1, (
+        "multi-service section differs across agents:\n"
+        + "\n".join(f"--- {k} ---\n{v}" for k, v in sections.items())
+    )
+
+
+def test_ui_planning_skills_do_not_gain_the_section():
+    """UI installs have no service packages — #86 puts them out of scope, and
+    a section telling a UI agent to pick a service would be noise."""
+    ui_paths = [
+        REPO_ROOT / "agents" / agent / "skills" / "ui" / skill / "SKILL.md"
+        for agent in ("claude-code", "codex", "copilot")
+        for skill in ("spec-planning", "implementation-plan")
+    ]
+    present = [p for p in ui_paths if p.is_file() and SERVICES_HEADING in p.read_text(encoding="utf-8")]
+    assert not present, f"UI skills carry the multi-service section: {present}"

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import pytest
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILL_PATHS = [
     REPO_ROOT / "agents" / agent / "skills" / layer / "architecture-preflight" / "SKILL.md"

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -958,8 +958,105 @@ class TestSourceRootAndServicesAgree:
         from cli.detect import detect_services, detect_source_root
 
         _hexagonal_package(tmp_path, "")
+        (tmp_path / "api" / "handlers.py").write_text("x = 1\n", encoding="utf-8")
+        (tmp_path / "services" / "orders.py").write_text("x = 1\n", encoding="utf-8")
         for svc in ("orders", "billing"):
             _hexagonal_package(tmp_path, f"src/{svc}")
 
         assert detect_source_root(tmp_path) == ""
         assert detect_services(tmp_path) == []
+
+
+class TestGovkitsOwnFoldersAreNotEvidence:
+    """govkit must not read its own output as the repo's architecture.
+
+    Before the per-service fan-out, a multi-service install put codex's
+    layer rules at the repo root — `api/AGENTS.md`, `ports/AGENTS.md` and so
+    on, in folders govkit created. Every later reading then saw layers at
+    the target root and reported a flat single-service repo. The damage was
+    self-perpetuating: once those folders existed, `detect_services` could
+    never again return anything, so the fan-out would never fire on the very
+    installs that needed it and the doctor check for stale rules could never
+    fire either.
+
+    A folder holding nothing but a govkit-authored `AGENTS.md` is govkit's
+    own artifact, not a source layer. Discounted **only at the target
+    root**, which is the one place govkit creates layer folders — everywhere
+    else it writes into folders the team already had, and discounting there
+    would make a greenfield `src/<pkg>/` install relocate its own rules on
+    the second run.
+    """
+
+    GOVKIT_ONLY = (
+        "<!-- BEGIN GOVKIT GOVERNANCE -->\n# rule\n"
+        "<!-- END GOVKIT GOVERNANCE -->\n"
+    )
+
+    def _pollute_root(self, target, *layers):
+        for layer in layers:
+            (target / layer).mkdir(parents=True, exist_ok=True)
+            (target / layer / "AGENTS.md").write_text(self.GOVKIT_ONLY, encoding="utf-8")
+
+    def test_a_polluted_multi_service_repo_still_reports_its_services(self, tmp_path):
+        from cli.detect import detect_services, detect_source_root
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        self._pollute_root(tmp_path, "api", "ports", "services", "adapters", "security")
+
+        assert detect_source_root(tmp_path) == ""
+        assert [n for n, _r in detect_services(tmp_path)] == ["billing", "orders"]
+
+    def test_real_root_layers_are_still_evidence(self, tmp_path):
+        """A team's own flat repo must keep reporting as flat. The layer
+        folders there hold code, not just govkit's file."""
+        from cli.detect import detect_services, detect_source_root
+
+        _hexagonal_package(tmp_path, "")
+        (tmp_path / "api" / "handlers.py").write_text("x = 1\n", encoding="utf-8")
+        (tmp_path / "services" / "orders.py").write_text("x = 1\n", encoding="utf-8")
+
+        assert detect_source_root(tmp_path) == ""
+        assert detect_services(tmp_path) == []
+
+    def test_a_layer_folder_holding_a_teams_own_agents_md_is_evidence(self, tmp_path):
+        """Only a folder holding *nothing but* govkit's block is discounted.
+        A file the team wrote — govkit's block appended below their content —
+        means they own that folder."""
+        from cli.detect import detect_source_root
+
+        _hexagonal_package(tmp_path, "")
+        for layer in ("api", "ports", "services", "adapters"):
+            (tmp_path / layer / "AGENTS.md").write_text(
+                "# Team notes\n\nOurs.\n" + self.GOVKIT_ONLY, encoding="utf-8",
+            )
+
+        # Still reads as layers at the root, so no service packages.
+        assert detect_source_root(tmp_path) == ""
+
+    def test_a_greenfield_package_layout_does_not_relocate_itself(self, tmp_path):
+        """The regression the narrow scoping exists to avoid. Empty layer
+        folders under `src/<pkg>/` hold only govkit's AGENTS.md after the
+        first install; discounting them there would drop the source root and
+        send the next run's rules back to the repo root."""
+        from cli.detect import detect_source_root
+
+        _hexagonal_package(tmp_path, "src/mypkg")
+        for layer in BACKEND_LAYERS:
+            (tmp_path / "src" / "mypkg" / layer / "AGENTS.md").write_text(
+                self.GOVKIT_ONLY, encoding="utf-8",
+            )
+
+        assert detect_source_root(tmp_path) == "src/mypkg"
+
+    def test_a_folder_with_other_files_beside_agents_md_is_evidence(self, tmp_path):
+        from cli.detect import detect_source_root
+
+        _hexagonal_package(tmp_path, "")
+        for layer in ("api", "ports", "services", "adapters"):
+            (tmp_path / layer / "AGENTS.md").write_text(self.GOVKIT_ONLY, encoding="utf-8")
+        (tmp_path / "api" / "handlers.py").write_text("x = 1\n", encoding="utf-8")
+        (tmp_path / "services" / "orders.py").write_text("x = 1\n", encoding="utf-8")
+
+        assert detect_source_root(tmp_path) == ""
+

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -22,6 +22,8 @@ class TestRepoProfileShape:
         assert prof.detected_api_style is None
         assert prof.detected_llm_signals == []
         assert prof.detected_architecture_signals == []
+        assert prof.detected_source_root == ""
+        assert prof.detected_services == []
 
 
 class TestLanguageDetection:
@@ -751,3 +753,213 @@ class TestFindRecursivePruning:
                 f"_find_recursive walked into a skip dir: {d}; "
                 f"pruning must happen via dirnames[:] mutation"
             )
+
+
+# ---------------------------------------------------------------------------
+# Service detection — #86
+# ---------------------------------------------------------------------------
+
+BACKEND_LAYERS = ("api", "ports", "services", "models", "adapters", "common")
+
+
+def _hexagonal_package(target, prefix: str) -> None:
+    """Create one hexagonal package rooted at `prefix` ("" = target root)."""
+    base = target / prefix if prefix else target
+    for layer in BACKEND_LAYERS:
+        (base / layer).mkdir(parents=True, exist_ok=True)
+
+
+class TestDetectServices:
+    """`detect_services` names the service packages in a multi-service repo.
+
+    It reads the same candidate roots `detect_source_root` walks — the work
+    that function already did and threw away whenever it found more than one
+    (see the plan's open question 1). The two answers must stay consistent,
+    which is what `TestSourceRootAndServicesAgree` below is for.
+    """
+
+    def test_two_service_packages_are_both_named(self, tmp_path):
+        from cli.detect import detect_services
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+
+        assert detect_services(tmp_path) == [
+            ("billing", "src/billing"),
+            ("orders", "src/orders"),
+        ]
+
+    def test_three_service_packages_are_all_named(self, tmp_path):
+        """Two is the case #86 reports; nothing may cap the list at two."""
+        from cli.detect import detect_services
+
+        for svc in ("billing", "orders", "shipping"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+
+        assert [name for name, _ in detect_services(tmp_path)] == [
+            "billing", "orders", "shipping",
+        ]
+
+    def test_documented_single_package_is_not_a_service_list(self, tmp_path):
+        """One package is the canonical single-service layout, described by
+        `source_root` alone. Emitting a one-entry list would make every
+        conforming repo look multi-service."""
+        from cli.detect import detect_services
+
+        _hexagonal_package(tmp_path, "src/mypkg")
+
+        assert detect_services(tmp_path) == []
+
+    def test_flat_under_src_is_not_a_service(self, tmp_path):
+        """`src/` holding the layers directly is a source root, not a service
+        package. Naming it would put a service called "src" in the file."""
+        from cli.detect import detect_services
+
+        _hexagonal_package(tmp_path, "src")
+
+        assert detect_services(tmp_path) == []
+
+    def test_layers_at_the_target_root_are_not_a_service(self, tmp_path):
+        from cli.detect import detect_services
+
+        _hexagonal_package(tmp_path, "")
+
+        assert detect_services(tmp_path) == []
+
+    def test_unrecognisable_repo_has_no_services(self, tmp_path):
+        from cli.detect import detect_services
+
+        (tmp_path / "docs").mkdir()
+
+        assert detect_services(tmp_path) == []
+
+    def test_non_conforming_sibling_is_omitted(self, tmp_path):
+        """`src/legacy/` that is not hexagonal at all sits beside two real
+        services. Only the conforming packages are listed — the plan's open
+        question 3."""
+        from cli.detect import detect_services
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "legacy" / "scripts").mkdir(parents=True)
+
+        assert [name for name, _ in detect_services(tmp_path)] == ["billing", "orders"]
+
+    def test_one_conforming_package_beside_a_non_conforming_one(self, tmp_path):
+        """Only one service survives the filter, so this is the single-service
+        case and gets no list."""
+        from cli.detect import detect_services
+
+        _hexagonal_package(tmp_path, "src/orders")
+        (tmp_path / "src" / "legacy" / "scripts").mkdir(parents=True)
+
+        assert detect_services(tmp_path) == []
+
+    def test_skip_dirs_are_never_services(self, tmp_path):
+        from cli.detect import detect_services
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        _hexagonal_package(tmp_path, "src/node_modules")
+        _hexagonal_package(tmp_path, "src/.hidden")
+
+        assert [name for name, _ in detect_services(tmp_path)] == ["billing", "orders"]
+
+    def test_roots_are_posix_relative_to_the_target(self, tmp_path):
+        """Windows separators in an emitted YAML path would be wrong for the
+        agents that read it."""
+        from cli.detect import detect_services
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+
+        for _name, root in detect_services(tmp_path):
+            assert "\\" not in root
+            assert not root.startswith("/")
+
+
+class TestSourceRootAndServicesAgree:
+    """One walk, two readings — the invariant that binds them.
+
+    `detect_source_root` and `detect_services` read the same candidate list.
+    If they ever disagree, `skill_context.yaml` states both a single root and
+    a set of services, which is the contradiction #86 exists to remove.
+    """
+
+    # layout -> (dirs to create, expected source_root, expected service count)
+    LAYOUTS = {
+        "flat-at-root":       ([""], "", 0),
+        "flat-under-src":     (["src"], "src", 0),
+        "documented-package": (["src/mypkg"], "src/mypkg", 0),
+        "two-services":       (["src/orders", "src/billing"], "", 2),
+        "three-services":     (["src/orders", "src/billing", "src/shipping"], "", 3),
+    }
+
+    @pytest.mark.parametrize("layout", sorted(LAYOUTS))
+    def test_both_answers_match_the_layout(self, tmp_path, layout):
+        from cli.detect import detect_services, detect_source_root
+
+        dirs, expected_root, expected_count = self.LAYOUTS[layout]
+        for prefix in dirs:
+            _hexagonal_package(tmp_path, prefix)
+
+        assert detect_source_root(tmp_path) == expected_root
+        assert len(detect_services(tmp_path)) == expected_count
+
+    @pytest.mark.parametrize("layout", sorted(LAYOUTS))
+    def test_services_are_listed_only_when_there_is_no_single_root(self, tmp_path, layout):
+        """The contradiction this pair must never produce: a file naming one
+        source root *and* a set of services."""
+        from cli.detect import detect_services, detect_source_root
+
+        dirs, _root, _count = self.LAYOUTS[layout]
+        for prefix in dirs:
+            _hexagonal_package(tmp_path, prefix)
+
+        if detect_services(tmp_path):
+            assert detect_source_root(tmp_path) == "", (
+                f"{layout}: services listed alongside a single source root"
+            )
+
+    def test_the_layout_table_asserts_both_outcomes(self):
+        """Guard against this table drifting to one shape. Written as counts
+        rather than "some layout has services", so a table that lost its
+        multi-service rows — or its single-service ones — fails here instead
+        of quietly making the parametrized tests vacuous."""
+        counts = {count for _dirs, _root, count in self.LAYOUTS.values()}
+        assert len(self.LAYOUTS) == 5
+        assert 0 in counts
+        assert {c for c in counts if c > 1} == {2, 3}
+        assert {root for _d, root, _c in self.LAYOUTS.values()} == {"", "src", "src/mypkg"}
+
+    def test_a_source_root_beside_a_foreign_package_names_neither(self, tmp_path):
+        """`src/` holding layers directly, next to `Source/pkg` that also
+        does. Two candidates, so no single root — but only one of them is a
+        service package, and one service is not a multi-service repo. The
+        honest answer is "govkit cannot tell", not a one-entry list naming
+        `src` as a service.
+
+        This is the case that decided `detect_services` filters candidates by
+        their parent rather than trusting the count.
+        """
+        from cli.detect import detect_services, detect_source_root
+
+        _hexagonal_package(tmp_path, "src")
+        _hexagonal_package(tmp_path, "Source/pkg")
+
+        assert detect_source_root(tmp_path) == ""
+        assert detect_services(tmp_path) == []
+
+    def test_root_layers_win_over_service_packages(self, tmp_path):
+        """A repo with layers at the root *and* `src/{orders,billing}/` has no
+        coherent answer. `detect_source_root` has always stopped at the root
+        in that case; the shared walk keeps that rather than inheriting it by
+        accident, and services stay unlisted."""
+        from cli.detect import detect_services, detect_source_root
+
+        _hexagonal_package(tmp_path, "")
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+
+        assert detect_source_root(tmp_path) == ""
+        assert detect_services(tmp_path) == []

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1200,3 +1200,178 @@ class TestMonorepoDiscovery:
         assert "apps/web" in out.replace("\\", "/")
         # Both clean → exit 0
         assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# D018 — path-scoped rules left where govkit no longer writes them
+# ---------------------------------------------------------------------------
+
+BACKEND_LAYERS = ("api", "ports", "services", "models", "adapters", "common")
+
+GOVKIT_BLOCK = (
+    "<!-- BEGIN GOVKIT GOVERNANCE -->\n# govkit rule\n"
+    "<!-- END GOVKIT GOVERNANCE -->\n"
+)
+
+
+def _multi_service_repo(target: Path) -> None:
+    for svc in ("orders", "billing"):
+        for layer in BACKEND_LAYERS:
+            (target / "src" / svc / layer).mkdir(parents=True)
+
+
+class TestD018StalePathScopedRules:
+    """Fanning codex's layer rules out per service leaves any earlier
+    root-level copy behind.
+
+    govkit never deletes it — a team may have written that file, and even
+    when it did not, a stale copy here is inert rather than contradictory:
+    codex resolves AGENTS.md upward from the file being edited and never
+    reaches a root `api/AGENTS.md` from `src/orders/api/`. That is why this
+    reports rather than retiring the file the way
+    `reconcile_legacy_instruction_files` does, where the alternative is the
+    agent loading governance twice.
+    """
+
+    def test_fires_for_a_govkit_orphan_left_at_the_root(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        d018s = [f for f in run_doctor(tmp_path) if f.id == "D018"]
+        assert len(d018s) == 1
+        assert d018s[0].file.replace("\\", "/") == "api/AGENTS.md"
+        assert d018s[0].severity == "warning"
+
+    def test_a_govkit_orphan_may_be_deleted(self, tmp_path):
+        """It holds nothing the team wrote, so the advice can say so."""
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        finding = [f for f in run_doctor(tmp_path) if f.id == "D018"][0]
+        assert "delete" in finding.suggested_action.lower()
+
+    def test_a_team_authored_file_is_never_advised_away(self, tmp_path):
+        """The same location, but the team wrote content outside the block.
+        govkit must not suggest removing a file it did not author."""
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(
+            "# Team notes\n\nOur own guidance.\n\n" + GOVKIT_BLOCK, encoding="utf-8",
+        )
+
+        action = [f for f in run_doctor(tmp_path) if f.id == "D018"][0].suggested_action.lower()
+        # The file itself is never a delete target — only govkit's own block
+        # inside it, which is content govkit put there.
+        assert "leave the file" in action
+        assert "delete api/agents.md" not in action
+        assert "remove api/agents.md" not in action
+        assert "block" in action
+
+    def test_names_the_live_location_so_the_advice_is_actionable(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        finding = [f for f in run_doctor(tmp_path) if f.id == "D018"][0]
+        text = (finding.message + finding.suggested_action).replace("\\", "/")
+        assert "src/orders" in text or "src/billing" in text
+
+    def test_silent_on_a_clean_multi_service_install(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_silent_when_the_rules_are_where_they_belong(self, tmp_path):
+        """The fanned-out copies must not be mistaken for stale ones."""
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        for svc in ("orders", "billing"):
+            (tmp_path / "src" / svc / "api" / "AGENTS.md").write_text(
+                GOVKIT_BLOCK, encoding="utf-8",
+            )
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_silent_on_a_single_service_repo_where_the_root_is_correct(self, tmp_path):
+        """A flat repo is where govkit *does* write root-relative layer
+        rules. Flagging them would call a correct install broken."""
+        from cli.doctor import run_doctor
+
+        for layer in BACKEND_LAYERS:
+            (tmp_path / layer).mkdir(parents=True)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_silent_for_a_documented_package_layout(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        for layer in BACKEND_LAYERS:
+            (tmp_path / "src" / "mypkg" / layer).mkdir(parents=True)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "src" / "mypkg" / "api" / "AGENTS.md").write_text(
+            GOVKIT_BLOCK, encoding="utf-8",
+        )
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    @pytest.mark.parametrize("agent", ["claude-code", "copilot"])
+    def test_silent_for_agents_with_no_path_scoped_rules(self, tmp_path, agent):
+        """Their rules are globs, never files inside layer folders. A stray
+        root `api/AGENTS.md` in such an install is not govkit's business."""
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent=agent)
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_a_file_without_a_govkit_block_is_not_govkits_business(self, tmp_path):
+        """A root `api/AGENTS.md` the team wrote and govkit never touched is
+        not a stale govkit rule — it is just their file."""
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(
+            "# Purely ours\n", encoding="utf-8",
+        )
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_every_stale_location_is_reported(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _multi_service_repo(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        for layer in ("api", "ports", "services"):
+            (tmp_path / layer).mkdir(exist_ok=True)
+            (tmp_path / layer / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        reported = {
+            f.file.replace("\\", "/") for f in run_doctor(tmp_path) if f.id == "D018"
+        }
+        assert reported == {"api/AGENTS.md", "ports/AGENTS.md", "services/AGENTS.md"}

--- a/tests/test_path_scoped_rules.py
+++ b/tests/test_path_scoped_rules.py
@@ -125,6 +125,196 @@ class TestCodexRulePlacement:
         assert body.count("BEGIN GOVKIT GOVERNANCE") == 1
 
 
+def _codex_path_scoped_dests() -> list[str]:
+    """The root-relative destinations codex's manifest declares as path-scoped.
+
+    Read from the manifest rather than listed here, so a rule added or
+    removed in the payload cannot leave these tests asserting a stale set.
+    """
+    from cli.manifest import load_manifest, resolve_variant_files
+
+    manifest = load_manifest("codex")
+    files, _shared, _governed = resolve_variant_files(
+        manifest, {"level": "4", "type": "api", "ci": "github", "stack": "python-fastapi"},
+    )
+    return [e["dest"] for e in files if e.get("path_scoped")]
+
+
+class TestMultiServiceFanOut:
+    """In a `src/{orders,billing}/` repo, codex's layer rules belong inside
+    each service.
+
+    Before this, `detect_source_root` returned `""` and the destinations
+    stayed root-relative, so `apply` wrote `api/AGENTS.md` at the repo root.
+    Codex resolves AGENTS.md upward from the file being edited, so a file at
+    `src/orders/api/handlers.py` reaches the top-level `AGENTS.md` and never
+    that one — the layer rules governed no code at all. The empty root
+    folders then made every later reading of the repo see a flat
+    single-service layout, which is what erased `architecture.services` on
+    upgrade.
+    """
+
+    @staticmethod
+    def _multi_service(target):
+        for svc in ("orders", "billing"):
+            for layer in BACKEND_LAYERS:
+                (target / "src" / svc / layer).mkdir(parents=True)
+
+    def test_the_manifest_really_declares_path_scoped_rules(self):
+        """Everything below is asserted against this set. If it emptied, the
+        tests would pass by describing nothing."""
+        dests = _codex_path_scoped_dests()
+        assert len(dests) >= 5
+        assert all(d.endswith("/AGENTS.md") for d in dests)
+        assert "api/AGENTS.md" in dests
+
+    def test_rules_land_inside_every_service(self, tmp_path):
+        target = tmp_path / "project"
+        target.mkdir()
+        self._multi_service(target)
+
+        _apply_codex(target)
+
+        for svc in ("orders", "billing"):
+            for dest in _codex_path_scoped_dests():
+                assert (target / "src" / svc / dest).is_file(), f"{svc}: missing {dest}"
+
+    def test_no_layer_rules_are_written_at_the_repo_root(self, tmp_path):
+        target = tmp_path / "project"
+        target.mkdir()
+        self._multi_service(target)
+
+        _apply_codex(target)
+
+        for dest in _codex_path_scoped_dests():
+            assert not (target / dest).exists(), (
+                f"{dest} written at the root, where codex will never resolve it"
+            )
+
+    def test_the_top_level_agents_md_is_untouched_by_the_fan_out(self, tmp_path):
+        """It is not path-scoped, so it stays exactly where it was."""
+        target = tmp_path / "project"
+        target.mkdir()
+        self._multi_service(target)
+
+        _apply_codex(target)
+
+        assert (target / "AGENTS.md").is_file()
+
+    def test_a_teams_own_file_at_a_service_location_keeps_its_content(self, tmp_path):
+        target = tmp_path / "project"
+        target.mkdir()
+        self._multi_service(target)
+        existing = target / "src" / "orders" / "api" / "AGENTS.md"
+        existing.write_text("# Orders notes\n\nMUST SURVIVE\n", encoding="utf-8")
+
+        _apply_codex(target)
+
+        body = existing.read_text(encoding="utf-8")
+        assert "MUST SURVIVE" in body
+        assert body.count("BEGIN GOVKIT GOVERNANCE") == 1
+
+    def test_three_services_each_get_the_rules(self, tmp_path):
+        target = tmp_path / "project"
+        target.mkdir()
+        for svc in ("orders", "billing", "shipping"):
+            for layer in BACKEND_LAYERS:
+                (target / "src" / svc / layer).mkdir(parents=True)
+
+        _apply_codex(target)
+
+        for svc in ("orders", "billing", "shipping"):
+            assert (target / "src" / svc / "api" / "AGENTS.md").is_file()
+
+    def test_non_conforming_siblings_get_no_rules(self, tmp_path):
+        """`src/legacy/` is not a service govkit can describe, so it is not
+        one govkit writes layer rules into either."""
+        target = tmp_path / "project"
+        target.mkdir()
+        self._multi_service(target)
+        (target / "src" / "legacy" / "scripts").mkdir(parents=True)
+
+        _apply_codex(target)
+
+        assert not (target / "src" / "legacy" / "api").exists()
+
+    def test_the_service_list_now_survives_an_upgrade(self, tmp_path):
+        """The point of the whole change. `apply` recorded the services
+        correctly before this; the root folders it created then made the next
+        `upgrade` read the repo as flat and drop them."""
+        import json
+
+        import yaml
+
+        from cli.cmd_upgrade import cmd_upgrade
+
+        target = tmp_path / "project"
+        target.mkdir()
+        self._multi_service(target)
+        _apply_codex(target)
+
+        def services():
+            data = yaml.safe_load(
+                (target / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+            )
+            return [s["name"] for s in data["architecture"].get("services", [])]
+
+        assert services() == ["billing", "orders"]
+
+        # An install from an earlier govkit, so upgrade does real work rather
+        # than short-circuiting on a matching version.
+        marker_path = target / ".govkit" / "marker.json"
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["version"] = "0.13.0"
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        assert services() == ["billing", "orders"]
+
+
+class TestSingleServiceFanOutRegression:
+    """Every layout that is not multi-service must install exactly as before."""
+
+    @pytest.mark.parametrize("prefix", ["", "src", "src/mypkg"])
+    def test_single_source_root_layouts_are_unchanged(self, tmp_path, prefix):
+        target = tmp_path / "project"
+        target.mkdir()
+        base = target / prefix if prefix else target
+        for layer in BACKEND_LAYERS:
+            (base / layer).mkdir(parents=True)
+
+        _apply_codex(target)
+
+        for dest in _codex_path_scoped_dests():
+            assert (base / dest).is_file(), f"{prefix or '<root>'}: missing {dest}"
+
+    def test_unknown_layout_still_installs_root_relative(self, tmp_path):
+        target = tmp_path / "project"
+        target.mkdir()
+
+        _apply_codex(target)
+
+        assert (target / "services" / "AGENTS.md").is_file()
+
+
+@pytest.mark.parametrize("agent", ["claude-code", "copilot"])
+def test_glob_based_agents_are_unaffected_by_the_fan_out(tmp_path, agent):
+    """Their rules carry `**/<layer>/**` globs that already match at any
+    depth, in every service — the accident #86 documents. The fan-out must
+    not start creating layer folders for them."""
+    target = tmp_path / "project"
+    target.mkdir()
+    for svc in ("orders", "billing"):
+        for layer in BACKEND_LAYERS:
+            (target / "src" / svc / layer).mkdir(parents=True)
+
+    _apply_codex(target, agent=agent)
+
+    assert not (target / "api" / "AGENTS.md").exists()
+    assert not (target / "src" / "orders" / "api" / "AGENTS.md").exists()
+
+
 @pytest.mark.parametrize("agent", ["claude-code", "copilot"])
 def test_glob_based_agents_are_unaffected(tmp_path, agent):
     """This change brings codex toward claude-code and copilot; it must not

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -1161,18 +1161,35 @@ class TestRepoIsObservedBeforeGovkitWritesToIt:
         )
         assert arch["source_root"] == ""
 
-    def test_codex_really_does_create_the_folders_that_would_hide_them(self, tmp_path):
-        """Without this, the codex row above could pass for the wrong reason
-        — a future change that stopped creating root-level layer folders
-        would make the regression untestable while looking green."""
-        target = tmp_path / "project"
-        target.mkdir()
-        _multi_service(target, "orders", "billing")
+    def test_the_layout_facts_come_from_the_profile_not_a_second_reading(self, tmp_path):
+        """The property itself, pinned where it cannot go vacuous.
 
-        self._apply(target, "codex")
+        The three rows above assert a correct end state. They no longer
+        *exercise* this: once codex's rules fan out per service, `apply`
+        stops creating root-level layer folders, so re-deriving afterwards
+        would reach the right answer anyway and the rows would pass either
+        way. (The guard that used to sit here watched for exactly that
+        change, and the fan-out is it.)
 
-        created = {d.name for d in target.iterdir() if d.is_dir()}
-        assert {"api", "ports", "services", "adapters"} <= created
+        So state it directly: hand `build_skill_context` a profile that
+        disagrees with the tree, and the profile must win. Any future write
+        that reshapes the target — a path-scoped rule for a new type, a
+        scaffold — is then covered without a test having to predict it.
+        """
+        from cli.detect import build_profile
+        from cli.skill_context import build_skill_context
+
+        marker = _write_marker(tmp_path)
+        _multi_service(tmp_path, "orders", "billing")
+        profile = build_profile(tmp_path)
+        assert len(profile.detected_services) == 2
+
+        # The tree now says something else entirely.
+        _make_layout(tmp_path, _layers_under(""))
+        assert build_profile(tmp_path).detected_services == []
+
+        arch = build_skill_context(tmp_path, marker, profile=profile)["architecture"]
+        assert [s["name"] for s in arch["services"]] == ["billing", "orders"]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     def test_apply_records_the_source_root_that_was_there_before_it_ran(self, tmp_path, agent):

--- a/tests/test_skill_context.py
+++ b/tests/test_skill_context.py
@@ -1043,3 +1043,425 @@ class TestLoadSkillContextSourceRoot:
         ctx = load_skill_context(tmp_path)
         assert ctx is not None
         assert ctx.source_root == ""
+
+
+# ---------------------------------------------------------------------------
+# architecture.services — #86
+# ---------------------------------------------------------------------------
+
+def _multi_service(target: Path, *names: str) -> None:
+    for svc in names:
+        _make_layout(target, _layers_under(f"src/{svc}"))
+
+
+# Layouts that describe exactly one place the code lives, and so must not
+# grow a `services` list. Written out so the "absent" assertion covers every
+# shape rather than whichever one was convenient.
+_SINGLE_SERVICE_LAYOUTS = [
+    ("flat-at-root", _layers_under("")),
+    ("flat-under-src", _layers_under("src")),
+    ("documented-package", _layers_under("src/mypkg")),
+    ("unrecognisable", ["docs"]),
+]
+
+
+class TestEmittedServices:
+    """`architecture.services` says "this repo holds several services".
+
+    Absent for the single-service case, which keeps every file written
+    before #86 valid and the common case a two-line read.
+    """
+
+    def test_multi_service_layout_names_every_service(self, tmp_path):
+        _multi_service(tmp_path, "orders", "billing")
+
+        assert _emit_architecture(tmp_path)["services"] == [
+            {"name": "billing", "root": "src/billing"},
+            {"name": "orders", "root": "src/orders"},
+        ]
+
+    def test_multi_service_layout_reports_no_single_source_root(self, tmp_path):
+        """The two fields are read together: `""` plus a list means "several
+        services", `""` alone means "govkit could not tell"."""
+        _multi_service(tmp_path, "orders", "billing")
+
+        arch = _emit_architecture(tmp_path)
+        assert arch["source_root"] == ""
+        assert len(arch["services"]) == 2
+
+    @pytest.mark.parametrize(
+        "dirs",
+        [dirs for _, dirs in _SINGLE_SERVICE_LAYOUTS],
+        ids=[layout_id for layout_id, _ in _SINGLE_SERVICE_LAYOUTS],
+    )
+    def test_single_service_layouts_omit_the_key_entirely(self, tmp_path, dirs):
+        _make_layout(tmp_path, dirs)
+
+        assert "services" not in _emit_architecture(tmp_path)
+
+    def test_unrecognisable_repo_is_distinguishable_from_multi_service(self, tmp_path):
+        """Both carry `source_root: ""`. The presence of `services` is the
+        only thing separating "there are three services" from "govkit could
+        not read this repo", so it must not be emitted as an empty list."""
+        _make_layout(tmp_path, ["docs"])
+        unreadable = _emit_architecture(tmp_path)
+
+        assert unreadable["source_root"] == ""
+        assert "services" not in unreadable
+
+    def test_the_single_service_table_is_populated(self):
+        assert len(_SINGLE_SERVICE_LAYOUTS) == 4
+
+
+class TestRepoIsObservedBeforeGovkitWritesToIt:
+    """The emitted file must describe the team's repo, not the repo govkit
+    just finished modifying.
+
+    Codex places a path-scoped `AGENTS.md` inside each layer folder. When
+    there is no single source root — which is exactly the multi-service
+    case — those destinations stay root-relative, so `apply` creates
+    root-level `api/`, `ports/`, `services/` and `adapters/`. Re-deriving
+    afterwards reads that as a flat single-service repo and the service
+    list vanishes.
+
+    `style` and `detected_signals` never had this problem: they come from a
+    `RepoProfile` built during stack selection, before a byte is written.
+    These pin the layout facts to that same observation.
+    """
+
+    @staticmethod
+    def _apply(target, agent):
+        import argparse
+
+        from cli.cmd_apply import cmd_apply
+
+        cmd_apply(argparse.Namespace(
+            agent=agent, target=str(target), level="4", type="api",
+            ci="github", stack=None, force=False, detect=False,
+        ))
+
+    @staticmethod
+    def _architecture(target):
+        import yaml
+        return yaml.safe_load(
+            (target / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+        )["architecture"]
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    def test_apply_records_the_services_that_were_there_before_it_ran(self, tmp_path, agent):
+        target = tmp_path / "project"
+        target.mkdir()
+        _multi_service(target, "orders", "billing")
+
+        self._apply(target, agent)
+
+        arch = self._architecture(target)
+        assert [s["name"] for s in arch.get("services", [])] == ["billing", "orders"], (
+            f"{agent}: services lost — the file describes the post-install tree"
+        )
+        assert arch["source_root"] == ""
+
+    def test_codex_really_does_create_the_folders_that_would_hide_them(self, tmp_path):
+        """Without this, the codex row above could pass for the wrong reason
+        — a future change that stopped creating root-level layer folders
+        would make the regression untestable while looking green."""
+        target = tmp_path / "project"
+        target.mkdir()
+        _multi_service(target, "orders", "billing")
+
+        self._apply(target, "codex")
+
+        created = {d.name for d in target.iterdir() if d.is_dir()}
+        assert {"api", "ports", "services", "adapters"} <= created
+
+    @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+    def test_apply_records_the_source_root_that_was_there_before_it_ran(self, tmp_path, agent):
+        target = tmp_path / "project"
+        target.mkdir()
+        _make_layout(target, _layers_under("src/mypkg"))
+
+        self._apply(target, agent)
+
+        assert self._architecture(target)["source_root"] == "src/mypkg"
+
+
+class TestServicesProvenance:
+    """`services` is tunable on the same terms as the rest of the block —
+    with one wrinkle the other fields do not have: govkit writes it only
+    sometimes, so a team may add a key govkit never derived."""
+
+    @staticmethod
+    def _read(target):
+        import yaml
+        return yaml.safe_load(
+            (target / ".govkit" / "skill_context.yaml").read_text(encoding="utf-8"),
+        )
+
+    @staticmethod
+    def _edit(target, mutate):
+        import yaml
+        path = target / ".govkit" / "skill_context.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        mutate(data)
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    def test_derived_services_are_recorded_for_the_next_run(self, tmp_path):
+        _multi_service(tmp_path, "orders", "billing")
+        _emit_architecture(tmp_path)
+
+        record = self._read(tmp_path)["_govkit_generated"]
+        assert record["services"] == [
+            {"name": "billing", "root": "src/billing"},
+            {"name": "orders", "root": "src/orders"},
+        ]
+
+    def test_no_services_means_no_record_entry(self, tmp_path):
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        _emit_architecture(tmp_path)
+
+        assert "services" not in self._read(tmp_path)["_govkit_generated"]
+
+    def test_a_hand_added_service_list_survives(self, tmp_path):
+        """The plan's promise: "a team that lists services govkit did not
+        detect keeps that list". govkit derived nothing here, so there is no
+        record entry to compare against — a live value govkit never wrote is
+        by definition the team's."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        write_skill_context(tmp_path, marker)
+
+        theirs = [{"name": "orders", "root": "services/orders"}]
+        self._edit(tmp_path, lambda d: d["architecture"].update(services=theirs))
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["services"] == theirs
+
+    def test_a_hand_added_service_list_survives_repeated_writes(self, tmp_path):
+        """Once is not enough: the next write records what it derived again,
+        so the comparison has to keep coming out the same way."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        write_skill_context(tmp_path, marker)
+
+        theirs = [{"name": "orders", "root": "services/orders"}]
+        self._edit(tmp_path, lambda d: d["architecture"].update(services=theirs))
+        for _ in range(3):
+            write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["services"] == theirs
+
+    def test_an_edited_service_entry_survives(self, tmp_path):
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _multi_service(tmp_path, "orders", "billing")
+        write_skill_context(tmp_path, marker)
+
+        renamed = [
+            {"name": "invoicing", "root": "src/billing"},
+            {"name": "orders", "root": "src/orders"},
+        ]
+        self._edit(tmp_path, lambda d: d["architecture"].update(services=renamed))
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["services"] == renamed
+
+    def test_untouched_services_refresh_when_a_service_is_added(self, tmp_path):
+        """The reason this is provenance and not "non-empty wins": a repo
+        that grows a third service must show it."""
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _multi_service(tmp_path, "orders", "billing")
+        write_skill_context(tmp_path, marker)
+        assert len(self._read(tmp_path)["architecture"]["services"]) == 2
+
+        _multi_service(tmp_path, "shipping")
+        write_skill_context(tmp_path, marker)
+
+        assert [s["name"] for s in self._read(tmp_path)["architecture"]["services"]] == [
+            "billing", "orders", "shipping",
+        ]
+
+    def test_an_install_predating_the_field_picks_it_up(self, tmp_path):
+        """An increment-1 file on a multi-service repo has no `services`
+        anywhere — not in the live block, not in the record. The new field
+        must appear, the same way increment 1's corrected root did.
+
+        Hand-built: a file produced by today's writer would already carry
+        the field and prove nothing.
+        """
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _multi_service(tmp_path, "orders", "billing")
+        hexagonal = {
+            "inbound": ["api/", "ports/inbound/"],
+            "outbound": ["adapters/", "ports/outbound/"],
+            "domain": ["services/", "models/"],
+        }
+        (tmp_path / ".govkit").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".govkit" / "skill_context.yaml").write_text(
+            yaml.safe_dump({
+                "architecture": {
+                    "style": "hexagonal", "source_root": "",
+                    "layers": dict(hexagonal), "detected_signals": ["hexagonal-shape"],
+                },
+                "stack": {},
+                "_govkit_generated": {
+                    "style": "hexagonal", "source_root": "", "layers": dict(hexagonal),
+                },
+            }, sort_keys=False),
+            encoding="utf-8",
+        )
+
+        write_skill_context(tmp_path, marker)
+
+        assert [s["name"] for s in self._read(tmp_path)["architecture"]["services"]] == [
+            "billing", "orders",
+        ]
+
+    def test_a_live_value_with_no_record_entry_is_treated_as_a_team_edit(self, tmp_path):
+        """The general rule `services` needs, stated for a field that has
+        always been derived. A record that does not mention a key did not
+        write it, so whatever is live came from somewhere else and stays."""
+        import yaml
+
+        from cli.skill_context import write_skill_context
+
+        marker = _write_marker(tmp_path)
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        write_skill_context(tmp_path, marker)
+
+        path = tmp_path / ".govkit" / "skill_context.yaml"
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data["architecture"]["source_root"] = "app/"
+        del data["_govkit_generated"]["source_root"]
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+        write_skill_context(tmp_path, marker)
+
+        assert self._read(tmp_path)["architecture"]["source_root"] == "app/"
+
+
+class TestLoadSkillContextServices:
+    def _write(self, target: Path, body: str) -> None:
+        (target / ".govkit").mkdir(parents=True, exist_ok=True)
+        (target / ".govkit" / "skill_context.yaml").write_text(body, encoding="utf-8")
+
+    def test_services_round_trip_as_typed_refs(self, tmp_path):
+        from cli.skill_context import ServiceRef, load_skill_context
+
+        _multi_service(tmp_path, "orders", "billing")
+        _emit_architecture(tmp_path)
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == [
+            ServiceRef(name="billing", root="src/billing"),
+            ServiceRef(name="orders", root="src/orders"),
+        ]
+
+    def test_single_service_repo_loads_an_empty_list(self, tmp_path):
+        """`if ctx.services:` must read as "is this a multi-service repo",
+        so the single-service case is falsy rather than None."""
+        from cli.skill_context import load_skill_context
+
+        _make_layout(tmp_path, _layers_under("src/mypkg"))
+        _emit_architecture(tmp_path)
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == []
+
+    @pytest.mark.parametrize("body", [
+        "architecture:\n  services: orders\nstack: {}\n",
+        "architecture:\n  services: 3\nstack: {}\n",
+        "architecture:\n  services:\n    orders: src/orders\nstack: {}\n",
+    ], ids=["scalar-string", "scalar-int", "mapping"])
+    def test_a_hand_mangled_services_value_does_not_crash_the_loader(self, tmp_path, body):
+        """`list("orders")` would splat into characters; a mapping is the
+        other natural mistake. Both degrade to no services rather than
+        raising into _post_install_finalize."""
+        from cli.skill_context import load_skill_context
+
+        self._write(tmp_path, body)
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == []
+
+    def test_non_dict_entries_are_skipped_not_fatal(self, tmp_path):
+        from cli.skill_context import ServiceRef, load_skill_context
+
+        self._write(tmp_path, (
+            "architecture:\n"
+            "  services:\n"
+            "  - orders\n"
+            "  - {name: billing, root: src/billing}\n"
+            "  - [a, b]\n"
+            "stack: {}\n"
+        ))
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == [ServiceRef(name="billing", root="src/billing")]
+
+    def test_entries_missing_a_field_are_skipped(self, tmp_path):
+        """A ref without a root cannot be acted on; half an entry is worse
+        than none."""
+        from cli.skill_context import ServiceRef, load_skill_context
+
+        self._write(tmp_path, (
+            "architecture:\n"
+            "  services:\n"
+            "  - {name: orders}\n"
+            "  - {root: src/billing}\n"
+            "  - {name: shipping, root: src/shipping}\n"
+            "  - {name: '', root: src/empty}\n"
+            "stack: {}\n"
+        ))
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == [ServiceRef(name="shipping", root="src/shipping")]
+
+    def test_wrong_typed_fields_are_skipped(self, tmp_path):
+        from cli.skill_context import load_skill_context
+
+        self._write(tmp_path, (
+            "architecture:\n"
+            "  services:\n"
+            "  - {name: 3, root: src/orders}\n"
+            "  - {name: billing, root: [src/billing]}\n"
+            "stack: {}\n"
+        ))
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == []
+
+    def test_services_are_read_from_the_live_block_not_the_record(self, tmp_path):
+        """`_govkit_generated` carries its own `services` list. The two are
+        made to differ here, so a loader reading the wrong one is visible."""
+        from cli.skill_context import ServiceRef, load_skill_context
+
+        self._write(tmp_path, (
+            "architecture:\n"
+            "  services:\n"
+            "  - {name: orders, root: src/orders}\n"
+            "stack: {}\n"
+            "_govkit_generated:\n"
+            "  services:\n"
+            "  - {name: billing, root: src/billing}\n"
+        ))
+
+        ctx = load_skill_context(tmp_path)
+        assert ctx is not None
+        assert ctx.services == [ServiceRef(name="orders", root="src/orders")]


### PR DESCRIPTION
Increments 2, 2b, 3 and 4 of `plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md`.
With #117 (increment 1) already on main, this **closes #86**.

Closes #86

## What a multi-service repo gets

```yaml
architecture:
  style: hexagonal
  source_root: ''          # no single root
  services:
    - name: billing
      root: src/billing
    - name: orders
      root: src/orders
```

- **skill_context describes the shape.** `services` is absent — not `[]` —
  for a single-service repo, so `source_root: ""` with no list still reads
  as "govkit could not tell" rather than "there are zero services".
- **Planning skills ask which service**, list the names, and prefix every
  path in their output with that service's `root`.
- **Codex's layer rules land inside each service.**
- **Doctor D018** names rules an earlier install left at the repo root.
- **Docs** describe the layout, the table of what govkit records, and point
  at the boundary reference — which now points back.

## The two defects the end-to-end runs found

Unit tests were green through both. Neither was visible without a real
`govkit apply`.

**1. Codex silently got none of increment 2.** It writes a path-scoped
`AGENTS.md` per layer; with no single source root those destinations stayed
root-relative, so `apply` *created* root-level `api/`, `ports/`, `services/`
and `adapters/`, and deriving afterwards read the repo as flat. Root cause:
`source_root`/`services` were observed after the install while
`style`/`detected_signals` come from a `RepoProfile` built before it. All
four now live on that profile.

**2. Those root rules governed nothing, and hid the services.** Verified on
a real install: **no `AGENTS.md` anywhere under `src/orders` or
`src/billing`** — codex resolves upward from the file being edited and never
reaches the repo root from service code. Five files governing nothing, the
same defect `resolve_path_scoped_dests` fixed for `src/<package>/` and left
unfixed for multi-service. The folders then made `detect_services` return
`[]` for ever, so the list vanished on the next `upgrade`.

Rules now fan out per service. **Nothing is removed** —
`write_managed_agent_block` already replaces a file only when it can prove
the file is govkit's own, and otherwise appends its block below the team's
content. Confirmed against a hand-written root `AGENTS.md` *and* a
hand-written root `api/AGENTS.md`: both kept their content through apply and
upgrade.

D018 reports what is left behind, with advice per case:

| Left at the root | Advice |
| --- | --- |
| holds only govkit's block | safe to delete, and names the live locations |
| holds the team's content too | leave the file; the block inside it is stale |

Deliberately not `reconcile_legacy_instruction_files`' delete — that exists
because leaving its file makes the agent load governance *twice*. A stale
root rule here is inert, not contradictory.

### The migration nearly shipped broken

The first fan-out draft fixed fresh installs only. The root folders an
earlier govkit created made `_layer_root_candidates` match at the target
root, so `detect_services` returned `[]` for ever — the fan-out could never
fire on the installs that needed it, and **D018 could never fire at all.** A
check that cannot fail. Only replaying a real pre-fan-out install caught it.

A folder holding nothing but a govkit-authored `AGENTS.md` is now discounted
— **only at the target root**, the one place govkit creates layer folders.
Discounting under `src/<pkg>/` would drop the source root of a greenfield
install whose layer folders hold only the rules govkit just wrote, sending
the next run's rules back to the root. Pinned by
`test_a_greenfield_package_layout_does_not_relocate_itself`.

## Other things worth flagging

- **Provenance needed a third case.** `services` is the first field govkit
  writes only *sometimes*, so a team listing services in a repo govkit reads
  as single-service had no record entry to differ from and their list was
  dropped. A live key with no record entry now reads as "govkit did not
  write this". Proved load-bearing by reverting the line: exactly the three
  tests that exist for it fail.
- **The skills section had to name paths, not just services.** "Plan in
  `orders`" still produces `services/pricing.py`, a folder that does not
  exist. The section requires the `root` prefix.
- **`REPO_STRUCTURE_README.md` is stack-agnostic**, so the boundary bullet
  defers to `TECH_STACK.md` rather than naming a tool (#104's convention).
  The obvious draft named it and would have failed
  `test_layer_vocabulary.py`.

## Verification

- Real `govkit apply` over **6 layouts × 3 agents** against the same runs
  without these changes: the only differences anywhere are the `services`
  block and codex's five layer files moving into each service.
- `apply` twice is **idempotent** on all four layouts.
- A pre-fan-out install upgrades to per-service rules, keeps its
  team-authored root file and its service list, and reports one D018 per
  stale location.
- The installed skill's advice was checked against the same install's
  emitted `skill_context` — two services, `src/orders` and `src/billing`,
  with `src/orders/services/` present on disk — and installs with no
  unexpanded tokens.
- `./run_tests` 2130 passed · `./full_test` 134 passed / 16 skipped (Maven
  absent locally) · `pytest -k parity` 19 passed · `ruff check` clean.

## Left open, recorded in the plan

Doctor naming *skipped* sibling packages like `src/legacy/` — open question
3's remaining half. The obvious version would fire on `src/utils/`,
`src/config/` and every shared package. It needs a definition of "near miss"
first; my proposal is a package holding at least one layer folder but too
few to match a fingerprint.

Also noted while editing: claude-code's backend planning skills read
`skill_context` for architecture while codex's and copilot's hardcode
hexagonal folder names. Pre-existing, unrelated to #86, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
