### PR TITLE
fix(skills): plan against the detected architecture, not hexagonal (#119)

### DIFF
--- a/agents/codex/skills/backend/implementation-plan/SKILL.md
+++ b/agents/codex/skills/backend/implementation-plan/SKILL.md
@@ -53,7 +53,10 @@ Read these artifacts before planning:
 
 The plan must:
 
-- Follow Hexagonal Architecture (ports + adapters)
+- Follow **this project's architecture** — read `.govkit/skill_context.yaml`
+  for `architecture.style` and the layer-to-folder mapping under
+  `architecture.layers`. Cite `docs/{{docs_area}}/architecture/BOUNDARIES.md` for
+  the canonical layer contract.
 - Enforce FIRST principles for unit tests
 - Enforce 7 Code Virtues for implementation
 - Respect all boundary and dependency contracts
@@ -67,7 +70,11 @@ The plan must:
 
 ### Architecture Mapping
 
-Identify inbound ports, domain services, outbound ports, adapters, and API routes. Explicitly confirm no boundary violations.
+Map the work to the layers in `.govkit/skill_context.yaml` under
+`architecture.layers` (inbound / outbound / domain). Cite the actual
+folder names this project uses (per `skill_context.architecture.layers.*`
+and `docs/{{docs_area}}/architecture/BOUNDARIES.md`). Explicitly confirm no
+boundary violations.
 
 ### Task Breakdown (Ordered Checklist)
 

--- a/agents/codex/skills/backend/spec-planning/SKILL.md
+++ b/agents/codex/skills/backend/spec-planning/SKILL.md
@@ -62,12 +62,14 @@ Existing artifacts (read if present, update if needed):
    - If `## Out of scope` is missing or empty, infer the deferred capabilities from the spec's negative space (domain neighbors with no scenarios), then BOTH:
      - insert `<!-- INFERRED: not declared in nfrs.md ## Out of scope; confirm with feature owner -->` directly under the plan's `### Out of scope` heading, and
      - state in the planning summary that Out-of-scope was inferred and should be confirmed.
-3. Identify required design elements aligned to Hexagonal Architecture:
-   - Inbound ports (`ports/inbound/`)
-   - Domain logic modules (`services/`)
-   - Outbound ports (`ports/outbound/`)
-   - Adapters (`adapters/`)
-   - API route entrypoints (`api/`)
+3. Identify required design elements per **this project's architecture**:
+   - Read `.govkit/skill_context.yaml` for the architecture style and the
+     folder hints under `architecture.layers` (inbound / outbound / domain).
+   - Read `docs/{{docs_area}}/architecture/BOUNDARIES.md` for the canonical layer
+     contract and `LAYER_IMPLEMENTATION.md` for the layer-by-layer guidance.
+   - List the inbound entry points, domain logic modules, outbound
+     dependencies, and any infrastructure adapters the feature needs —
+     using the project's own folder names, not generic ones.
 4. Flag any deviation from architecture contracts:
    - `ARCH_CONTRACT.md`, `BOUNDARIES.md`, `API_CONVENTIONS.md`, `SECURITY_AUTH_PATTERNS.md`
 5. Determine ADR need. Mark **ADR required** if any of these occur:

--- a/agents/copilot/skills/backend/implementation-plan/SKILL.md
+++ b/agents/copilot/skills/backend/implementation-plan/SKILL.md
@@ -53,7 +53,10 @@ Read these artifacts before planning:
 
 The plan must:
 
-- Follow Hexagonal Architecture (ports + adapters)
+- Follow **this project's architecture** — read `.govkit/skill_context.yaml`
+  for `architecture.style` and the layer-to-folder mapping under
+  `architecture.layers`. Cite `docs/{{docs_area}}/architecture/BOUNDARIES.md` for
+  the canonical layer contract.
 - Enforce FIRST principles for unit tests
 - Enforce 7 Code Virtues for implementation
 - Respect all boundary and dependency contracts
@@ -67,7 +70,11 @@ The plan must:
 
 ### Architecture Mapping
 
-Identify inbound ports, domain services, outbound ports, adapters, and API routes. Explicitly confirm no boundary violations.
+Map the work to the layers in `.govkit/skill_context.yaml` under
+`architecture.layers` (inbound / outbound / domain). Cite the actual
+folder names this project uses (per `skill_context.architecture.layers.*`
+and `docs/{{docs_area}}/architecture/BOUNDARIES.md`). Explicitly confirm no
+boundary violations.
 
 ### Task Breakdown (Ordered Checklist)
 

--- a/agents/copilot/skills/backend/spec-planning/SKILL.md
+++ b/agents/copilot/skills/backend/spec-planning/SKILL.md
@@ -60,12 +60,14 @@ Existing artifacts (read if present, update if needed):
    - If `## Out of scope` is missing or empty, infer the deferred capabilities from the spec's negative space (domain neighbors with no scenarios), then BOTH:
      - insert `<!-- INFERRED: not declared in nfrs.md ## Out of scope; confirm with feature owner -->` directly under the plan's `### Out of scope` heading, and
      - state in the planning summary that Out-of-scope was inferred and should be confirmed.
-3. Identify required design elements aligned to Hexagonal Architecture:
-   - Inbound ports (`ports/inbound/**`)
-   - Domain logic modules (`services/**`)
-   - Outbound ports (`ports/outbound/**`)
-   - Adapters (`adapters/**`)
-   - API route entrypoints (`api/**`)
+3. Identify required design elements per **this project's architecture**:
+   - Read `.govkit/skill_context.yaml` for the architecture style and the
+     folder hints under `architecture.layers` (inbound / outbound / domain).
+   - Read `docs/{{docs_area}}/architecture/BOUNDARIES.md` for the canonical layer
+     contract and `LAYER_IMPLEMENTATION.md` for the layer-by-layer guidance.
+   - List the inbound entry points, domain logic modules, outbound
+     dependencies, and any infrastructure adapters the feature needs —
+     using the project's own folder names, not generic ones.
 4. Flag any deviation from architecture contracts:
    - `ARCH_CONTRACT.md`
    - `BOUNDARIES.md`

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -502,17 +502,23 @@ That definition needs deciding before the check is written, which is why 2b
 shipped without it. Lifted into **#120** rather than left here, since an open
 question inside a plan marked Implemented is where things go to be forgotten.
 
-### Codex and copilot planning skills assume hexagonal — #119
+### ~~Codex and copilot planning skills assume hexagonal~~ — closed by #119
 
 Found while adding increment 3's section and deliberately not fixed there.
 claude-code's copies of `spec-planning` and `implementation-plan` read
-`architecture.layers`; codex's and copilot's name `ports/inbound/`,
+`architecture.layers`; codex's and copilot's named `ports/inbound/`,
 `services/` and `adapters/` outright. On a Clean or layered repo — where
 govkit correctly records `Presentation/`, `Application/`, `Infrastructure/` —
-two of three agents plan against folders that do not exist.
+two of three agents planned against folders that do not exist. The same held
+for every `type: data` install, which ships these skills and gets
+`models/staging/`.
 
-The parity suite cannot see it: it pins frontmatter plus a few named
-sections, and skill bodies are otherwise free to differ.
+The parity suite could not see it: it pins frontmatter plus a few named
+sections, and skill bodies are otherwise free to differ. #119 added the
+missing invariant — every backend planning skill must reference
+`architecture.layers` and must assert no architecture style — which is the
+narrow, checkable form of "the three agents agree on where the architecture
+comes from".
 
 ### D018 covered only half of what it was shaped for — closed by #83
 

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -305,3 +305,83 @@ def test_ui_planning_skills_do_not_gain_the_section():
     ]
     present = [p for p in ui_paths if p.is_file() and SERVICES_HEADING in p.read_text(encoding="utf-8")]
     assert not present, f"UI skills carry the multi-service section: {present}"
+
+
+# ---------------------------------------------------------------------------
+# Planning skills describe the project's own architecture — #119
+# ---------------------------------------------------------------------------
+
+# Phrases that assert a specific architecture style as this project's. Each
+# appears only in the hardcoded lists #119 removed — `ports/inbound` and
+# `ports/outbound` are hexagonal-only package names, and naming a style
+# outright contradicts a repo govkit detected as clean or layered.
+#
+# Deliberately narrow. A bare `services/` cannot be banned: the multi-service
+# section legitimately uses `services/pricing.py` as an example of scoping a
+# path to a service root, which is a claim about paths, not about layers.
+_STYLE_ASSERTIONS = (
+    "Hexagonal Architecture",
+    "Clean Architecture",
+    "Layered Architecture",
+    "ports/inbound",
+    "ports/outbound",
+)
+
+
+@pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
+def test_planning_skill_reads_the_recorded_architecture(skill_path: Path):
+    """govkit detects the style and writes the layer folders down. A planning
+    skill that hardcodes folder names instead plans against packages the repo
+    may not have."""
+    text = skill_path.read_text(encoding="utf-8")
+    for token in (".govkit/skill_context.yaml", "architecture.layers"):
+        assert token in text, (
+            f"{skill_path.relative_to(REPO_ROOT)} never references {token}"
+        )
+
+
+@pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
+def test_planning_skill_asserts_no_architecture_style(skill_path: Path):
+    """The same six files ship to every backend stack and every layout. A
+    repo govkit reads as `clean` gets `Presentation/`, `Application/` and
+    `Infrastructure/` — telling its agent to produce `ports/inbound/` names
+    folders that do not exist."""
+    text = skill_path.read_text(encoding="utf-8")
+    offenders = [phrase for phrase in _STYLE_ASSERTIONS if phrase in text]
+    assert not offenders, (
+        f"{skill_path.relative_to(REPO_ROOT)} asserts an architecture style "
+        f"instead of reading the detected one: {offenders}"
+    )
+
+
+def test_the_style_assertion_list_still_catches_the_original_defect():
+    """Guard against the ban list being trimmed to whatever happens to pass.
+    Every phrase here was present in codex's or copilot's copies before #119;
+    a list that no longer describes that defect is not protecting against it.
+    """
+    assert "Hexagonal Architecture" in _STYLE_ASSERTIONS
+    assert "ports/inbound" in _STYLE_ASSERTIONS
+    # And the ban must not be so broad it forbids the multi-service example,
+    # which names a path inside a service rather than a layer of this repo.
+    assert not any("services/pricing" in phrase for phrase in _STYLE_ASSERTIONS)
+
+
+def test_architecture_guidance_parity_across_agents():
+    """The three agents may phrase their skills differently, but they must
+    not disagree about *where this project's layers come from*. #119 existed
+    because claude-code read the recorded architecture and the other two
+    asserted hexagonal — a divergence the frontmatter-and-named-sections
+    parity checks cannot see."""
+    for skill in ("spec-planning", "implementation-plan"):
+        refs = {}
+        for agent in ("claude-code", "codex", "copilot"):
+            text = (REPO_ROOT / "agents" / agent / "skills" / "backend" / skill
+                    / "SKILL.md").read_text(encoding="utf-8")
+            refs[agent] = (
+                "architecture.layers" in text,
+                any(p in text for p in _STYLE_ASSERTIONS),
+            )
+        assert len(set(refs.values())) == 1, (
+            f"{skill}: agents disagree on where the architecture comes from: {refs}"
+        )
+        assert refs["claude-code"] == (True, False)

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -5,6 +5,7 @@ added to all architecture-preflight SKILL.md files across the three agents
 Per [[feedback_agent_parity]], all 3 agents must ship identical rules and
 skills. This test pins that invariant for the new section."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -311,21 +312,53 @@ def test_ui_planning_skills_do_not_gain_the_section():
 # Planning skills describe the project's own architecture — #119
 # ---------------------------------------------------------------------------
 
-# Phrases that assert a specific architecture style as this project's. Each
-# appears only in the hardcoded lists #119 removed — `ports/inbound` and
-# `ports/outbound` are hexagonal-only package names, and naming a style
-# outright contradicts a repo govkit detected as clean or layered.
+# Tokens that assert a specific architecture as this project's, rather than
+# reading the one govkit detected. Matched case-insensitively on word
+# boundaries, so `Hexagonal architecture`, `HEXAGONAL` and a bare `hexagonal`
+# are caught alongside the exact phrasing #119 removed.
 #
-# Deliberately narrow. A bare `services/` cannot be banned: the multi-service
-# section legitimately uses `services/pricing.py` as an example of scoping a
-# path to a service root, which is a claim about paths, not about layers.
+# The bare style ids are here because they are what `architecture.style`
+# holds: a skill that names one has decided the answer instead of reading it.
+# `clean` and `layered` are ordinary English, so banning them costs the
+# occasional reworded sentence — accepted deliberately. A false positive is
+# loud and fixable in one edit; a false negative is silent, and this whole
+# check exists because a silent one shipped.
+#
+# `ports/inbound` and `ports/outbound` are hexagonal-only package names.
+# A bare `services/` deliberately is **not** banned: the multi-service
+# section legitimately uses `services/pricing.py` to show a path scoped to a
+# service root, which is a claim about paths, not about this repo's layers.
 _STYLE_ASSERTIONS = (
-    "Hexagonal Architecture",
-    "Clean Architecture",
-    "Layered Architecture",
+    "hexagonal",
+    "clean",
+    "layered",
+    "dbt-layered",
     "ports/inbound",
     "ports/outbound",
 )
+
+_STYLE_ASSERTION_RE = re.compile(
+    "|".join(rf"(?<![\w-]){re.escape(token)}(?![\w-])" for token in _STYLE_ASSERTIONS),
+    re.IGNORECASE,
+)
+
+
+def _prose(text: str) -> str:
+    """`text` with fenced code blocks removed.
+
+    Same split `tests/test_stack_neutral_docs.py` makes, for the same reason:
+    a rule must be architecture-neutral, while an *example* may be concrete.
+    A fenced snippet showing `style: hexagonal` documents the file format a
+    skill has to read; the same words in prose assert what this repo is.
+    """
+    kept, in_fence = [], False
+    for line in text.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            kept.append(line)
+    return "\n".join(kept)
 
 
 @pytest.mark.parametrize("skill_path", PLANNING_SKILL_PATHS, ids=_planning_id)
@@ -344,26 +377,80 @@ def test_planning_skill_reads_the_recorded_architecture(skill_path: Path):
 def test_planning_skill_asserts_no_architecture_style(skill_path: Path):
     """The same six files ship to every backend stack and every layout. A
     repo govkit reads as `clean` gets `Presentation/`, `Application/` and
-    `Infrastructure/` — telling its agent to produce `ports/inbound/` names
-    folders that do not exist."""
-    text = skill_path.read_text(encoding="utf-8")
-    offenders = [phrase for phrase in _STYLE_ASSERTIONS if phrase in text]
+    `Infrastructure/`; one it reads as `dbt-layered` gets `models/staging/`.
+    Telling either agent to produce `ports/inbound/` names folders that do
+    not exist."""
+    offenders = sorted({
+        m.group(0).lower()
+        for m in _STYLE_ASSERTION_RE.finditer(_prose(skill_path.read_text(encoding="utf-8")))
+    })
     assert not offenders, (
         f"{skill_path.relative_to(REPO_ROOT)} asserts an architecture style "
-        f"instead of reading the detected one: {offenders}"
+        f"instead of reading the detected one: {offenders}. Read "
+        f"`architecture.style` and `architecture.layers` from "
+        f".govkit/skill_context.yaml instead. If this is a false positive on "
+        f"ordinary English, reword it — the ban is intentionally blunt."
     )
 
 
-def test_the_style_assertion_list_still_catches_the_original_defect():
+# (text, should_match) — what the matcher must and must not catch. Written as
+# a table so trimming the ban list to whatever happens to pass fails here.
+_STYLE_MATCHER_CASES = [
+    # The exact wording #119 removed.
+    ("3. Identify required design elements aligned to Hexagonal Architecture:", True),
+    ("- Inbound ports (`ports/inbound/`)", True),
+    ("- Outbound ports (`ports/outbound/**`)", True),
+    ("- Follow Hexagonal Architecture (ports + adapters)", True),
+    # Capitalisation variants — the bypass a case-sensitive check allowed.
+    ("Follow Hexagonal architecture", True),
+    ("follow HEXAGONAL ARCHITECTURE", True),
+    # Bare style ids: what `architecture.style` holds. Naming one is deciding
+    # the answer rather than reading it.
+    ("This project uses a hexagonal layout.", True),
+    ("Assume a clean layout.", True),
+    ("Assume a layered layout.", True),
+    ("Assume dbt-layered.", True),
+    # Must NOT match: the multi-service example names a path inside a
+    # service, which is a claim about paths, not about this repo's layers.
+    ("   `src/orders/services/pricing.py`.", False),
+    ("- Domain logic modules and their services", False),
+    # Word boundaries: no firing inside longer words.
+    ("Cleanup of the task list is out of scope.", False),
+    ("Apply the guidance layer-by-layer.", False),
+    ("Read the multilayered guidance.", False),
+    # The wording that replaced it must survive.
+    ("   - Read `.govkit/skill_context.yaml` for the architecture style and the", False),
+    ("     folder hints under `architecture.layers` (inbound / outbound / domain).", False),
+]
+
+
+@pytest.mark.parametrize(
+    "text, should_match", _STYLE_MATCHER_CASES,
+    ids=[f"{'catch' if m else 'allow'}:{t[:38].strip()}" for t, m in _STYLE_MATCHER_CASES],
+)
+def test_the_style_matcher_catches_the_defect_and_nothing_else(text, should_match):
+    assert bool(_STYLE_ASSERTION_RE.search(_prose(text))) is should_match
+
+
+def test_a_fenced_example_may_name_a_style():
+    """Documenting the file format is not asserting an architecture. A skill
+    showing what `.govkit/skill_context.yaml` looks like has to be able to
+    put a real value in it — the same split `test_stack_neutral_docs.py`
+    makes between a rule and an illustration."""
+    fenced = "Read it:\n\n```yaml\narchitecture:\n  style: hexagonal\n```\n\nThen plan.\n"
+    assert not _STYLE_ASSERTION_RE.search(_prose(fenced))
+    # ...but the same sentence outside a fence is still caught.
+    assert _STYLE_ASSERTION_RE.search(_prose("The style is hexagonal.\n"))
+
+
+def test_the_style_assertion_list_still_describes_the_original_defect():
     """Guard against the ban list being trimmed to whatever happens to pass.
-    Every phrase here was present in codex's or copilot's copies before #119;
-    a list that no longer describes that defect is not protecting against it.
-    """
-    assert "Hexagonal Architecture" in _STYLE_ASSERTIONS
-    assert "ports/inbound" in _STYLE_ASSERTIONS
-    # And the ban must not be so broad it forbids the multi-service example,
-    # which names a path inside a service rather than a layer of this repo.
-    assert not any("services/pricing" in phrase for phrase in _STYLE_ASSERTIONS)
+    Every id here is a value `architecture.style` can hold, and the two
+    package names were in codex's and copilot's copies before #119."""
+    assert {"hexagonal", "clean", "layered", "dbt-layered"} <= set(_STYLE_ASSERTIONS)
+    assert {"ports/inbound", "ports/outbound"} <= set(_STYLE_ASSERTIONS)
+    # The ban must not grow to forbid the multi-service example.
+    assert not any("services/pricing" in token for token in _STYLE_ASSERTIONS)
 
 
 def test_architecture_guidance_parity_across_agents():
@@ -379,7 +466,7 @@ def test_architecture_guidance_parity_across_agents():
                     / "SKILL.md").read_text(encoding="utf-8")
             refs[agent] = (
                 "architecture.layers" in text,
-                any(p in text for p in _STYLE_ASSERTIONS),
+                bool(_STYLE_ASSERTION_RE.search(_prose(text))),
             )
         assert len(set(refs.values())) == 1, (
             f"{skill}: agents disagree on where the architecture comes from: {refs}"


### PR DESCRIPTION
Closes #119

## The defect

govkit detects the architecture style and records the layer folders. Two of
three agents' planning skills ignored that and asserted hexagonal.

Same repo, same `govkit apply`, a Clean-Architecture tree
(`src/myapp/{Application,Domain,Infrastructure,Presentation}/`):

```yaml
architecture:
  style: clean
  layers:
    inbound:  [Presentation/, Api/]
    outbound: [Infrastructure/]
    domain:   [Application/, Domain/]
```

**codex's installed skill, before:**

```
3. Identify required design elements aligned to Hexagonal Architecture:
   - Inbound ports (`ports/inbound/`)
   - Domain logic modules (`services/`)
   - Outbound ports (`ports/outbound/`)
```

None of those folders exist in that repo.

It is not only Clean and layered repos. These same skills ship to
`type: data`, where the recorded layers are `models/staging/`,
`models/intermediate/` and `models/marts/` — so every dbt install was being
told to produce ports and adapters too.

## The fix

codex's and copilot's copies now carry claude-code's wording — read
`.govkit/skill_context.yaml` for `architecture.style` and `architecture.layers`,
cite the project's own folder names. claude-code is unchanged.

Worth stating: the **rules** never had this problem. `rule_templating`
expands `architecture.layers` into each rule's globs at install time for all
three agents. This was specific to the planning skills, which are static
markdown.

## Why the parity suite missed it

It pins **frontmatter** byte-identical plus a handful of named sections;
skill bodies are otherwise free to differ. So a divergence in the *substance*
of the architecture guidance was invisible.

Two new invariants close that for this property:

- every backend planning skill must reference `.govkit/skill_context.yaml`
  and `architecture.layers`
- none may assert an architecture style

The ban list is deliberately narrow. `services/` **cannot** be forbidden —
the multi-service section from #86 legitimately uses `services/pricing.py` as
an example of scoping a path to a service root, which is a claim about paths,
not about this repo's layers. So it bans the hexagonal-only package names
(`ports/inbound`, `ports/outbound`) and the style names themselves.

A guard test asserts the ban list still contains the phrases the original
defect actually used, and still permits the multi-service example — so it
cannot later be trimmed to whatever happens to pass.

## Verification

Real `govkit apply` on three repo shapes, all three agents:

| Repo | detected style | recorded layers | all agents agree |
| --- | --- | --- | --- |
| Clean | `clean` | `Presentation/`, `Application/`, `Infrastructure/` | yes |
| hexagonal | `hexagonal` | `api/`, `ports/inbound/`, `services/` | yes |
| dbt | `dbt-layered` | `models/staging/`, `models/marts/` | yes |

`{{docs_area}}` expands to `backend` / `data` as appropriate, no unexpanded
tokens, and no installed planning skill names a hexagonal package for any
agent.

`./run_tests` 2152 passed · `./full_test` 134 passed / 16 skipped · `pytest
-k parity` 20 passed · `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
