### PR TITLE
fix(doctor): report every superseded path-scoped rule location (#83)

### DIFF
--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -845,12 +845,22 @@ def _check_stale_path_scoped_rules(
 ) -> list[ValidationFinding]:
     """D018 — a path-scoped rule sits where govkit no longer writes one.
 
-    In a multi-service repo govkit installs codex's layer rules inside each
-    service (`src/orders/api/AGENTS.md`). An earlier govkit put a single
-    copy at the repo root, where codex — which resolves AGENTS.md upward
-    from the file being edited — never reaches it from service code. Those
-    root copies govern nothing, and the folders holding them make the repo
-    read as flat single-service, which erases `architecture.services`.
+    govkit re-roots codex's layer rules onto the code they govern: onto the
+    detected source root (`src/api/AGENTS.md`), or once per service in a
+    multi-service repo (`src/orders/api/AGENTS.md`). An install made before
+    either change has them at the repo root, and the old copies stay —
+    govkit does not delete files in the user's tree.
+
+    They govern nothing there. Codex resolves AGENTS.md upward from the file
+    being edited, so `src/api/main.py` reaches `src/api/`, `src/` and the
+    repo root, never the root-level `api/` folder. The harm is a stale copy
+    that drifts from the live one, not conflicting instructions.
+
+    The question is **"does govkit still write here?"**, answered by asking
+    `resolve_path_scoped_dests` — the same function that decides placement —
+    rather than by testing for any one layout. Scoping this to the
+    multi-service case is what left #83 open after the check first shipped:
+    the single-source-root relocation is the same defect and went unreported.
 
     Reported, never removed. Two reasons, in order of importance: the file
     may be one the team authored, with govkit's block appended below their
@@ -862,31 +872,38 @@ def _check_stale_path_scoped_rules(
     Silent for claude-code and copilot: their rules are globs matching at
     any depth, so they declare no path-scoped entries at all.
     """
-    services = _detected_services(target)
-    if not services:
-        return []
-
     agent = marker.get("agent")
     if not agent:
         return []
     try:
+        from .install_common import resolve_path_scoped_dests
         from .manifest import load_manifest, resolve_variant_files
 
         manifest = load_manifest(agent)
         options = {**(marker.get("options") or {}), "level": marker.get("level", "3")}
         files, _shared, _governed = resolve_variant_files(manifest, options)
+        live_dests = {
+            entry["dest"]
+            for entry in resolve_path_scoped_dests(files, target)
+            if entry.get("path_scoped") and entry.get("dest")
+        }
     except (OSError, ValueError, KeyError, SystemExit):
         # Doctor never fails the run over an unreadable manifest; other
         # checks (D010) already speak to a broken install.
         return []
 
-    live_roots = ", ".join(root for _name, root in services)
     findings: list[ValidationFinding] = []
     for entry in files:
         if not entry.get("path_scoped"):
             continue
         dest = entry.get("dest")
-        if not dest:
+        # `dest` is the manifest's root-relative destination. When it is
+        # still among the live ones, this layout does not relocate the rule
+        # and the file at the root is the current copy, not a leftover.
+        if not dest or dest in live_dests:
+            continue
+        live = _live_locations_for(dest, live_dests)
+        if not live:
             continue
         stale = target / dest
         body = read_text_or_none(stale)
@@ -894,19 +911,19 @@ def _check_stale_path_scoped_rules(
         # team's file, and none of govkit's business.
         if body is None or GOVKIT_BLOCK_BEGIN not in body:
             continue
+        live_list = ", ".join(live)
         team_authored = body.strip() != _govkit_block_only(body).strip()
         if team_authored:
             action = (
                 f"leave the file as it is — govkit did not author it. The govkit "
-                f"block inside it is no longer refreshed; the live layer rules are "
-                f"now under each service ({live_roots}). Delete just the block "
-                f"between the BEGIN/END GOVKIT GOVERNANCE markers if you no longer "
-                f"want it."
+                f"block inside it is no longer refreshed; the live copy of this "
+                f"rule is at {live_list}. Delete just the block between the "
+                f"BEGIN/END GOVKIT GOVERNANCE markers if you no longer want it."
             )
         else:
             action = (
                 f"safe to delete {dest} — it holds only govkit's block, and the "
-                f"live layer rules are now under each service ({live_roots})"
+                f"live copy of this rule is at {live_list}"
             )
         findings.append(ValidationFinding(
             id="D018",
@@ -914,9 +931,9 @@ def _check_stale_path_scoped_rules(
             category="stale-path-scoped-rule",
             file=dest,
             message=(
-                f"{dest} governs no code in this multi-service repo — {agent} "
-                f"resolves AGENTS.md upward from the file being edited and never "
-                f"reaches the repo root from service code"
+                f"{dest} is a superseded rule location — govkit now installs this "
+                f"rule at {live_list}. {agent} resolves AGENTS.md upward from the "
+                f"file being edited, so the copy at {dest} governs none of that code"
             ),
             suggested_action=action,
         ))
@@ -936,14 +953,16 @@ def _govkit_block_only(body: str) -> str:
     return body[begin:end + len(GOVKIT_BLOCK_END)]
 
 
-def _detected_services(target: Path) -> list[tuple[str, str]]:
-    """`detect_services` with doctor's never-raise contract."""
-    try:
-        from .detect import detect_services
+def _live_locations_for(dest: str, live_dests: set[str]) -> list[str]:
+    """Where govkit now installs the rule the manifest declares at `dest`.
 
-        return detect_services(target)
-    except OSError:
-        return []
+    Matched by suffix rather than recomputed, so the answer comes from the
+    same `resolve_path_scoped_dests` call that produced `live_dests` and
+    cannot drift from it. One entry for a single source root, one per
+    service in a multi-service repo.
+    """
+    suffix = "/" + dest
+    return sorted(d for d in live_dests if d.endswith(suffix))
 
 
 # D002 (rule body mentions an absent folder name) is intentionally deferred.

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -486,7 +486,7 @@ earlier install left behind. Kept as a pointer because the reasoning that
 found them is worth keeping: unit tests were green across every layout while
 codex, one of three agents, got none of the feature.
 
-### Should doctor name skipped sibling packages?
+### Should doctor name skipped sibling packages? — tracked as #120
 
 Open question 3's remaining half, deliberately left out of 2b. A team reading
 `services: [orders, billing]` cannot tell whether that is the whole repo.
@@ -499,7 +499,35 @@ few to match a fingerprint, which is the case where govkit almost listed it
 and a team would be surprised it did not.
 
 That definition needs deciding before the check is written, which is why 2b
-shipped without it.
+shipped without it. Lifted into **#120** rather than left here, since an open
+question inside a plan marked Implemented is where things go to be forgotten.
+
+### Codex and copilot planning skills assume hexagonal — #119
+
+Found while adding increment 3's section and deliberately not fixed there.
+claude-code's copies of `spec-planning` and `implementation-plan` read
+`architecture.layers`; codex's and copilot's name `ports/inbound/`,
+`services/` and `adapters/` outright. On a Clean or layered repo — where
+govkit correctly records `Presentation/`, `Application/`, `Infrastructure/` —
+two of three agents plan against folders that do not exist.
+
+The parity suite cannot see it: it pins frontmatter plus a few named
+sections, and skill bodies are otherwise free to differ.
+
+### D018 covered only half of what it was shaped for — closed by #83
+
+D018 shipped in 2b asking "are there services?" when the question it needed
+was "does govkit still write to this location?". The single-source-root
+relocation (#82, `api/AGENTS.md` -> `src/api/AGENTS.md`) is the same defect
+and went unreported, which is how **#83** stayed open after the check landed.
+
+It now asks `resolve_path_scoped_dests` — the same function that decides
+placement — so the check covers every layout that relocates rules and stays
+quiet for every layout that does not, with a completeness test over all five.
+
+Worth recording as a shape: a check guarded by *one cause* of a condition
+rather than by the condition itself will miss the other causes, and look
+correct doing it.
 
 ## Out of scope
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1375,3 +1375,151 @@ class TestD018StalePathScopedRules:
             f.file.replace("\\", "/") for f in run_doctor(tmp_path) if f.id == "D018"
         }
         assert reported == {"api/AGENTS.md", "ports/AGENTS.md", "services/AGENTS.md"}
+
+
+class TestD018SupersededSingleRootRules:
+    """#83 — the single-source-root half of the same defect.
+
+    #82 moved codex's path-scoped rules onto the detected source root, so an
+    install made before it has them at the repo root. D018 shipped in #118
+    reporting only the multi-service case, because its guard asked whether
+    services were detected rather than whether govkit still writes to the
+    root-relative location. The check is the same one; only the question was
+    too narrow.
+    """
+
+    def _src_layout(self, target: Path, prefix: str = "src") -> None:
+        for layer in BACKEND_LAYERS:
+            (target / prefix / layer).mkdir(parents=True)
+
+    def _orphan_at_root(self, target: Path, *layers: str) -> None:
+        for layer in layers:
+            (target / layer).mkdir(parents=True, exist_ok=True)
+            (target / layer / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+    def test_fires_for_a_root_orphan_when_the_source_root_is_src(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._src_layout(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        self._orphan_at_root(tmp_path, "api")
+
+        d018s = [f for f in run_doctor(tmp_path) if f.id == "D018"]
+        assert len(d018s) == 1
+        assert d018s[0].file.replace("\\", "/") == "api/AGENTS.md"
+
+    def test_names_the_live_location_under_the_source_root(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._src_layout(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        self._orphan_at_root(tmp_path, "api")
+
+        finding = [f for f in run_doctor(tmp_path) if f.id == "D018"][0]
+        text = (finding.message + finding.suggested_action).replace("\\", "/")
+        assert "src/api/AGENTS.md" in text
+
+    def test_fires_for_the_documented_package_layout(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._src_layout(tmp_path, "src/mypkg")
+        _write_marker(tmp_path, agent="codex")
+        self._orphan_at_root(tmp_path, "api", "ports", "services")
+
+        reported = {
+            f.file.replace("\\", "/") for f in run_doctor(tmp_path) if f.id == "D018"
+        }
+        assert reported == {"api/AGENTS.md", "ports/AGENTS.md", "services/AGENTS.md"}
+
+    def test_a_team_authored_root_orphan_is_never_advised_away(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._src_layout(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(
+            "# Team notes\n\nOurs.\n\n" + GOVKIT_BLOCK, encoding="utf-8",
+        )
+
+        action = [f for f in run_doctor(tmp_path) if f.id == "D018"][0].suggested_action.lower()
+        assert "leave the file" in action
+        assert "delete api/agents.md" not in action
+
+    def test_silent_when_the_root_is_where_govkit_still_writes(self, tmp_path):
+        """A flat repo: the root-relative destination *is* the live one.
+        Reporting it would call a correct install broken."""
+        from cli.doctor import run_doctor
+
+        for layer in BACKEND_LAYERS:
+            (tmp_path / layer).mkdir(parents=True)
+        (tmp_path / "api" / "handlers.py").write_text("x = 1\n", encoding="utf-8")
+        (tmp_path / "services" / "orders.py").write_text("x = 1\n", encoding="utf-8")
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_silent_on_a_greenfield_repo(self, tmp_path):
+        """No source tree at all, so destinations stay root-relative and the
+        root copy is the live one."""
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "api").mkdir()
+        (tmp_path / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
+
+    def test_the_live_copy_itself_is_never_reported(self, tmp_path):
+        """Both copies present — the one under the source root is current."""
+        from cli.doctor import run_doctor
+
+        self._src_layout(tmp_path)
+        _write_marker(tmp_path, agent="codex")
+        (tmp_path / "src" / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+        self._orphan_at_root(tmp_path, "api")
+
+        reported = {
+            f.file.replace("\\", "/") for f in run_doctor(tmp_path) if f.id == "D018"
+        }
+        assert reported == {"api/AGENTS.md"}
+
+
+def test_d018_covers_every_layout_where_rules_move():
+    """Completeness guard. D018 exists because govkit relocates path-scoped
+    rules; it must fire for every layout that relocates them and stay quiet
+    for every layout that does not. A guard scoped to one relocation shape
+    is how #83 stayed open after #118 shipped the check.
+    """
+    import tempfile
+    from pathlib import Path as _P
+
+    from cli.doctor import run_doctor
+
+    relocating = {
+        "src": ["src"],
+        "src/mypkg": ["src/mypkg"],
+        "multi-service": ["src/orders", "src/billing"],
+    }
+    stationary = {
+        "flat-at-root": [""],
+        "greenfield": [],
+    }
+    for name, prefixes in {**relocating, **stationary}.items():
+        with tempfile.TemporaryDirectory() as tmp:
+            target = _P(tmp)
+            for prefix in prefixes:
+                base = target / prefix if prefix else target
+                for layer in BACKEND_LAYERS:
+                    (base / layer).mkdir(parents=True, exist_ok=True)
+            if name == "flat-at-root":
+                (target / "api" / "handlers.py").write_text("x = 1\n", encoding="utf-8")
+                (target / "services" / "o.py").write_text("x = 1\n", encoding="utf-8")
+            _write_marker(target, agent="codex")
+            (target / "api").mkdir(parents=True, exist_ok=True)
+            (target / "api" / "AGENTS.md").write_text(GOVKIT_BLOCK, encoding="utf-8")
+
+            fired = bool([f for f in run_doctor(target) if f.id == "D018"])
+            assert fired == (name in relocating), (
+                f"{name}: D018 fired={fired}, expected {name in relocating}"
+            )


### PR DESCRIPTION
Closes #83

## The defect

D018 landed in #118 to report codex rules left where govkit no longer writes
them. Its guard asked **"are there services?"** when the question it needed
was **"does govkit still write to this location?"**

Those are not the same question. `resolve_path_scoped_dests` relocates rules
in two situations: onto a detected source root (#82 — `api/AGENTS.md` →
`src/api/AGENTS.md`), and once per service in a multi-service repo (#118).
The check only saw the second. #83's scenario — the first — produced no
findings at all:

```
live rules:  src/api/AGENTS.md, src/ports/AGENTS.md, …   (correct)
orphans:     api/ ports/ services/ adapters/ security/    (stale)
doctor:      no findings
```

## The fix

Ask `resolve_path_scoped_dests` — the same function that decides placement —
for the live destinations, and report any root-relative destination no longer
among them. The check now names no layout at all, so it covers every
relocation without being told about each one.

Against #83's exact scenario:

```
D018  api/AGENTS.md
      api/AGENTS.md is a superseded rule location — govkit now installs this
      rule at src/api/AGENTS.md. codex resolves AGENTS.md upward from the file
      being edited, so the copy at api/AGENTS.md governs none of that code
      fix: leave the file as it is — govkit did not author it. …

D018  services/AGENTS.md
      fix: safe to delete services/AGENTS.md — it holds only govkit's block,
      and the live copy of this rule is at src/services/AGENTS.md
```

The team-authored file keeps its "leave it alone" advice; the four govkit
orphans are told they are safe to delete. **Nothing is deleted by govkit** —
unchanged from #118, and the reason is unchanged too: a stale root rule is
inert rather than contradictory, unlike the case
`reconcile_legacy_instruction_files` deletes for.

## Test

A completeness test walks all five layouts and asserts D018 fires for exactly
the three that relocate rules:

| Layout | rules relocate | D018 |
| --- | --- | --- |
| `src/{api,…}` | yes | fires |
| `src/mypkg/{api,…}` | yes | fires |
| `src/{orders,billing}/{…}` | yes | fires |
| layers at repo root | no | silent |
| greenfield | no | silent |

Written that way on purpose: a guard scoped to one relocation shape is
exactly what this PR fixes, so the test targets that class of mistake rather
than the one instance of it.

## Note on severity

#83 called itself cosmetic, and it now is. The worse half — those root
folders making detection see a flat repo, so the *next* upgrade pushes rules
back to the root and undoes #82 — was already fixed in #118 by the
govkit-authored-folder discount, though that PR did not connect it to #83.
Measured on #83's tree:

```
old logic sees   ['adapters', 'ports'] -> MATCH    -> source_root ''  -> rules relocate to root
with the discount []                   -> no match -> source_root 'src' -> rules stay put
```

## Also in this PR

Plan pointers promised when #119 and #120 were filed, plus a note recording
the shape of the mistake: **a check guarded by one cause of a condition
rather than by the condition itself will miss the other causes, and look
correct doing it.**

`./run_tests` 2138 passed · `./full_test` 134 passed / 16 skipped · `pytest
-k parity` 19 passed · `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
