### PR TITLE
fix(cli): announce when a rewrite discards edits inside the govkit block (#81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,17 @@ govkit distinguishes these categories of files:
 
 **govkit never overwrites files you authored.** Everything govkit installs lives in a namespace it owns — a `govkit/` subdirectory under the rules dir, a `govkit-` prefix on skills, or a fenced managed block inside Codex's `AGENTS.md`. So your own `CLAUDE.md`, a rule you named `.claude/rules/api.md`, or a skill you named `spec-planning` all coexist with govkit's copies untouched. When you upgrade an install created by an older govkit that *did* write a top-level `CLAUDE.md`, `upgrade` retires that orphan only when it can prove it was govkit's own (byte-identical to the shipped governance, or unmodified since the last apply); if you edited it, it is kept and you're told how to adopt the managed layout.
 
+The inside of Codex's managed block is the one place that rule does not
+reach — it is govkit's content, and every `apply` and `upgrade` rewrites it,
+as the note fenced in the block says. That is what makes the rest of the
+file safe to own. If you edit inside the block anyway, govkit now tells you
+when it replaces your edit:
+
+```
+warning: replaced your edits inside the govkit block at AGENTS.md
+— that block is managed by govkit; put your own instructions outside it
+```
+
 After upgrading, review the diff and commit:
 
 ```bash

--- a/cli/headers.py
+++ b/cli/headers.py
@@ -20,6 +20,7 @@ renders invisibly in tooling that respects markdown comments.
 """
 
 import hashlib
+import re
 from pathlib import Path
 
 _HEADER_START = "<!-- govkit:editable"
@@ -37,6 +38,74 @@ _BLOCK_NOTE = (
     "`govkit upgrade`. Put your own instructions outside it. -->"
 )
 
+# SHA-256 of the body govkit last wrote into the block, recorded inside the
+# block so a later run can tell a team's edit from its own content. Comparing
+# the live body against the *new* body instead would flag every legitimate
+# governance change as a user edit — the same trap the skill_context
+# provenance record exists to avoid.
+#
+# It lives on its own line rather than in the BEGIN marker because that
+# marker's exact text is what `detect._is_govkit_authored_folder` and
+# doctor's D018 search for.
+_BLOCK_HASH_RE = re.compile(r"^<!-- govkit:block-hash ([0-9a-f]{64}) -->$", re.MULTILINE)
+
+
+def _block_hash_line(digest: str) -> str:
+    return f"<!-- govkit:block-hash {digest} -->"
+
+
+def compute_block_body_hash(body: str) -> str:
+    """SHA-256 of a managed block's body, normalized the way it is stored.
+
+    Hashes the decoded string with trailing newlines stripped, so a
+    line-ending rewrite on checkout never registers as an edit.
+    """
+    return hashlib.sha256(body.rstrip("\n").encode("utf-8")).hexdigest()
+
+
+def parse_block_hash(text: str) -> str | None:
+    """The hash govkit recorded in `text`'s managed block, or None."""
+    match = _BLOCK_HASH_RE.search(text)
+    return match.group(1) if match else None
+
+
+def extract_block_body(text: str) -> str | None:
+    """The governance body inside `text`'s managed block, or None.
+
+    Everything between the markers except govkit's own bookkeeping lines —
+    the note and the recorded hash. Those are dropped **wherever they sit**
+    rather than by position: a rewrite replaces the whole span between the
+    markers, so a line the team inserted anywhere in it is an edit that will
+    be discarded, including above the note where a positional reading would
+    not have looked.
+    """
+    begin = text.find(GOVKIT_BLOCK_BEGIN)
+    if begin == -1:
+        return None
+    end = text.find(GOVKIT_BLOCK_END, begin)
+    if end == -1:
+        return None
+    inner = text[begin + len(GOVKIT_BLOCK_BEGIN):end]
+    kept = [
+        line for line in inner.split("\n")
+        if line.strip() != _BLOCK_NOTE and not _BLOCK_HASH_RE.fullmatch(line.strip())
+    ]
+    return "\n".join(kept).strip("\n")
+
+
+def block_body_is_edited(text: str) -> bool | None:
+    """Has the managed block's body changed since govkit wrote it?
+
+    `None` means undecidable — no block, or a block from before the hash was
+    recorded. Callers fall back to mtime rather than reading it as "clean",
+    because a silent "no" is exactly the failure #81 reports.
+    """
+    recorded = parse_block_hash(text)
+    body = extract_block_body(text)
+    if recorded is None or body is None:
+        return None
+    return compute_block_body_hash(body) != recorded
+
 
 def upsert_govkit_block(
     existing: str | None, body: str, replace_unblocked: bool = False,
@@ -52,7 +121,11 @@ def upsert_govkit_block(
     - `existing` has no block and not `replace_unblocked` ⇒ the block is
       appended below the team's content, which is preserved.
     """
-    block = f"{GOVKIT_BLOCK_BEGIN}\n{_BLOCK_NOTE}\n{body.rstrip(chr(10))}\n{GOVKIT_BLOCK_END}\n"
+    hash_line = _block_hash_line(compute_block_body_hash(body))
+    block = (
+        f"{GOVKIT_BLOCK_BEGIN}\n{_BLOCK_NOTE}\n{hash_line}\n"
+        f"{body.rstrip(chr(10))}\n{GOVKIT_BLOCK_END}\n"
+    )
     if existing is None or replace_unblocked and GOVKIT_BLOCK_BEGIN not in existing:
         return block
 

--- a/cli/install_common.py
+++ b/cli/install_common.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 
 from . import paths
 from .fs import copy_entry, read_text_or_none
-from .headers import GOVKIT_BLOCK_BEGIN, upsert_govkit_block
+from .headers import GOVKIT_BLOCK_BEGIN, block_body_is_edited, upsert_govkit_block
 from .marker import _compare_version, read_govkit_marker
 
 if TYPE_CHECKING:
@@ -68,6 +68,44 @@ def _unmodified_since(path: Path, applied_at: str | None) -> bool:
         return False
 
 
+def _warn_if_block_edits_are_discarded(
+    dest: Path, existing: str, applied_at: str | None,
+) -> None:
+    """Announce that a rewrite is about to discard edits inside the block.
+
+    Replacing the block is correct and documented — its own note says the
+    content is overwritten on `govkit upgrade`, and that is what makes the
+    surrounding file safe to own. Doing it in silence is the defect (#81).
+
+    Deliberately **not** modelled on governed-doc protection, which refuses
+    without `--force`. That file is the team's and worth withholding a write
+    over; this block is govkit's and withholding would break the contract
+    the note states. So this warns on every path — plain `apply`, plain
+    `upgrade` and both `--force` variants — because all four discard the
+    edit, which is what measuring the four actually showed. #81 reported it
+    as a `--force` gap only, having hit the version-match no-op that makes a
+    plain upgrade look like it preserved the edit.
+
+    A block with no recorded hash predates that record, so it falls back to
+    mtime against the marker's `applied_at`, the same fallback governed docs
+    use for pre-hash headers. Without the fallback every install that exists
+    today would stay silent until its first rewrite.
+    """
+    edited = block_body_is_edited(existing)
+    if edited is None:
+        # Undecidable from content. Only the timestamp is left, and it only
+        # means anything once there is a prior install to compare against.
+        edited = applied_at is not None and not _unmodified_since(dest, applied_at)
+    if not edited:
+        return
+    print(
+        f"  warning: replaced your edits inside the govkit block at {dest} "
+        "— that block is managed by govkit; put your own instructions "
+        "outside it so they survive",
+        file=sys.stderr,
+    )
+
+
 def write_managed_agent_block(dest: Path, body: str, applied_at: str | None = None) -> None:
     """Install govkit's governance into `dest` as a managed block.
 
@@ -83,6 +121,8 @@ def write_managed_agent_block(dest: Path, body: str, applied_at: str | None = No
     replace_unblocked = False
     if existing is not None and GOVKIT_BLOCK_BEGIN not in existing:
         replace_unblocked = existing == body or _unmodified_since(dest, applied_at)
+    if existing is not None and GOVKIT_BLOCK_BEGIN in existing:
+        _warn_if_block_edits_are_discarded(dest, existing, applied_at)
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(
         upsert_govkit_block(existing, body, replace_unblocked=replace_unblocked),

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -356,3 +356,113 @@ class TestUpsertGovkitBlock:
         out = upsert_govkit_block(old_full, "NEW GOVERNANCE", replace_unblocked=True)
         assert "old govkit governance" not in out
         assert "NEW GOVERNANCE" in out
+
+
+# ---------------------------------------------------------------------------
+# Managed-block edit detection — #81
+# ---------------------------------------------------------------------------
+
+class TestManagedBlockHash:
+    """govkit records what it wrote into the block, so a later run can tell a
+    team's edit from its own content.
+
+    Same provenance shape the skill_context architecture block uses, and for
+    the same reason: comparing the live body against the *new* body would
+    flag every legitimate govkit content change as a user edit.
+    """
+
+    def test_a_written_block_records_its_body_hash(self):
+        from cli.headers import parse_block_hash, upsert_govkit_block
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        assert parse_block_hash(out) is not None
+
+    def test_the_recorded_hash_matches_the_body_that_was_written(self):
+        from cli.headers import block_body_is_edited, upsert_govkit_block
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        assert block_body_is_edited(out) is False
+
+    def test_an_edit_inside_the_block_is_detected(self):
+        from cli.headers import block_body_is_edited, upsert_govkit_block
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        tampered = out.replace("GOVERNANCE BODY", "GOVERNANCE BODY\nTEAM EDIT")
+        assert block_body_is_edited(tampered) is True
+
+    def test_an_edit_above_the_note_is_detected(self):
+        """A rewrite replaces the whole span between the markers, so a line
+        inserted anywhere inside it is discarded — including above govkit's
+        note, where reading the body positionally would not have looked."""
+        from cli.headers import block_body_is_edited, upsert_govkit_block
+
+        begin = "<!-- BEGIN GOVKIT GOVERNANCE -->"
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        tampered = out.replace(begin, begin + "\nTEAM EDIT", 1)
+        assert block_body_is_edited(tampered) is True
+
+    def test_an_edit_between_the_note_and_the_body_is_detected(self):
+        from cli.headers import block_body_is_edited, parse_block_hash, upsert_govkit_block
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        hash_line = f"<!-- govkit:block-hash {parse_block_hash(out)} -->"
+        tampered = out.replace(hash_line, hash_line + "\nTEAM EDIT", 1)
+        assert block_body_is_edited(tampered) is True
+
+    def test_edits_outside_the_block_are_not_the_blocks_business(self):
+        """Content around the block is the team's by design — changing it is
+        not an edit *to* the block."""
+        from cli.headers import block_body_is_edited, upsert_govkit_block
+
+        out = upsert_govkit_block("# team top\n", "GOVERNANCE BODY")
+        assert block_body_is_edited(out) is False
+        assert block_body_is_edited(out + "\n# team bottom\n") is False
+
+    def test_a_block_with_no_recorded_hash_is_undecidable(self):
+        """Pre-#81 blocks carry no hash. `None` means "cannot tell" so the
+        caller falls back to mtime, rather than silently reading as "clean"."""
+        from cli.headers import block_body_is_edited
+
+        begin = "<!-- BEGIN GOVKIT GOVERNANCE -->"
+        end = "<!-- END GOVKIT GOVERNANCE -->"
+        legacy = f"{begin}\nOLD GOVERNANCE\n{end}\n"
+        assert block_body_is_edited(legacy) is None
+
+    def test_text_with_no_block_at_all_is_undecidable(self):
+        from cli.headers import block_body_is_edited
+
+        assert block_body_is_edited("# just a team file\n") is None
+
+    def test_rewriting_a_block_refreshes_the_hash(self):
+        """An untouched block must not read as edited after govkit changes
+        the governance text — the record moves with the content."""
+        from cli.headers import block_body_is_edited, upsert_govkit_block
+
+        first = upsert_govkit_block(None, "OLD GOVERNANCE")
+        second = upsert_govkit_block(first, "NEW GOVERNANCE")
+        assert "OLD GOVERNANCE" not in second
+        assert block_body_is_edited(second) is False
+
+    def test_the_hash_line_is_not_mistaken_for_governance(self):
+        """It lives inside the block, so it must not leak into the body that
+        gets hashed — or the hash would never match itself."""
+        from cli.headers import upsert_govkit_block
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        assert out.count("GOVERNANCE BODY") == 1
+
+    def test_markers_are_unchanged_so_existing_readers_still_work(self):
+        """`detect._is_govkit_authored_folder` and doctor's D018 both locate
+        the block by these exact strings. Adding the hash must not move them.
+        """
+        from cli.headers import (
+            GOVKIT_BLOCK_BEGIN,
+            GOVKIT_BLOCK_END,
+            upsert_govkit_block,
+        )
+
+        out = upsert_govkit_block(None, "GOVERNANCE BODY")
+        assert GOVKIT_BLOCK_BEGIN == "<!-- BEGIN GOVKIT GOVERNANCE -->"
+        assert GOVKIT_BLOCK_END == "<!-- END GOVKIT GOVERNANCE -->"
+        assert out.startswith(GOVKIT_BLOCK_BEGIN)
+        assert out.rstrip().endswith(GOVKIT_BLOCK_END)

--- a/tests/test_path_scoped_rules.py
+++ b/tests/test_path_scoped_rules.py
@@ -328,3 +328,158 @@ def test_glob_based_agents_are_unaffected(tmp_path, agent):
 
     assert not (target / "services").exists()
     assert not (target / "src" / "mypkg" / "services" / "AGENTS.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Announcing a replaced managed block — #81
+# ---------------------------------------------------------------------------
+
+GOVKIT_BEGIN = "<!-- BEGIN GOVKIT GOVERNANCE -->"
+
+
+def _edit_inside_the_block(path) -> None:
+    text = path.read_text(encoding="utf-8")
+    assert GOVKIT_BEGIN in text, f"no govkit block in {path}"
+    path.write_text(
+        text.replace(GOVKIT_BEGIN, GOVKIT_BEGIN + "\nTEAM EDIT INSIDE BLOCK", 1),
+        encoding="utf-8",
+    )
+
+
+class TestReplacedBlockIsAnnounced:
+    """Replacing the block is correct — it says so in its own note ("content
+    in this block is overwritten on `govkit upgrade`"). Doing it in silence
+    is not.
+
+    #81 framed this as a `--force` gap. It is wider: measured against a real
+    install with the marker aged so `upgrade` does real work, an edit inside
+    the block is replaced by plain `apply`, `apply --force`, plain `upgrade`
+    and `upgrade --force` alike, and none of them said a word. The issue's
+    "survived" row for plain upgrade was the version-match no-op its own
+    reproduction note warns about.
+
+    So this is not modelled on governed-doc protection, which *refuses*
+    without `--force`. The block is govkit-owned and documented as such;
+    the fix is to announce, not to withhold.
+    """
+
+    @staticmethod
+    def _install(target):
+        target.mkdir(parents=True, exist_ok=True)
+        for layer in BACKEND_LAYERS:
+            (target / "src" / "myapp" / layer).mkdir(parents=True, exist_ok=True)
+        _apply_codex(target)
+
+    @staticmethod
+    def _age_marker(target):
+        import json
+        path = target / ".govkit" / "marker.json"
+        marker = json.loads(path.read_text(encoding="utf-8"))
+        marker["version"] = "0.13.0"
+        path.write_text(json.dumps(marker), encoding="utf-8")
+
+    def test_apply_announces_a_replaced_block(self, tmp_path, capsys):
+        target = tmp_path / "project"
+        self._install(target)
+        _edit_inside_the_block(target / "AGENTS.md")
+        capsys.readouterr()
+
+        _apply_codex(target)
+
+        out = capsys.readouterr()
+        combined = out.out + out.err
+        assert "TEAM EDIT INSIDE BLOCK" not in (target / "AGENTS.md").read_text(encoding="utf-8")
+        assert "AGENTS.md" in combined
+        assert "govkit block" in combined.lower()
+
+    def test_upgrade_announces_a_replaced_block(self, tmp_path, capsys):
+        from cli.cmd_upgrade import cmd_upgrade
+
+        target = tmp_path / "project"
+        self._install(target)
+        _edit_inside_the_block(target / "AGENTS.md")
+        self._age_marker(target)
+        capsys.readouterr()
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        combined = "".join(capsys.readouterr())
+        assert "govkit block" in combined.lower()
+
+    def test_upgrade_force_announces_a_replaced_block(self, tmp_path, capsys):
+        from cli.cmd_upgrade import cmd_upgrade
+
+        target = tmp_path / "project"
+        self._install(target)
+        _edit_inside_the_block(target / "AGENTS.md")
+        self._age_marker(target)
+        capsys.readouterr()
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=True))
+
+        combined = "".join(capsys.readouterr())
+        assert "govkit block" in combined.lower()
+
+    def test_an_untouched_block_is_replaced_in_silence(self, tmp_path, capsys):
+        """The common case. Every run rewrites every block; warning each time
+        would bury the one that matters."""
+        target = tmp_path / "project"
+        self._install(target)
+        capsys.readouterr()
+
+        _apply_codex(target)
+
+        combined = "".join(capsys.readouterr()).lower()
+        assert "govkit block" not in combined
+
+    def test_edits_outside_the_block_never_warn(self, tmp_path, capsys):
+        """Content outside the block is the team's and survives, so there is
+        nothing to announce."""
+        target = tmp_path / "project"
+        self._install(target)
+        path = target / "AGENTS.md"
+        path.write_text("# Team notes\n\nMUST SURVIVE\n" + path.read_text(encoding="utf-8"),
+                        encoding="utf-8")
+        capsys.readouterr()
+
+        _apply_codex(target)
+
+        combined = "".join(capsys.readouterr()).lower()
+        assert "MUST SURVIVE" in path.read_text(encoding="utf-8")
+        assert "govkit block" not in combined
+
+    def test_the_warning_names_the_file_and_says_where_to_put_edits(self, tmp_path, capsys):
+        target = tmp_path / "project"
+        self._install(target)
+        _edit_inside_the_block(target / "AGENTS.md")
+        capsys.readouterr()
+
+        _apply_codex(target)
+
+        combined = "".join(capsys.readouterr())
+        assert "AGENTS.md" in combined
+        assert "outside" in combined.lower()
+
+    def test_a_pre_hash_block_edited_after_install_is_announced(self, tmp_path, capsys):
+        """Blocks written before #81 carry no hash. They fall back to mtime
+        against the marker's applied_at, the same fallback governed docs use
+        for pre-hash headers — otherwise every existing install would be
+        silent until its first rewrite."""
+        import re
+
+        target = tmp_path / "project"
+        self._install(target)
+        path = target / "AGENTS.md"
+        # Strip the hash line to simulate a block from before this change.
+        path.write_text(
+            re.sub(r"^<!-- govkit:block-hash .*-->\n", "", path.read_text(encoding="utf-8"),
+                   flags=re.MULTILINE),
+            encoding="utf-8",
+        )
+        _edit_inside_the_block(path)
+        capsys.readouterr()
+
+        _apply_codex(target)
+
+        combined = "".join(capsys.readouterr()).lower()
+        assert "govkit block" in combined


### PR DESCRIPTION
Closes #81

## The issue's matrix was wrong, and it matters

#81 reports this as a `--force` gap, with plain `upgrade` shown as preserving
the edit. Measured against a real install — marker aged so `upgrade` does
real work — the edit is discarded on **all four** paths, silently:

| path | edit inside the block | announced (before) |
| --- | --- | --- |
| `apply` | replaced | no |
| `apply --force` | replaced | no |
| `upgrade` | replaced | no |
| `upgrade --force` | replaced | no |

The "survived" row was the version-match no-op that the issue's own
reproduction note warns about. The trap was flagged in the issue and still
fallen into for that row.

So the warning fires on every path, not only under `--force`.

## Announce, don't withhold

Deliberately **not** modelled on governed-doc protection, which refuses
without `--force`. That file is the team's and worth withholding a write
over. This block is govkit's — its own fenced note says the content is
overwritten on upgrade, and that promise is what makes the rest of
`AGENTS.md` safe to own. Refusing would break the contract; the defect was
only the silence.

```
warning: replaced your edits inside the govkit block at …/AGENTS.md
— that block is managed by govkit; put your own instructions outside it so they survive
```

## Detection

Same provenance shape `skill_context` uses: the block records a SHA-256 of
the body govkit wrote, and a differing live body is a team edit. Comparing
against the *new* body instead would flag every legitimate governance change
as an edit.

The hash sits on its own line inside the block, not in the `BEGIN` marker —
that marker's exact text is what `detect._is_govkit_authored_folder` and
doctor's D018 search for, and a test pins that the markers are unchanged.

**Writing the tests found a gap in my first draft.** Reading the body as
"everything after the hash line" missed an edit inserted between `BEGIN` and
the note — which is inside the span a rewrite replaces, so it is discarded
just the same. The note and hash lines are now dropped wherever they sit,
with tests for an edit above the note and between the note and the body.

## Migration

Blocks written before this carry no hash, so they fall back to mtime against
the marker's `applied_at` — the same fallback governed docs use for pre-hash
headers. Without it every install that exists today would stay silent until
its first rewrite.

Verified on a real pre-change install (built by stashing this branch's `cli/`
changes): 0 hash lines → edit → `upgrade` announces it → block gains its hash
→ next `upgrade` is silent.

## Verification

- All four paths announce; a clean re-apply of an untouched install stays
  silent, which matters because every run rewrites every block and warning
  each time would bury the one that counts.
- Edits *outside* the block still survive and still say nothing.
- `./run_tests` 2188 passed · `./full_test` 134 passed / 16 skipped · `pytest
  -k parity` 20 passed · `ruff check` clean.

README's ownership section gains the one case where "govkit never overwrites
files you authored" does not reach, and what govkit now says about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
