### PR TITLE
feat(cli): add govkit --version (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Backend installs ship no UI artifacts; UI installs ship no backend artifacts. Th
 | `govkit extension` | `extension list` shows bundled extension packs; `extension add <id> --target <path>` copies one into your project's `extensions/<id>/`. |
 | `govkit upgrade` | Refresh the files govkit owns (contracts, CI gates, templates) to a new version without touching the files you own. |
 | `govkit list` | List available agents and starter templates. |
+| `govkit --version` | Print the installed version — the same one recorded in `.govkit/marker.json` and compared by `upgrade`. |
 
 > `govkit doctor` and `govkit validate` cover different surfaces: **doctor** checks whether the installed governance still *fits the repo*; **validate** checks whether your *features* meet the governed contract. Both are designed to run in CI.
 

--- a/cli/govkit.py
+++ b/cli/govkit.py
@@ -22,6 +22,7 @@ Usage:
     govkit init my_feature --target /path/to/project
     govkit init my_feature --starter backend --target /path/to/project
     govkit validate --target /path/to/project
+    govkit --version
 """
 
 from __future__ import annotations
@@ -37,6 +38,7 @@ from .cmd_stack import register as _register_stack
 from .cmd_upgrade import register as _register_upgrade
 from .cmd_validate import register as _register_validate
 from .doctor import register as _register_doctor
+from .version import GOVKIT_VERSION
 
 # Subcommand registrars. Each command module owns its argparse surface and
 # binds its handler via `set_defaults(func=...)`. Adding a command = create its
@@ -58,6 +60,17 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         prog="govkit",
         description="governed AI delivery kit — apply spec scaffolding to a project",
+    )
+    # Reports the same number `marker.json` records and `upgrade` compares
+    # against — both read it from `cli/version.py`. A user quoting
+    # `govkit --version` in a bug report is then describing the install that
+    # actually ran.
+    #
+    # The version action resolves during parsing, so it answers even though
+    # the subparser below is `required=True` and a bare `govkit` is an error.
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {GOVKIT_VERSION}",
+        help="print the installed govkit version and exit",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     for register in _REGISTRARS:

--- a/tests/test_main_dispatch.py
+++ b/tests/test_main_dispatch.py
@@ -69,3 +69,74 @@ def test_unknown_command_exits_nonzero(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         govkit.main()
     assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# --version — #123
+# ---------------------------------------------------------------------------
+
+class TestVersionFlag:
+    """`govkit --version` prints the installed version and exits cleanly.
+
+    The subparser is declared `required=True`, so a bare `govkit` is an
+    error. `--version` has to resolve before that check — argparse fires a
+    `version` action during parsing and exits — and this pins it, because
+    getting it wrong turns `govkit --version` into a usage error rather than
+    an answer.
+    """
+
+    def _run(self, monkeypatch, capsys, argv):
+        import pytest as _pytest
+
+        monkeypatch.setattr(sys, "argv", argv)
+        with _pytest.raises(SystemExit) as exc:
+            govkit.main()
+        return exc.value.code, capsys.readouterr()
+
+    def test_version_flag_exits_zero(self, monkeypatch, capsys):
+        code, _ = self._run(monkeypatch, capsys, ["govkit", "--version"])
+        assert code == 0
+
+    def test_version_flag_prints_the_installed_version(self, monkeypatch, capsys):
+        from cli.version import GOVKIT_VERSION
+
+        _code, out = self._run(monkeypatch, capsys, ["govkit", "--version"])
+        assert GOVKIT_VERSION in (out.out + out.err)
+
+    def test_version_output_names_the_program(self, monkeypatch, capsys):
+        _code, out = self._run(monkeypatch, capsys, ["govkit", "--version"])
+        assert (out.out + out.err).strip().startswith("govkit ")
+
+    def test_version_needs_no_subcommand(self, monkeypatch, capsys):
+        """A bare `govkit` is a usage error; `govkit --version` must not be.
+        Same reason: the version action has to win over the required
+        subparser."""
+        import pytest as _pytest
+
+        monkeypatch.setattr(sys, "argv", ["govkit"])
+        with _pytest.raises(SystemExit) as bare:
+            govkit.main()
+        assert bare.value.code != 0
+
+        code, _ = self._run(monkeypatch, capsys, ["govkit", "--version"])
+        assert code == 0
+
+    def test_it_reports_the_same_number_the_marker_records(self, monkeypatch, capsys):
+        """One number, not two. `--version` is what a user quotes in a bug
+        report; the marker and `upgrade`'s comparison are what govkit acts
+        on. If they could disagree, the report would describe a different
+        install from the one that ran."""
+        from cli import marker, version
+
+        _code, out = self._run(monkeypatch, capsys, ["govkit", "--version"])
+        reported = (out.out + out.err).split()[-1]
+        assert reported == version.GOVKIT_VERSION
+        assert marker.version.GOVKIT_VERSION == reported
+
+    def test_help_still_lists_the_subcommands(self, monkeypatch, capsys):
+        """Adding a top-level flag must not disturb the command surface."""
+        code, out = self._run(monkeypatch, capsys, ["govkit", "--help"])
+        text = out.out + out.err
+        assert code == 0
+        for command in ("apply", "doctor", "upgrade", "validate"):
+            assert command in text


### PR DESCRIPTION
Closes #123

```
$ govkit --version
govkit 0.16.0
```

## One number, not two

It reports `cli/version.py`'s `GOVKIT_VERSION` — the same value `marker.json`
records and `upgrade` compares against. A test asserts those cannot diverge,
because the whole point of the flag is that a user quoting it in a bug report
is describing the install that actually ran.

The version comes from `importlib.metadata`, populated at install time.
That's deliberately not `pyproject.toml`: a wheel doesn't ship it. A source
checkout with no install reports `dev`, which is honest.

## The bit worth testing

The subparser is declared `required=True`, so a bare `govkit` is a usage
error (exit 2). argparse's `version` action resolves during parsing and exits
before that check — which is the only reason `govkit --version` is an answer
rather than a usage error.

That's pinned by a test, because getting it wrong fails silently: the flag
would just stop working and the failure would read as ordinary argparse
behaviour rather than a regression.

## Verified

From a **clean wheel install**, not only the editable one — mirroring CI's
`wheel-smoke` job:

```
govkit --version   -> govkit 0.16.0   (exit 0)
govkit list        -> Available agents: …
govkit             -> exit 2          (still a usage error)
```

`./run_tests` 2214 passed · `ruff check` clean. README's command table gains
the flag.

## One thing to know about this machine

The editable install here reports `0.14.0` while `pyproject.toml` says
`0.16.0` — its metadata is `govkit-0.14.0.dist-info`, generated before the
last version bump. Not a defect in this change, and govkit stays internally
consistent (the marker and `upgrade` read the same stale number). A
`pip install -e .` resyncs it. The wheel build reports `0.16.0` correctly,
which is what users get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
