### PR TITLE
feat(doctor): name service packages govkit did not list (#120)

### DIFF
--- a/cli/detect.py
+++ b/cli/detect.py
@@ -94,6 +94,13 @@ _LAYERED_FOLDERS = {"Controllers", "Services", "Repositories"}
 _CLEAN_FOLDERS = {"Application", "Domain", "Infrastructure", "Presentation"}
 _DBT_FOLDERS = {"staging", "intermediate", "marts"}
 
+# The fingerprints source-root detection matches against, and how many of a
+# fingerprint's folders a package must hold to be recognised. `detect_services`
+# and `detect_near_miss_packages` read both from here so "one below
+# recognised" cannot drift away from what recognised means.
+_LAYER_FINGERPRINTS = (_HEXAGONAL_FOLDERS, _LAYERED_FOLDERS, _CLEAN_FOLDERS)
+_FINGERPRINT_THRESHOLD = 2
+
 
 # ---------------------------------------------------------------------------
 # RepoProfile
@@ -531,13 +538,13 @@ def _layer_root_candidates(target: Path) -> list[Path]:
     Direct children only — `iterdir()` on `src/`, `Source/` and each of
     their packages. Cost is fixed regardless of repo size.
     """
-    fingerprints = (_HEXAGONAL_FOLDERS, _LAYERED_FOLDERS, _CLEAN_FOLDERS)
-
     def _matches(root: Path, discount_govkit: bool = False) -> bool:
         names = _child_dir_names(root)
         if discount_govkit:
             names = {n for n in names if not _is_govkit_authored_folder(root / n)}
-        return any(len(fp & names) >= 2 for fp in fingerprints)
+        return any(
+            len(fp & names) >= _FINGERPRINT_THRESHOLD for fp in _LAYER_FINGERPRINTS
+        )
 
     # Only the target root discounts govkit's own folders — see
     # `_is_govkit_authored_folder`. Applying it to `src/<pkg>/` would drop
@@ -585,6 +592,51 @@ def detect_source_root(target: Path) -> str:
     if len(candidates) != 1 or candidates[0] == target:
         return ""
     return candidates[0].relative_to(target).as_posix()
+
+
+def detect_near_miss_packages(target: Path) -> list[tuple[str, tuple[str, ...]]]:
+    """`(root, matched folders)` for packages govkit almost called services.
+
+    `detect_services` omits any package holding too few architecture layers.
+    That is right — govkit can say nothing useful about `src/legacy/` — but
+    it is silent, and a team reading `services: [orders, billing]` cannot
+    tell whether that is the whole repo.
+
+    A near miss overlaps some fingerprint by **exactly one** folder: enough
+    that govkit looked at it, too little to name it. Reporting every
+    unlisted directory instead would fire on `src/utils/`, `src/config/` and
+    every shared package in every multi-service repo, which is noise — and
+    noise trains people to ignore the check.
+
+    The fingerprints and the threshold are the ones `_layer_root_candidates`
+    uses, not a second copy, so "one below recognised" cannot drift away
+    from what recognised means.
+
+    Note the fingerprints are case-sensitive: the layered one holds
+    `Services`, so a package with only `src/x/services/` overlaps nothing
+    and is not a near miss.
+    """
+    recognised = set(_layer_root_candidates(target))
+    near_misses: list[tuple[str, tuple[str, ...]]] = []
+    for root in (target / name for name in _PACKAGE_ROOTS):
+        if not root.is_dir():
+            continue
+        try:
+            packages = sorted(p for p in root.iterdir() if p.is_dir())
+        except OSError:
+            continue
+        for package in packages:
+            if package.name.startswith(".") or package.name in _SKIP_DIRS:
+                continue
+            if package in recognised:
+                continue
+            names = _child_dir_names(package)
+            matched = max((fp & names for fp in _LAYER_FINGERPRINTS), key=len, default=set())
+            if 0 < len(matched) < _FINGERPRINT_THRESHOLD:
+                near_misses.append(
+                    (package.relative_to(target).as_posix(), tuple(sorted(matched))),
+                )
+    return near_misses
 
 
 def detect_services(target: Path) -> list[tuple[str, str]]:

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -965,6 +965,58 @@ def _live_locations_for(dest: str, live_dests: set[str]) -> list[str]:
     return sorted(d for d in live_dests if d.endswith(suffix))
 
 
+@_register_check("D019")
+def _check_skipped_service_packages(
+    target: Path, marker: dict,
+) -> list[ValidationFinding]:
+    """D019 — a package govkit almost recognised as a service, and did not.
+
+    `architecture.services` in skill_context lists the packages holding a
+    full set of architecture layers. Anything short of that is omitted,
+    correctly — govkit can say nothing useful about `src/legacy/` — but the
+    omission is silent, and since #118 the planning skills offer only the
+    names govkit found. A team reading `services: [orders, billing]` has no
+    way to tell whether that is the whole repo.
+
+    Only *near misses* are reported: a package overlapping one architecture
+    fingerprint by a single folder, which is where govkit looked and almost
+    named it. Reporting every unlisted directory would fire on `src/utils/`,
+    `src/config/` and every shared package in every repo — noise, and noise
+    trains people to ignore the check.
+
+    Informational. Nothing is broken; the repo is simply not fully
+    described, and the fix may well be "nothing".
+    """
+    try:
+        from .detect import detect_near_miss_packages
+
+        near_misses = detect_near_miss_packages(target)
+    except OSError:
+        return []
+
+    findings: list[ValidationFinding] = []
+    for root, matched in near_misses:
+        seen = ", ".join(f"{name}/" for name in matched)
+        findings.append(ValidationFinding(
+            id="D019",
+            severity="info",
+            category="unlisted-service-package",
+            file=root,
+            message=(
+                f"{root} holds {seen} but too few architecture layers for govkit "
+                f"to recognise it as a service, so it is absent from "
+                f"architecture.services in .govkit/skill_context.yaml"
+            ),
+            suggested_action=(
+                f"no action needed if {root} is not a service. If it is one, give "
+                f"it the layer folders this project's architecture uses (see "
+                f"architecture.layers in .govkit/skill_context.yaml), or add it to "
+                f"architecture.services by hand — govkit preserves that edit"
+            ),
+        ))
+    return findings
+
+
 # D002 (rule body mentions an absent folder name) is intentionally deferred.
 # The body of most rule files contains explanatory text that references
 # architecture concepts ("adapters implement outbound port contracts...")

--- a/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
+++ b/plans/MULTI_SERVICE_SKILL_CONTEXT_PLAN.md
@@ -486,7 +486,7 @@ earlier install left behind. Kept as a pointer because the reasoning that
 found them is worth keeping: unit tests were green across every layout while
 codex, one of three agents, got none of the feature.
 
-### Should doctor name skipped sibling packages? — tracked as #120
+### ~~Should doctor name skipped sibling packages?~~ — closed by #120
 
 Open question 3's remaining half, deliberately left out of 2b. A team reading
 `services: [orders, billing]` cannot tell whether that is the whole repo.
@@ -501,6 +501,26 @@ and a team would be surprised it did not.
 That definition needs deciding before the check is written, which is why 2b
 shipped without it. Lifted into **#120** rather than left here, since an open
 question inside a plan marked Implemented is where things go to be forgotten.
+
+**Settled, and the near-miss rule needed correcting first.** Doctor **D019**
+now reports a package overlapping one fingerprint by exactly one folder,
+reading the fingerprints and the `>= 2` threshold from the same constants
+`_layer_root_candidates` uses so the two cannot drift.
+
+#120's write-up illustrated a near miss with `src/reporting/services/`. That
+is wrong: the fingerprints are case-sensitive and the layered one holds
+`Services`, so a lone lowercase `services/` overlaps **nothing** and is not a
+near miss at all. Building the check against that example would have produced
+one that stayed silent on the very case its issue used to justify it. Real
+near misses are `src/legacy/ports/` and `src/shared/Domain/`, and there is a
+test pinning that the lowercase case is not one.
+
+The open sub-question — whether to report when `services` is absent entirely
+— is answered **yes**. One conforming package beside a near miss reads as
+single-service, so govkit picked a source root and ignored the other package.
+That is more surprising there, not less.
+
+Severity is `info`: nothing is broken, and the right fix is often nothing.
 
 ### ~~Codex and copilot planning skills assume hexagonal~~ — closed by #119
 

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1060,3 +1060,143 @@ class TestGovkitsOwnFoldersAreNotEvidence:
 
         assert detect_source_root(tmp_path) == ""
 
+
+
+# ---------------------------------------------------------------------------
+# Near-miss packages — #120
+# ---------------------------------------------------------------------------
+
+class TestDetectNearMissPackages:
+    """Packages govkit *almost* recognised as services.
+
+    `detect_services` omits anything that does not hold enough architecture
+    layers, correctly — but silently. A team reading `services: [orders,
+    billing]` cannot tell whether that is the whole repo.
+
+    A near miss is a package overlapping some fingerprint by exactly one
+    folder: enough that govkit looked at it, too little to name it. That is
+    the set where the omission is surprising. `src/utils/` overlapping
+    nothing is not surprising and is not reported — reporting every unlisted
+    directory would fire on every shared package in every repo.
+    """
+
+    def test_a_package_with_one_hexagonal_folder_is_a_near_miss(self, tmp_path):
+        from cli.detect import detect_near_miss_packages
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+
+        assert [root for root, _layers in detect_near_miss_packages(tmp_path)] == [
+            "src/legacy",
+        ]
+
+    def test_the_matched_folders_are_reported(self, tmp_path):
+        """So the message can say what govkit saw, not just that it saw
+        something."""
+        from cli.detect import detect_near_miss_packages
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "legacy" / "adapters").mkdir(parents=True)
+
+        assert detect_near_miss_packages(tmp_path) == [("src/legacy", ("adapters",))]
+
+    def test_a_clean_architecture_near_miss_is_found(self, tmp_path):
+        from cli.detect import detect_near_miss_packages
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "shared" / "Domain").mkdir(parents=True)
+
+        assert detect_near_miss_packages(tmp_path) == [("src/shared", ("Domain",))]
+
+    def test_a_package_overlapping_nothing_is_not_reported(self, tmp_path):
+        """`src/utils/` is not a service and nobody expected it to be.
+        Reporting it is the noise this check exists to avoid."""
+        from cli.detect import detect_near_miss_packages
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "utils" / "helpers").mkdir(parents=True)
+        (tmp_path / "src" / "config").mkdir(parents=True)
+
+        assert detect_near_miss_packages(tmp_path) == []
+
+    def test_a_lowercase_services_folder_overlaps_nothing(self, tmp_path):
+        """The layered fingerprint holds `Services`, not `services`. A
+        package with only `src/x/services/` matches no fingerprint at all, so
+        it is not a near miss — #120's original write-up got this wrong and
+        would have had the check silent on its own example."""
+        from cli.detect import detect_near_miss_packages
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "reporting" / "services").mkdir(parents=True)
+
+        assert detect_near_miss_packages(tmp_path) == []
+
+    def test_a_recognised_service_is_never_a_near_miss(self, tmp_path):
+        from cli.detect import detect_near_miss_packages, detect_services
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+
+        named = {root for _n, root in detect_services(tmp_path)}
+        assert named == {"src/orders", "src/billing"}
+        assert not [r for r, _ in detect_near_miss_packages(tmp_path) if r in named]
+
+    def test_reported_for_a_single_service_repo_too(self, tmp_path):
+        """The sub-question #120 left open, answered yes. One conforming
+        package and one near miss reads as single-service, and govkit picked
+        a source root while ignoring the other package — more surprising
+        there, not less."""
+        from cli.detect import detect_near_miss_packages, detect_source_root
+
+        _hexagonal_package(tmp_path, "src/orders")
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+
+        assert detect_source_root(tmp_path) == "src/orders"
+        assert detect_near_miss_packages(tmp_path) == [("src/legacy", ("ports",))]
+
+    def test_silent_when_the_layers_sit_at_the_repo_root(self, tmp_path):
+        from cli.detect import detect_near_miss_packages
+
+        _hexagonal_package(tmp_path, "")
+
+        assert detect_near_miss_packages(tmp_path) == []
+
+    def test_silent_on_a_repo_with_no_source_root(self, tmp_path):
+        from cli.detect import detect_near_miss_packages
+
+        (tmp_path / "docs").mkdir()
+
+        assert detect_near_miss_packages(tmp_path) == []
+
+    def test_skip_dirs_and_hidden_packages_are_ignored(self, tmp_path):
+        from cli.detect import detect_near_miss_packages
+
+        for svc in ("orders", "billing"):
+            _hexagonal_package(tmp_path, f"src/{svc}")
+        (tmp_path / "src" / "node_modules" / "ports").mkdir(parents=True)
+        (tmp_path / "src" / ".cache" / "ports").mkdir(parents=True)
+
+        assert detect_near_miss_packages(tmp_path) == []
+
+    def test_the_threshold_is_the_one_detection_uses(self, tmp_path):
+        """Near miss is defined against the same fingerprints and the same
+        `>= 2` threshold `detect_source_root` applies. If the check kept its
+        own copy the two would drift and this would report packages that are
+        in fact services, or miss ones that are not."""
+        from cli.detect import detect_near_miss_packages, detect_services
+
+        # Exactly the threshold: two hexagonal folders -> a service.
+        (tmp_path / "src" / "orders" / "ports").mkdir(parents=True)
+        (tmp_path / "src" / "orders" / "adapters").mkdir(parents=True)
+        (tmp_path / "src" / "billing" / "ports").mkdir(parents=True)
+        (tmp_path / "src" / "billing" / "adapters").mkdir(parents=True)
+        # One below it -> a near miss.
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+
+        assert len(detect_services(tmp_path)) == 2
+        assert [r for r, _ in detect_near_miss_packages(tmp_path)] == ["src/legacy"]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1523,3 +1523,119 @@ def test_d018_covers_every_layout_where_rules_move():
             assert fired == (name in relocating), (
                 f"{name}: D018 fired={fired}, expected {name in relocating}"
             )
+
+
+class TestD019SkippedServicePackages:
+    """#120 — govkit names what it did not list.
+
+    `architecture.services` omits packages that hold too few architecture
+    layers. Correct, but silent: a team reading `services: [orders, billing]`
+    cannot tell whether that is the whole repo, and since #118 the planning
+    skills offer only the names govkit found.
+    """
+
+    def _services(self, target: Path) -> None:
+        for svc in ("orders", "billing"):
+            for layer in BACKEND_LAYERS:
+                (target / "src" / svc / layer).mkdir(parents=True)
+
+    def test_names_a_near_miss_package(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._services(tmp_path)
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        d019s = [f for f in run_doctor(tmp_path) if f.id == "D019"]
+        assert len(d019s) == 1
+        assert "src/legacy" in d019s[0].message.replace("\\", "/")
+
+    def test_is_informational_not_a_failure(self, tmp_path):
+        """Nothing is broken — the repo just is not fully described. Doctor
+        exits non-zero only on errors, and this must not change that."""
+        from cli.doctor import run_doctor
+
+        self._services(tmp_path)
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        finding = [f for f in run_doctor(tmp_path) if f.id == "D019"][0]
+        assert finding.severity == "info"
+
+    def test_says_what_it_saw_and_what_was_missing(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._services(tmp_path)
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        finding = [f for f in run_doctor(tmp_path) if f.id == "D019"][0]
+        text = finding.message + finding.suggested_action
+        assert "ports" in text
+        assert "architecture.services" in text
+
+    def test_silent_when_every_package_is_a_service(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._services(tmp_path)
+        _write_marker(tmp_path)
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D019"] == []
+
+    def test_silent_for_packages_that_look_nothing_like_services(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._services(tmp_path)
+        (tmp_path / "src" / "utils" / "helpers").mkdir(parents=True)
+        (tmp_path / "src" / "config").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D019"] == []
+
+    def test_reports_each_near_miss_separately(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._services(tmp_path)
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+        (tmp_path / "src" / "shared" / "Domain").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        reported = {
+            f.file.replace("\\", "/") for f in run_doctor(tmp_path) if f.id == "D019"
+        }
+        assert reported == {"src/legacy", "src/shared"}
+
+    def test_fires_on_a_single_service_repo(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        for layer in BACKEND_LAYERS:
+            (tmp_path / "src" / "orders" / layer).mkdir(parents=True)
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        assert len([f for f in run_doctor(tmp_path) if f.id == "D019"]) == 1
+
+    def test_silent_on_a_flat_repo(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        for layer in BACKEND_LAYERS:
+            (tmp_path / layer).mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D019"] == []
+
+    def test_does_not_change_the_exit_code(self, tmp_path):
+        """An info finding alone must leave `govkit doctor` green."""
+        import argparse
+
+        import pytest as _pytest
+
+        from cli.doctor import cmd_doctor
+
+        self._services(tmp_path)
+        (tmp_path / "src" / "legacy" / "ports").mkdir(parents=True)
+        _write_marker(tmp_path)
+
+        with _pytest.raises(SystemExit) as exc:
+            cmd_doctor(argparse.Namespace(target=str(tmp_path)))
+        assert exc.value.code == 0


### PR DESCRIPTION
Closes #120

## What it does

`architecture.services` omits packages holding too few architecture layers —
correctly, but silently. Since #118 the planning skills offer only the names
govkit found, so an omission now shapes what the agent proposes.

D019 reports a **near miss**: a package overlapping one fingerprint by
exactly one folder, which is where govkit looked and almost named it.

On a real install with seven packages under `src/`:

```
packages under src/  : billing config legacy orders reporting shared utils
listed as services   : ['billing', 'orders']

D019  src/legacy
      src/legacy holds ports/ but too few architecture layers for govkit to
      recognise it as a service, so it is absent from architecture.services
      fix: no action needed if src/legacy is not a service. If it is one, give it
      the layer folders this project's architecture uses …, or add it to
      architecture.services by hand — govkit preserves that edit

D019  src/shared
      src/shared holds Domain/ …
```

Quiet on `config`, `utils` and `reporting` — reporting every unlisted
directory would fire on every shared package in every repo, which is noise,
and noise trains people to ignore the check.

## The issue's example was wrong, and it mattered

#120 (which I wrote) illustrated a near miss with `src/reporting/services/`.
The fingerprints are **case-sensitive** and the layered one holds `Services`,
so a lone lowercase `services/` overlaps **nothing**:

| package | best overlap | verdict |
| --- | --- | --- |
| `src/reporting/services/` | 0 | not a service — **not** a near miss |
| `src/legacy/ports/` | 1 (hexagonal) | near miss |
| `src/shared/Domain/` | 1 (clean) | near miss |
| `src/orders/{ports,adapters}/` | 2 | service |

Building against the issue's example would have produced a check that stayed
silent on the very case used to justify it — and a fixture built from the
same example would have "verified" it. There is now a test pinning that the
lowercase case is not a near miss.

## No second copy of the rule

`detect_near_miss_packages` reads the fingerprints and the `>= 2` threshold
from the same constants `_layer_root_candidates` uses, extracted here as
`_LAYER_FINGERPRINTS` and `_FINGERPRINT_THRESHOLD`. "One below recognised"
therefore cannot drift from what recognised means — a test asserts a package
at the threshold is a service and one below it is a near miss.

## The sub-question, answered

#120 left open whether to report when `services` is absent entirely.
**Yes.** One conforming package beside a near miss reads as single-service,
so govkit picked a source root and ignored the other package. That is more
surprising there, not less.

## Severity

`info`. Nothing is broken; the repo is just not fully described, and the
right fix is often nothing. Verified on a real install that the exit code is
driven by D001's errors and D019 leaves it alone — plus a unit test that an
info-only run exits 0.

`./run_tests` 2190 passed · `./full_test` 134 passed / 16 skipped · `pytest
-k parity` 20 passed · `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
