### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,86 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-08-04
+
+Boundary enforcement now runs in a tool that understands each backend stack,
+multi-service repos are described and governed as such, and several checks
+that could pass without examining anything were repaired.
+
+**Upgrading:** `govkit upgrade` moves files in two cases. In a multi-service
+repo, Codex's layer rules move from the repo root into each service; the old
+root copies are left in place and reported by the new D018 rather than
+deleted. Codex's managed `AGENTS.md` block also gains a content hash line.
+Neither touches content you wrote.
+
+### Added
+
+- Boundary enforcement for every backend stack, in a tool that can read its
+  source: `dependency-cruiser` (nodejs-fastify), `go-arch-lint` (go-gin),
+  ArchUnit (java-spring-boot) and ArchUnitNET (dotnet-aspnet) join
+  import-linter (python-fastapi). The gate is selected per stack, and each
+  reference contract ships at L3. All five are executed against generated
+  fixtures in CI, not merely asserted structurally.
+- `architecture.services` in `.govkit/skill_context.yaml` — one entry per
+  service package, with `name` and `root` — so a skill can scope its work to
+  one service. Absent for single-service repos, which keeps every existing
+  file valid. `SkillContext.services` exposes it as typed `ServiceRef`s.
+- The backend `spec-planning` and `implementation-plan` skills ask which
+  service to plan for when a repo holds several and the request names none,
+  and scope every path in their output to that service's root.
+- `govkit --version`, reporting the same version recorded in
+  `.govkit/marker.json` and compared by `upgrade`.
+- **doctor D018** — path-scoped rules left where govkit no longer writes
+  them, with different advice for a govkit orphan and a file you authored.
+- **doctor D019** — packages govkit almost recognised as services and did
+  not list, so the omission stops being silent.
+
+### Changed
+
+- **Codex's path-scoped rules install once per service in a multi-service
+  repo** (`src/orders/api/AGENTS.md`), instead of a single copy at the repo
+  root that governed no code — Codex resolves `AGENTS.md` upward from the
+  file being edited and never reached it from service code.
+- **Codex's managed `AGENTS.md` block records a hash of its own content**, so
+  govkit can tell your edit from its own. Replacing the block is unchanged
+  and still documented in the block; what is new is that govkit now says so
+  when it discards an edit made inside it.
+- `architecture.source_root` is derived from the repo instead of being
+  hardcoded to `src/`. `""` now means "no single source root" — layers at
+  the repo root, several services, or a layout govkit cannot read — and is
+  read together with `services`.
+- The backend planning skills read the detected architecture rather than
+  assuming hexagonal. On a Clean, layered or dbt repo, Codex and Copilot
+  previously named packages that did not exist.
+- Stack-agnostic backend docs no longer state stack-specific rules or name a
+  boundary tool; they defer to `TECH_STACK.md`. Python code examples remain
+  as labelled illustrations.
+- The hexagonal layer vocabulary is consistent across the payload, and
+  `REPO_STRUCTURE_README.md` documents the multi-service shape.
+- `doctor` and `calibrate` discover nested installs in a monorepo instead of
+  stopping at the first governed root.
+
+### Fixed
+
+- The shipped import-linter reference analysed **nothing**: it declared
+  `root_package = "src"`, which is not a package in the prescribed src
+  layout, so grimp resolved zero dependencies and every contract reported
+  KEPT — including against injected violations. It also now ships from L3.
+- L4+ installs ran `boundary-check`, `sonarqube`, `security-scan` and
+  `commit-format` **twice** on every push, because the L3 and L4 gate files
+  both defined them.
+- D001 could not expand brace globs (`**/*.{py,go,ts}`), so installs
+  carrying such a rule reported a permanent, unfixable error against a
+  correct repo.
+- D008 missed LLM dependencies: the marker list omitted `claude-agent-sdk`
+  (which never pulls in `anthropic`), and the scanned manifests omitted
+  `.csproj`, `go.mod` and `build.gradle`, so .NET, Go and Java projects
+  false-negatived regardless of SDK.
+- Team edits to the `architecture` block of `skill_context.yaml` survive the
+  rewrite that every apply, upgrade, stack apply and calibrate performs.
+- `calibrate` correcting the architecture style now re-scopes the installed
+  rules, and re-renders the PII keyword list into rule bodies.
+
 ## [0.16.0] — 2026-07-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.16.0"
+version = "0.17.0"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Prepares the release you're about to promote to PyPI.

## Why this is blocking, not housekeeping

`pyproject.toml` said `0.16.0`, and **0.16.0 is already on PyPI**. A publish
would have built `govkit-0.16.0-*` and been rejected at upload. Meanwhile 32
commits since the `v0.16.0` tag had accumulated under an **empty**
`[Unreleased]`.

## Version

**0.17.0.** Minor rather than major: features were added (per-stack boundary
enforcement, multi-service support, D018/D019, `--version`) and no CLI
contract broke. Say the word if you want a different number — it's one line
in `pyproject.toml` and one heading.

## The entry leads with what moves

Two changes touch files in an already-governed repo on `upgrade`, so they
open the section rather than sitting in a list:

- Codex's layer rules relocate from the repo root into each service in a
  multi-service repo. The old root copies are **left in place** and reported
  by D018, not deleted.
- Codex's managed `AGENTS.md` block gains a content-hash line.

Neither touches content you wrote.

## One thing I had to correct

D016 and D017 were in my first draft under Added. Checking each check id
against the `v0.16.0` tag showed both shipped **in** 0.16.0 with the
ui-nextjs work and are already documented in that entry. Only D018 and D019
are new. Every remaining claim was verified against the tree rather than
written from memory — the five boundary gate files, the four new reference
contracts, `ServiceRef`, the `--version` wiring, the skills' multi-service
section, and that all five contracts have executing fixture tests.

## Verified on the real artifacts

Built wheel + sdist, `twine check` passes on both, then installed the wheel
into a clean venv:

```
govkit --version    -> govkit 0.17.0
apply (multi-service, codex):
  marker version    -> 0.17.0
  services          -> ['billing', 'orders']
  per-service rules -> src/orders/api/AGENTS.md present
  doctor exit       -> 0
```

`./run_tests` 2214 passed.

## After merge

`publish.yml` triggers on `release: types: [published]` — nothing else fires
it. So: tag `v0.17.0` and publish a GitHub release from it.

**Before your smoke testing**, run `pip install -e .` in this checkout. Its
metadata is still `govkit-0.14.0.dist-info`, so `--version`, marker stamping
and `upgrade`'s "already at X" short-circuit all currently report 0.14.0
locally — the code is live, only the version metadata is stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
