### PR TITLE
feat(payload): UI docs parity and prototype design references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,10 @@ Only 6 architecture docs vary per backend/data stack (`TECH_STACK.md`, `API_CONV
 UI project types are standalone and reject both `--stack` and
 `govkit stack apply`. `ui-nextjs` uses its own server-first API-first payload;
 direct SQL/database dependencies are a non-waivable boundary enforced by
-doctor D016.
+doctor D016. The `nextjs/` docs folder is intentionally larger than `react/`
+and `angular/` — its extra docs are server-first concerns with no SPA
+equivalent. Do not replicate them for parity; see
+`docs/ui/architecture/README.md`.
 
 ## When changing behavior, keep the payload internally consistent
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,8 @@ The 8-step lifecycle above applies to all project types. Key differences by type
 - `api.md` for API client functions
 - `accessibility.md` for accessibility concerns
 
+**Visual direction:** Tailwind maps semantic tokens from `docs/ui/design/BRAND.md`. See `docs/ui/architecture/react/STYLING.md`. Feature `design.md` + advisory `design/references/` work the same as for Next.js below.
+
 **Implementation order:** API functions → React Query hooks → Zustand stores → Components → E2E tests
 
 **CI gates:** `ci/github/ui-quality-gate.yml`, `ci/github/ui-eval-gate.yml`
@@ -403,6 +405,8 @@ The 8-step lifecycle above applies to all project types. Key differences by type
 **Architecture:** MVVM with vertical slice feature structure. Standalone components with `OnPush`. See `docs/ui/architecture/MVVM_CONTRACT.md`.
 
 **Layer rules:** Same as React, with Angular-specific content.
+
+**Visual direction:** Component-scoped styles consume semantic tokens from `docs/ui/design/BRAND.md`; no Tailwind mandate. See `docs/ui/architecture/angular/STYLING.md`.
 
 **Implementation order:** API functions → TanStack Query inject functions → Signal stores → Standalone components → E2E tests
 
@@ -423,7 +427,10 @@ This rule cannot be waived by ADR.
 
 **Visual direction:** Tailwind CSS v4 maps semantic tokens from
 `docs/ui/design/BRAND.md`. Each L4+ feature includes `design.md` and an
-advisory `design/references/` folder for screenshots, sketches, and mockups.
+advisory `design/references/` folder for screenshots, sketches, mockups, and
+interactive prototypes (for example an AI-generated HTML prototype —
+reference-only; prototype code is never imported into `src/`). `govkit
+doctor` (D020) warns when the folder and `design.md` drift apart.
 
 **Implementation order:** contracts/types → backend API adapter → application
 use case/view model → Server Component composition → minimal Client Components
@@ -829,12 +836,16 @@ These guides map concrete products to the provider-neutral `llm-application` por
 
 - [COMPONENT_CONVENTIONS.md](docs/ui/architecture/react/COMPONENT_CONVENTIONS.md)
 - [STATE_MANAGEMENT.md](docs/ui/architecture/react/STATE_MANAGEMENT.md) — React Query + Zustand
+- [STYLING.md](docs/ui/architecture/react/STYLING.md) — Tailwind mechanism for the `BRAND.md` semantic tokens
+- [TESTING.md](docs/ui/architecture/react/TESTING.md) — test layers, API boundary, journeys, visual comparisons
 - [TECH_STACK.md](docs/ui/architecture/react/TECH_STACK.md)
 
 ### Angular UI
 
 - [COMPONENT_CONVENTIONS.md](docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md)
 - [STATE_MANAGEMENT.md](docs/ui/architecture/angular/STATE_MANAGEMENT.md) — TanStack Angular Query + Signals
+- [STYLING.md](docs/ui/architecture/angular/STYLING.md) — component-scoped styles over `BRAND.md` semantic tokens
+- [TESTING.md](docs/ui/architecture/angular/TESTING.md) — test layers, API boundary, journeys, visual comparisons
 - [TECH_STACK.md](docs/ui/architecture/angular/TECH_STACK.md)
 
 ### Data (Core — Level 4)

--- a/agents/claude-code/claude-md/l4-ui-angular.md
+++ b/agents/claude-code/claude-md/l4-ui-angular.md
@@ -27,6 +27,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/angular/STYLING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/claude-code/claude-md/l4-ui-angular.md
+++ b/agents/claude-code/claude-md/l4-ui-angular.md
@@ -28,6 +28,7 @@ Read before generating any code:
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/angular/STYLING.md`
+- `docs/ui/architecture/angular/TESTING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/claude-code/claude-md/l4-ui-react.md
+++ b/agents/claude-code/claude-md/l4-ui-react.md
@@ -28,6 +28,7 @@ Read before generating any code:
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/react/STYLING.md`
+- `docs/ui/architecture/react/TESTING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/claude-code/claude-md/l4-ui-react.md
+++ b/agents/claude-code/claude-md/l4-ui-react.md
@@ -27,6 +27,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/react/STYLING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/claude-code/claude-md/ui-angular.md
+++ b/agents/claude-code/claude-md/ui-angular.md
@@ -36,6 +36,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/angular/STYLING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/claude-code/claude-md/ui-angular.md
+++ b/agents/claude-code/claude-md/ui-angular.md
@@ -37,6 +37,7 @@ Read before generating any code:
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/angular/STYLING.md`
+- `docs/ui/architecture/angular/TESTING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/claude-code/claude-md/ui-react.md
+++ b/agents/claude-code/claude-md/ui-react.md
@@ -37,6 +37,7 @@ Read before generating any code:
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/react/STYLING.md`
+- `docs/ui/architecture/react/TESTING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/claude-code/claude-md/ui-react.md
+++ b/agents/claude-code/claude-md/ui-react.md
@@ -36,6 +36,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/react/STYLING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/claude-code/skills/ui/architecture-preflight/SKILL.md
+++ b/agents/claude-code/skills/ui/architecture-preflight/SKILL.md
@@ -132,9 +132,12 @@ This is informational and does not block planning.
 - Confirm `docs/ui/design/BRAND.md` is complete for the visual decisions this
   feature needs
 - Review `features/<feature_name>/design.md`
-- Inventory files under `features/<feature_name>/design/references/`
-- Treat screenshots and mockups as advisory unless `design.md` explicitly
-  promotes a named property to an accepted requirement
+- Inventory files under `features/<feature_name>/design/references/` —
+  images and interactive prototypes alike
+- Treat screenshots, mockups, and prototypes as advisory unless `design.md`
+  explicitly promotes a named property to an accepted requirement
+- Confirm no implementation will import or copy prototype code — prototypes
+  inform; `src/` code is written fresh under the architecture contracts
 - Record loading, empty, error, success, responsive, keyboard, focus, and
   reduced-motion states
 

--- a/agents/claude-code/skills/ui/implementation-plan/SKILL.md
+++ b/agents/claude-code/skills/ui/implementation-plan/SKILL.md
@@ -49,6 +49,8 @@ or business logic in Next.js server code.
 ### 5. View — Components
 - [ ] Build components bottom-up (leaf components first)
 - [ ] Wire to hooks — no direct API calls
+- [ ] No code imported or copied from `design/references/` prototypes —
+      references inform; implementation follows the architecture contracts
 - [ ] Write component tests (React Testing Library / Angular Testing Library)
 - [ ] Run axe accessibility check in each test
 

--- a/agents/claude-code/skills/ui/spec-planning/SKILL.md
+++ b/agents/claude-code/skills/ui/spec-planning/SKILL.md
@@ -67,9 +67,12 @@ For each Gherkin scenario tagged `@accessibility`: describe the WCAG criteria an
 ### 5.5 Visual Direction
 
 Map the approved brand and feature `design.md` to semantic tokens, component
-states, responsive behavior, and accessibility. List every screenshot/mockup
-reference with what may be learned from it. References remain advisory unless
-`design.md` promotes a named property to a requirement.
+states, responsive behavior, and accessibility. List every screenshot,
+mockup, and prototype reference with what may be learned from it. References
+remain advisory unless `design.md` promotes a named property to a
+requirement. Prototype code (for example an AI-generated HTML prototype in
+`design/references/`) is never imported, copied, or extended in `src/` —
+promoted behavior enters the plan through `design.md`.
 
 ### 6. Evaluation Compliance Summary
 

--- a/agents/codex/agents-md/l4-ui-angular.md
+++ b/agents/codex/agents-md/l4-ui-angular.md
@@ -27,6 +27,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/angular/STYLING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/codex/agents-md/l4-ui-angular.md
+++ b/agents/codex/agents-md/l4-ui-angular.md
@@ -28,6 +28,7 @@ Read before generating any code:
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/angular/STYLING.md`
+- `docs/ui/architecture/angular/TESTING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/codex/agents-md/l4-ui-react.md
+++ b/agents/codex/agents-md/l4-ui-react.md
@@ -28,6 +28,7 @@ Read before generating any code:
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/react/STYLING.md`
+- `docs/ui/architecture/react/TESTING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/codex/agents-md/l4-ui-react.md
+++ b/agents/codex/agents-md/l4-ui-react.md
@@ -27,6 +27,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/react/STYLING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/evaluation/eval_criteria.md`
 

--- a/agents/codex/agents-md/ui-angular.md
+++ b/agents/codex/agents-md/ui-angular.md
@@ -36,6 +36,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/angular/STYLING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/codex/agents-md/ui-angular.md
+++ b/agents/codex/agents-md/ui-angular.md
@@ -37,6 +37,7 @@ Read before generating any code:
 - `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/angular/STYLING.md`
+- `docs/ui/architecture/angular/TESTING.md`
 - `docs/ui/architecture/angular/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/codex/agents-md/ui-react.md
+++ b/agents/codex/agents-md/ui-react.md
@@ -37,6 +37,7 @@ Read before generating any code:
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
 - `docs/ui/architecture/react/STYLING.md`
+- `docs/ui/architecture/react/TESTING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/codex/agents-md/ui-react.md
+++ b/agents/codex/agents-md/ui-react.md
@@ -36,6 +36,7 @@ Read before generating any code:
 - `docs/ui/architecture/MVVM_CONTRACT.md`
 - `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 - `docs/ui/architecture/react/STATE_MANAGEMENT.md`
+- `docs/ui/architecture/react/STYLING.md`
 - `docs/ui/architecture/react/TECH_STACK.md`
 - `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/codex/skills/ui/architecture-preflight/SKILL.md
+++ b/agents/codex/skills/ui/architecture-preflight/SKILL.md
@@ -132,9 +132,12 @@ This is informational and does not block planning.
 - Confirm `docs/ui/design/BRAND.md` is complete for the visual decisions this
   feature needs
 - Review `features/<feature_name>/design.md`
-- Inventory files under `features/<feature_name>/design/references/`
-- Treat screenshots and mockups as advisory unless `design.md` explicitly
-  promotes a named property to an accepted requirement
+- Inventory files under `features/<feature_name>/design/references/` —
+  images and interactive prototypes alike
+- Treat screenshots, mockups, and prototypes as advisory unless `design.md`
+  explicitly promotes a named property to an accepted requirement
+- Confirm no implementation will import or copy prototype code — prototypes
+  inform; `src/` code is written fresh under the architecture contracts
 - Record loading, empty, error, success, responsive, keyboard, focus, and
   reduced-motion states
 

--- a/agents/codex/skills/ui/implementation-plan/SKILL.md
+++ b/agents/codex/skills/ui/implementation-plan/SKILL.md
@@ -49,6 +49,8 @@ or business logic in Next.js server code.
 ### 5. View — Components
 - [ ] Build components bottom-up (leaf components first)
 - [ ] Wire to hooks — no direct API calls
+- [ ] No code imported or copied from `design/references/` prototypes —
+      references inform; implementation follows the architecture contracts
 - [ ] Write component tests (React Testing Library / Angular Testing Library)
 - [ ] Run axe accessibility check in each test
 

--- a/agents/codex/skills/ui/spec-planning/SKILL.md
+++ b/agents/codex/skills/ui/spec-planning/SKILL.md
@@ -67,9 +67,12 @@ For each Gherkin scenario tagged `@accessibility`: describe the WCAG criteria an
 ### 5.5 Visual Direction
 
 Map the approved brand and feature `design.md` to semantic tokens, component
-states, responsive behavior, and accessibility. List every screenshot/mockup
-reference with what may be learned from it. References remain advisory unless
-`design.md` promotes a named property to a requirement.
+states, responsive behavior, and accessibility. List every screenshot,
+mockup, and prototype reference with what may be learned from it. References
+remain advisory unless `design.md` promotes a named property to a
+requirement. Prototype code (for example an AI-generated HTML prototype in
+`design/references/`) is never imported, copied, or extended in `src/` —
+promoted behavior enters the plan through `design.md`.
 
 ### 6. Evaluation Compliance Summary
 

--- a/agents/copilot/copilot-instructions/ui-angular.md
+++ b/agents/copilot/copilot-instructions/ui-angular.md
@@ -58,6 +58,7 @@ Read before generating any code:
 * `docs/ui/architecture/MVVM_CONTRACT.md`
 * `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 * `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
+* `docs/ui/architecture/angular/STYLING.md`
 * `docs/ui/architecture/angular/TECH_STACK.md`
 * `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/copilot/copilot-instructions/ui-angular.md
+++ b/agents/copilot/copilot-instructions/ui-angular.md
@@ -59,6 +59,7 @@ Read before generating any code:
 * `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md`
 * `docs/ui/architecture/angular/STATE_MANAGEMENT.md`
 * `docs/ui/architecture/angular/STYLING.md`
+* `docs/ui/architecture/angular/TESTING.md`
 * `docs/ui/architecture/angular/TECH_STACK.md`
 * `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/copilot/copilot-instructions/ui-react.md
+++ b/agents/copilot/copilot-instructions/ui-react.md
@@ -58,6 +58,7 @@ Read before generating any code:
 * `docs/ui/architecture/MVVM_CONTRACT.md`
 * `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 * `docs/ui/architecture/react/STATE_MANAGEMENT.md`
+* `docs/ui/architecture/react/STYLING.md`
 * `docs/ui/architecture/react/TECH_STACK.md`
 * `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/copilot/copilot-instructions/ui-react.md
+++ b/agents/copilot/copilot-instructions/ui-react.md
@@ -59,6 +59,7 @@ Read before generating any code:
 * `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md`
 * `docs/ui/architecture/react/STATE_MANAGEMENT.md`
 * `docs/ui/architecture/react/STYLING.md`
+* `docs/ui/architecture/react/TESTING.md`
 * `docs/ui/architecture/react/TECH_STACK.md`
 * `docs/ui/architecture/ACCESSIBILITY_STANDARDS.md`
 

--- a/agents/copilot/skills/ui/architecture-preflight/SKILL.md
+++ b/agents/copilot/skills/ui/architecture-preflight/SKILL.md
@@ -132,9 +132,12 @@ This is informational and does not block planning.
 - Confirm `docs/ui/design/BRAND.md` is complete for the visual decisions this
   feature needs
 - Review `features/<feature_name>/design.md`
-- Inventory files under `features/<feature_name>/design/references/`
-- Treat screenshots and mockups as advisory unless `design.md` explicitly
-  promotes a named property to an accepted requirement
+- Inventory files under `features/<feature_name>/design/references/` —
+  images and interactive prototypes alike
+- Treat screenshots, mockups, and prototypes as advisory unless `design.md`
+  explicitly promotes a named property to an accepted requirement
+- Confirm no implementation will import or copy prototype code — prototypes
+  inform; `src/` code is written fresh under the architecture contracts
 - Record loading, empty, error, success, responsive, keyboard, focus, and
   reduced-motion states
 

--- a/agents/copilot/skills/ui/implementation-plan/SKILL.md
+++ b/agents/copilot/skills/ui/implementation-plan/SKILL.md
@@ -49,6 +49,8 @@ or business logic in Next.js server code.
 ### 5. View — Components
 - [ ] Build components bottom-up (leaf components first)
 - [ ] Wire to hooks — no direct API calls
+- [ ] No code imported or copied from `design/references/` prototypes —
+      references inform; implementation follows the architecture contracts
 - [ ] Write component tests (React Testing Library / Angular Testing Library)
 - [ ] Run axe accessibility check in each test
 

--- a/agents/copilot/skills/ui/spec-planning/SKILL.md
+++ b/agents/copilot/skills/ui/spec-planning/SKILL.md
@@ -67,9 +67,12 @@ For each Gherkin scenario tagged `@accessibility`: describe the WCAG criteria an
 ### 5.5 Visual Direction
 
 Map the approved brand and feature `design.md` to semantic tokens, component
-states, responsive behavior, and accessibility. List every screenshot/mockup
-reference with what may be learned from it. References remain advisory unless
-`design.md` promotes a named property to a requirement.
+states, responsive behavior, and accessibility. List every screenshot,
+mockup, and prototype reference with what may be learned from it. References
+remain advisory unless `design.md` promotes a named property to a
+requirement. Prototype code (for example an AI-generated HTML prototype in
+`design/references/`) is never imported, copied, or extended in `src/` —
+promoted behavior enters the plan through `design.md`.
 
 ### 6. Evaluation Compliance Summary
 

--- a/cli/calibrate.py
+++ b/cli/calibrate.py
@@ -281,9 +281,11 @@ def build_checklist(target: Path, marker: dict) -> list[CalibrationStep]:
             "user flows, accessibility thresholds, and opt-in visual regression."
         )
     elif is_ui_type(type_value):
-        testing_path = "docs/ui/evaluation/eval_criteria.md"
+        testing_path = f"{arch}/TESTING.md"
         testing_suggestion = (
-            "Confirm component, E2E, FIRST, and accessibility thresholds match team practice."
+            "Confirm test layers, component/E2E frameworks, and accessibility "
+            "thresholds match team practice. Evaluation thresholds live in "
+            "docs/ui/evaluation/eval_criteria.md."
         )
     elif type_value == "data":
         testing_path = f"{arch}/TESTING.md"

--- a/cli/doctor.py
+++ b/cli/doctor.py
@@ -1017,6 +1017,110 @@ def _check_skipped_service_packages(
     return findings
 
 
+# First table cell that names a file: `checkout-mockup.png`, login-flow.html.
+# Header cells ("File"), separators ("---"), and the "None yet" placeholder
+# carry no dot-extension and never match.
+_DESIGN_REFERENCE_FILENAME = re.compile(r"^[\w][\w.\- ]*\.[A-Za-z0-9]+$")
+
+
+def _design_reference_table_files(design_text: str) -> list[str]:
+    """Filenames documented in design.md's reference table rows.
+
+    Reads the first cell of every markdown table row, backticks stripped.
+    Both UI starters shape the table with the filename first; cells that
+    don't look like a filename are ignored rather than parsed strictly, so
+    a hand-edited table keeps working.
+    """
+    names: list[str] = []
+    for line in design_text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if not cells:
+            continue
+        first = cells[0].strip("`").strip()
+        if _DESIGN_REFERENCE_FILENAME.match(first):
+            names.append(first)
+    return names
+
+
+@_register_check("D020")
+def _check_design_reference_drift(
+    target: Path, marker: dict,
+) -> list[ValidationFinding]:
+    """D020 — design/references/ files and design.md's table drift apart.
+
+    The reference contract (feature design.md) says every retained file
+    under design/references/ gets a table row declaring what to learn from
+    it and its authority. Nothing enforced that: a mockup dropped into the
+    folder stays undocumented, and a documented file can be deleted leaving
+    a dangling row. Both directions are warnings — design.md is advisory to
+    `govkit validate` (a contract its tests pin), so doctor surfaces the
+    drift without failing anyone's CI.
+    """
+    features_dir = target / "features"
+    if not features_dir.is_dir():
+        return []
+    try:
+        feature_dirs = sorted(d for d in features_dir.iterdir() if d.is_dir())
+    except OSError:
+        return []
+
+    findings: list[ValidationFinding] = []
+    for feature in feature_dirs:
+        text = read_text_or_none(feature / "design.md")
+        if text is None:
+            continue
+        rel = f"features/{feature.name}"
+        refs_dir = feature / "design" / "references"
+        on_disk: list[str] = []
+        if refs_dir.is_dir():
+            try:
+                on_disk = sorted(
+                    p.name for p in refs_dir.iterdir()
+                    if p.is_file() and p.name != "README.md"
+                )
+            except OSError:
+                on_disk = []
+
+        for name in on_disk:
+            if name not in text:
+                findings.append(ValidationFinding(
+                    id="D020",
+                    severity="warning",
+                    category="design-reference-unlisted",
+                    file=f"{rel}/design/references/{name}",
+                    message=(
+                        f"{rel}/design/references/{name} is not documented "
+                        f"in {rel}/design.md"
+                    ),
+                    suggested_action=(
+                        f"add a row for {name} to the reference table in "
+                        f"{rel}/design.md (what to learn from it, what not "
+                        "to copy, authority) or delete the file"
+                    ),
+                ))
+
+        for name in _design_reference_table_files(text):
+            if not (refs_dir / name).is_file():
+                findings.append(ValidationFinding(
+                    id="D020",
+                    severity="warning",
+                    category="design-reference-missing",
+                    file=f"{rel}/design.md",
+                    message=(
+                        f"{rel}/design.md documents {name} but "
+                        f"{rel}/design/references/{name} does not exist"
+                    ),
+                    suggested_action=(
+                        f"restore {name} under {rel}/design/references/ or "
+                        "remove its table row from design.md"
+                    ),
+                ))
+    return findings
+
+
 # D002 (rule body mentions an absent folder name) is intentionally deferred.
 # The body of most rule files contains explanatory text that references
 # architecture concepts ("adapters implement outbound port contracts...")

--- a/docs/ui/architecture/README.md
+++ b/docs/ui/architecture/README.md
@@ -1,0 +1,42 @@
+# UI Architecture Docs — Layout and Intentional Asymmetry
+
+Repo-side documentation for govkit contributors. This file is **not**
+installed into target projects — the agent manifests' `governed` lists name
+their entries explicitly, and this README is deliberately not one of them.
+
+## Layout
+
+Shared docs at this level install for every UI project type:
+
+- `MVVM_CONTRACT.md` — layer model for React/Vite and Angular (§1–5) plus
+  the Next.js layer mapping (§6)
+- `ACCESSIBILITY_STANDARDS.md`
+- `NFRS_CONVENTIONS.md`
+- `ADR/TEMPLATE.md`
+
+Per-stack folders (`react/`, `angular/`, `nextjs/`) each ship the same core
+set, pinned by `tests/test_ui_stack_docs.py`:
+
+- `TECH_STACK.md`
+- `COMPONENT_CONVENTIONS.md`
+- `STATE_MANAGEMENT.md`
+- `STYLING.md`
+- `TESTING.md`
+
+## Why `nextjs/` ships more docs than `react/` and `angular/`
+
+Three additional docs are **intentionally nextjs-only** because they govern
+server-first App Router concerns that have no equivalent in a client-side
+SPA:
+
+- `APPLICATION_STRUCTURE.md` — App Router layout, route files, colocation.
+  For react/angular, the equivalent contract is `MVVM_CONTRACT.md` §3
+  (Feature Slice Structure); a separate doc would duplicate it.
+- `API_BOUNDARY.md` — Server Components, Server Actions, and thin-BFF route
+  handlers against the no-database boundary (doctor D016).
+- `SERVER_CLIENT_BOUNDARIES.md` — the server/client component split.
+
+Do not "fix" this asymmetry by copying these docs into `react/` or
+`angular/`. If a genuinely stack-agnostic concern emerges from one of them,
+promote it into a shared doc instead. Decision record:
+`plans/UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md`.

--- a/docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md
+++ b/docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md
@@ -231,7 +231,10 @@ setFilter(filter: string) {
 
 ## 9. Testing
 
-All components must be tested with **Vitest + Angular Testing Utilities**.
+All components must be tested with **Jest + Angular Testing Library**, per
+`TECH_STACK.md`. This section carries the component-test rules; the full
+test-layer contract (API boundary, queries/stores, journeys, visual
+comparisons) is `TESTING.md`.
 
 ### Requirements
 
@@ -244,7 +247,6 @@ All components must be tested with **Vitest + Angular Testing Utilities**.
 ### Example
 
 ```typescript
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { screen, render } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { UserProfileComponent } from './user-profile.component';
@@ -254,7 +256,7 @@ describe('UserProfileComponent', () => {
     // Arrange
     const profile = { id: '1', firstName: 'Alice', lastName: 'Smith' };
     // Mock the query function
-    vi.mocked(injectUserProfile).mockReturnValue({
+    jest.mocked(injectUserProfile).mockReturnValue({
       data: () => profile,
       isPending: () => false,
       isError: () => false,
@@ -269,14 +271,14 @@ describe('UserProfileComponent', () => {
     expect(screen.getByText('Alice Smith')).toBeInTheDocument();
 
     // Accessibility check
-    const { axe } = await import('vitest-axe');
+    const { axe } = await import('jest-axe');
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
 
   it('shows loading spinner while data fetches', async () => {
     // Mock pending state
-    vi.mocked(injectUserProfile).mockReturnValue({
+    jest.mocked(injectUserProfile).mockReturnValue({
       data: () => undefined,
       isPending: () => true,
       isError: () => false,

--- a/docs/ui/architecture/angular/STYLING.md
+++ b/docs/ui/architecture/angular/STYLING.md
@@ -1,0 +1,113 @@
+# Angular Styling and Brand Tokens
+
+Component-scoped styles implement the visual system recorded in
+`docs/ui/design/BRAND.md`. Brand values live only in that approved contract;
+this document defines the mechanism that applies them. Examples use semantic
+token names, never literal brand values. Angular carries no Tailwind
+mandate — utility frameworks are a per-project ADR decision.
+
+---
+
+## 1. Global Stylesheet
+
+The application has exactly one global stylesheet (`src/styles.css` or the
+Angular CLI equivalent). It may contain:
+
+- semantic theme variables (CSS custom properties on `:root` mapping
+  `BRAND.md` roles, including dark-theme redefinitions)
+- font-face declarations
+- narrowly scoped resets/base rules
+- global focus, selection, and reduced-motion primitives
+
+Feature-specific layouts and appearance do not accumulate in the global
+stylesheet.
+
+---
+
+## 2. Semantic Tokens
+
+Map `BRAND.md` decisions to semantic roles such as:
+
+- background/surface/elevated
+- foreground/muted
+- primary/secondary/accent
+- success/warning/danger/info
+- border/focus
+- spacing/density
+- radius
+- shadow
+- motion duration/easing
+
+Component styles consume roles through `var(--...)` custom properties, not
+isolated raw brand swatches. Light and dark themes preserve the same
+semantic meaning.
+
+---
+
+## 3. Component-Scoped Styles
+
+- Every component styles itself through its own stylesheet (`styleUrl`),
+  per `COMPONENT_CONVENTIONS.md`; default (emulated) view encapsulation
+  stays on.
+- Component styles reference semantic custom properties — no hard-coded
+  colors, font stacks, spacing values, or shadows that bypass the token
+  layer.
+- Do not pierce encapsulation: no `::ng-deep`, no global selectors targeting
+  another component's internals. Style a child through its documented
+  inputs, CSS custom properties, or `::part` where the child exposes parts.
+- No inline styles in templates for ordinary layout or brand styling.
+
+Inline styles are acceptable only for genuinely runtime-calculated values
+that cannot be represented safely through classes or CSS variables.
+
+---
+
+## 4. Responsive Design
+
+The feature design brief declares required viewports and layout behavior.
+Implement mobile/narrow behavior intentionally rather than shrinking a
+desktop mockup.
+
+Verify:
+
+- content reflow
+- touch target size
+- overflow and long text
+- navigation transformation
+- tables/charts at narrow widths
+- zoom to 200%
+
+---
+
+## 5. Accessibility
+
+- Normal text contrast: at least 4.5:1.
+- Large text and meaningful non-text UI contrast: at least 3:1 where the
+  standard permits.
+- Focus indicators are visible in every theme.
+- Color never acts as the only signal.
+- Motion respects reduced-motion preferences.
+- Forced-colors/high-contrast behavior is tested where the audience requires
+  it.
+
+---
+
+## 6. Assets and References
+
+Use optimized, licensed assets with documented ownership. Reference images in
+`features/<feature>/design/references/` guide implementation according to
+their declared authority; they do not override accessibility, security, or
+NFR contracts.
+
+---
+
+## 7. Component Libraries
+
+Introducing a component library (for example Angular Material) or a utility
+CSS framework requires an ADR covering:
+
+- accessibility maturity
+- styling/token integration with the `BRAND.md` semantic roles
+- theming and encapsulation fit
+- bundle impact
+- ownership and upgrade policy

--- a/docs/ui/architecture/angular/TECH_STACK.md
+++ b/docs/ui/architecture/angular/TECH_STACK.md
@@ -25,7 +25,18 @@ See `docs/ui/architecture/angular/STATE_MANAGEMENT.md` for usage rules.
 
 ---
 
-## 3. Testing
+## 3. Styling
+
+| Concern | Approach |
+|---|---|
+| Component styles | Component-scoped stylesheets (`styleUrl`), emulated encapsulation |
+| Design tokens | CSS custom properties mapping `docs/ui/design/BRAND.md` roles |
+
+No Tailwind mandate — utility frameworks are a per-project ADR decision. See `STYLING.md` for the styling contract.
+
+---
+
+## 4. Testing
 
 | Concern | Tool |
 |---|---|
@@ -36,7 +47,7 @@ See `docs/ui/architecture/angular/STATE_MANAGEMENT.md` for usage rules.
 
 ---
 
-## 4. Observability
+## 5. Observability
 
 | Concern | Tool |
 |---|---|
@@ -48,7 +59,7 @@ OpenTelemetry instrumentation lives in `src/shared/observability/`. Features mus
 
 ---
 
-## 5. HTTP
+## 6. HTTP
 
 | Concern | Tool |
 |---|---|
@@ -59,7 +70,7 @@ No raw `fetch` or `axios`. Use the shared `ApiService` in `src/shared/api/api.se
 
 ---
 
-## 6. Quality Gates (CI)
+## 7. Quality Gates (CI)
 
 | Gate | Tool |
 |---|---|
@@ -71,13 +82,14 @@ No raw `fetch` or `axios`. Use the shared `ApiService` in `src/shared/api/api.se
 
 ---
 
-## 7. Governance
+## 8. Governance
 
 | Concern | Location |
 |---|---|
 | Architecture contract | `docs/ui/architecture/MVVM_CONTRACT.md` |
 | Component conventions | `docs/ui/architecture/angular/COMPONENT_CONVENTIONS.md` |
 | State management rules | `docs/ui/architecture/angular/STATE_MANAGEMENT.md` |
+| Styling contract | `docs/ui/architecture/angular/STYLING.md` |
 | Evaluation criteria | `docs/ui/evaluation/eval_criteria.md` |
 | FIRST scoring rubric | `docs/ui/evaluation/FIRST_SCORING_RUBRIC.md` |
 | Virtue scoring rubric | `docs/ui/evaluation/VIRTUE_SCORING_RUBRIC.md` |

--- a/docs/ui/architecture/angular/TESTING.md
+++ b/docs/ui/architecture/angular/TESTING.md
@@ -1,0 +1,109 @@
+# Angular Testing
+
+Testing follows the MVVM layer boundaries and verifies user-visible behavior,
+API integration, accessibility, and architecture constraints. Tooling is
+declared in `TECH_STACK.md`; component-test rules live in
+`COMPONENT_CONVENTIONS.md`.
+
+---
+
+## 1. Test Layers
+
+| Layer | Primary approach |
+|---|---|
+| Pure functions/mappers | Jest unit tests |
+| API services (`api/`) | Jest + `HttpClientTestingModule` or MSW |
+| Query inject functions | Jest + Angular Testing Library with the HTTP boundary controlled |
+| Signal stores | Jest unit tests on named actions/computed signals |
+| Components (`components/`) | Jest + Angular Testing Library |
+| User journeys | Playwright |
+| Accessibility | jest-axe (component) + @axe-core/playwright (E2E), plus manual checks for critical interactions |
+| Approved visual states | Playwright screenshot comparison |
+
+---
+
+## 2. API Boundary Tests
+
+API-service tests cover:
+
+- request method/path/body/header mapping
+- authentication propagation through the shared `ApiService`
+- success mapping
+- validation and authorization failures
+- safe unexpected-error mapping
+- timeout/cancellation where relevant
+
+Mock at the HTTP boundary (`HttpClientTestingModule` or MSW). Do not mock the
+shared `ApiService` itself — its behavior is part of what these tests protect.
+
+---
+
+## 3. Query and Store Tests
+
+- Query-function tests exercise fetch/mutation behavior, transformations, and
+  error states with HTTP responses controlled at the boundary.
+- Signal-store tests call named actions and assert signal/computed values; no
+  component rendering required.
+- Server state stays in TanStack Query and client state in Signals — a test
+  needing both layers at once usually indicates a boundary violation.
+
+---
+
+## 4. Component Tests
+
+- Query by accessible role, label, or visible text.
+- Test behavior, not implementation details.
+- Cover keyboard interactions, including `OnPush` change-detection paths
+  driven through user events rather than manual `detectChanges` calls.
+- Run axe checks for rendered interactive components.
+- Avoid broad snapshots.
+
+See `COMPONENT_CONVENTIONS.md` §Testing for the binding component-test rules.
+
+---
+
+## 5. Playwright Journeys
+
+Every `@e2e` acceptance scenario maps to a Playwright test. Each critical flow
+uses production-like routing and API behavior and covers applicable loading,
+empty, error, success, unauthorized, and not-found states.
+
+Run an axe scan on each governed flow and attach useful diagnostics on failure.
+
+---
+
+## 6. Visual Comparisons
+
+Only approved screens/states become golden visual baselines. Tests declare:
+
+- route and state
+- viewport and browser project
+- theme
+- stabilized test data
+- masked volatile regions
+
+Generate and compare baselines in the same controlled CI environment. Snapshot
+updates require review.
+
+---
+
+## 7. Architecture Checks
+
+CI verifies:
+
+- MVVM boundary rules (no `HttpClient` calls in components, no cross-feature
+  imports, no `shared/` → `features/` imports)
+- type checking
+- linting separately from the production build
+
+---
+
+## 8. Manual Verification
+
+For significant UI changes, record:
+
+- keyboard-only walkthrough
+- screen-reader check of the primary flow
+- 200% zoom/reflow
+- responsive viewports from `design.md`
+- light/dark/high-contrast behavior where applicable

--- a/docs/ui/architecture/react/COMPONENT_CONVENTIONS.md
+++ b/docs/ui/architecture/react/COMPONENT_CONVENTIONS.md
@@ -17,11 +17,10 @@ Live in `src/shared/components/`. Truly generic UI primitives (Button, Input, Mo
 ```
 MyComponent/
 ├── MyComponent.tsx         # Component implementation
-├── MyComponent.test.tsx    # Component tests
-└── MyComponent.module.css  # Styles (if using CSS modules)
+└── MyComponent.test.tsx    # Component tests
 ```
 
-One component per file. Index barrel files are permitted at the feature components level only.
+One component per file. Index barrel files are permitted at the feature components level only. Components style themselves with Tailwind utility classes — no per-component stylesheet files. See `STYLING.md`.
 
 ---
 
@@ -68,7 +67,6 @@ Use React Hook Form. Never manage form state with `useState` per field.
 - Hooks: camelCase prefixed with `use` (`useUserProfile`)
 - Stores: camelCase prefixed with `use` (`useFilterStore`)
 - API functions: camelCase verb + resource (`fetchUserProfile`, `updateUserProfile`)
-- CSS module classes: camelCase (`styles.profileCard`)
 
 ---
 
@@ -77,7 +75,7 @@ Use React Hook Form. Never manage form state with `useState` per field.
 - `any` type — use `unknown` and narrow, or define a proper type
 - `useEffect` for data fetching — use React Query
 - Direct DOM manipulation — use refs only when no React alternative exists
-- Inline styles for layout — use CSS modules or a design token system
+- Inline styles for layout or brand styling — use Tailwind utilities and the semantic tokens in `STYLING.md`
 - Business logic in JSX — extract to a function or hook
 
 ---

--- a/docs/ui/architecture/react/COMPONENT_CONVENTIONS.md
+++ b/docs/ui/architecture/react/COMPONENT_CONVENTIONS.md
@@ -183,7 +183,10 @@ const useFilterStore = create((set) => ({
 
 ## 8. Testing
 
-All components must be tested with **Vitest + React Testing Library**.
+All components must be tested with **Vitest + React Testing Library**, per
+`TECH_STACK.md`. This section carries the component-test rules; the full
+test-layer contract (API boundary, hooks/stores, journeys, visual
+comparisons) is `TESTING.md`.
 
 ### Requirements
 

--- a/docs/ui/architecture/react/STYLING.md
+++ b/docs/ui/architecture/react/STYLING.md
@@ -1,0 +1,110 @@
+# React Styling and Brand Tokens
+
+Tailwind CSS implements the visual system recorded in
+`docs/ui/design/BRAND.md`. Brand values live only in that approved contract;
+this document defines the mechanism that applies them. Examples use semantic
+token names, never literal brand values.
+
+---
+
+## 1. Global Stylesheet
+
+The application has exactly one global stylesheet (the Vite CSS entry). It
+may contain:
+
+- Tailwind directives (`@tailwind base/components/utilities`)
+- semantic theme variables (CSS custom properties mapping `BRAND.md` roles)
+- font-face declarations
+- narrowly scoped resets/base rules
+- global focus, selection, and reduced-motion primitives
+
+Feature-specific layouts and appearance do not accumulate in the global
+stylesheet.
+
+---
+
+## 2. Semantic Tokens
+
+Map `BRAND.md` decisions to semantic roles such as:
+
+- background/surface/elevated
+- foreground/muted
+- primary/secondary/accent
+- success/warning/danger/info
+- border/focus
+- spacing/density
+- radius
+- shadow
+- motion duration/easing
+
+Expose roles as CSS custom properties and reference them from the Tailwind
+theme configuration so utilities stay semantic. Components consume roles,
+not isolated raw brand swatches. Light and dark themes preserve the same
+semantic meaning.
+
+---
+
+## 3. Tailwind Usage
+
+- Prefer standard or semantic utilities.
+- Use `clsx` + `tailwind-merge` for conditional class composition.
+- Keep variant definitions close to reusable components.
+- Avoid string-building that prevents Tailwind from detecting classes.
+- Avoid arbitrary values when a semantic token exists.
+- Do not use inline styles for ordinary layout or brand styling.
+- Do not create per-component stylesheet files; components style through
+  utility classes.
+
+Inline styles are acceptable only for genuinely runtime-calculated values
+that cannot be represented safely through classes or CSS variables.
+
+---
+
+## 4. Responsive Design
+
+The feature design brief declares required viewports and layout behavior.
+Implement mobile/narrow behavior intentionally rather than shrinking a
+desktop mockup.
+
+Verify:
+
+- content reflow
+- touch target size
+- overflow and long text
+- navigation transformation
+- tables/charts at narrow widths
+- zoom to 200%
+
+---
+
+## 5. Accessibility
+
+- Normal text contrast: at least 4.5:1.
+- Large text and meaningful non-text UI contrast: at least 3:1 where the
+  standard permits.
+- Focus indicators are visible in every theme.
+- Color never acts as the only signal.
+- Motion respects reduced-motion preferences.
+- Forced-colors/high-contrast behavior is tested where the audience requires
+  it.
+
+---
+
+## 6. Assets and References
+
+Use optimized, licensed assets with documented ownership. Reference images in
+`features/<feature>/design/references/` guide implementation according to
+their declared authority; they do not override accessibility, security, or
+NFR contracts.
+
+---
+
+## 7. Component Libraries
+
+Tailwind CSS does not imply a component library. Introducing one requires an
+ADR covering:
+
+- accessibility maturity
+- styling/token integration
+- bundle impact
+- ownership and upgrade policy

--- a/docs/ui/architecture/react/TECH_STACK.md
+++ b/docs/ui/architecture/react/TECH_STACK.md
@@ -20,7 +20,7 @@
 | CSS framework | Tailwind CSS | 3+ |
 | Component variants | `clsx` + `tailwind-merge` | latest |
 
-No custom global stylesheets. All styles via Tailwind utility classes. Use `clsx`/`twMerge` for conditional class composition in components.
+All component styling via Tailwind utility classes; the single global entry stylesheet is constrained to the roles listed in `STYLING.md`. Use `clsx`/`twMerge` for conditional class composition in components. Brand values come from `docs/ui/design/BRAND.md` semantic tokens — see `STYLING.md`.
 
 ---
 
@@ -88,8 +88,9 @@ No Axios. Use the shared base client in `src/shared/api/client.ts`.
 | Concern | Location |
 |---|---|
 | Architecture contract | `docs/ui/architecture/MVVM_CONTRACT.md` |
-| Component conventions | `docs/ui/architecture/COMPONENT_CONVENTIONS.md` |
-| State management rules | `docs/ui/architecture/STATE_MANAGEMENT.md` |
+| Component conventions | `docs/ui/architecture/react/COMPONENT_CONVENTIONS.md` |
+| State management rules | `docs/ui/architecture/react/STATE_MANAGEMENT.md` |
+| Styling contract | `docs/ui/architecture/react/STYLING.md` |
 | Evaluation criteria | `docs/ui/evaluation/eval_criteria.md` |
 | FIRST scoring rubric | `docs/ui/evaluation/FIRST_SCORING_RUBRIC.md` |
 | Virtue scoring rubric | `docs/ui/evaluation/VIRTUE_SCORING_RUBRIC.md` |

--- a/docs/ui/architecture/react/TESTING.md
+++ b/docs/ui/architecture/react/TESTING.md
@@ -1,0 +1,109 @@
+# React Testing
+
+Testing follows the MVVM layer boundaries and verifies user-visible behavior,
+API integration, accessibility, and architecture constraints. Tooling is
+declared in `TECH_STACK.md`; component-test rules and worked examples live in
+`COMPONENT_CONVENTIONS.md`.
+
+---
+
+## 1. Test Layers
+
+| Layer | Primary approach |
+|---|---|
+| Pure functions/mappers | Vitest unit tests |
+| API functions (`api/`) | Vitest + MSW with the transport boundary controlled |
+| Hooks (`hooks/`) | Vitest `renderHook` + MSW |
+| Stores (`store/`) | Vitest unit tests on named actions |
+| Components (`components/`) | Vitest + React Testing Library |
+| User journeys | Playwright |
+| Accessibility | jest-axe (component) + @axe-core/playwright (E2E), plus manual checks for critical interactions |
+| Approved visual states | Playwright screenshot comparison |
+
+---
+
+## 2. API Boundary Tests
+
+API-function tests cover:
+
+- request method/path/body/header mapping
+- authentication propagation through the shared base client
+- success mapping
+- validation and authorization failures
+- safe unexpected-error mapping
+- timeout/cancellation where relevant
+
+Mock at the HTTP boundary with MSW. Do not mock the shared base client
+itself — its behavior is part of what these tests protect.
+
+---
+
+## 3. Hook and Store Tests
+
+- Hook tests exercise query/mutation behavior, `select` transformations, and
+  error states through `renderHook` with MSW-controlled responses.
+- Store tests call named actions and assert resulting state; no component
+  rendering required.
+- Server state stays in React Query and client state in Zustand — a test
+  needing both layers at once usually indicates a boundary violation.
+
+---
+
+## 4. Component Tests
+
+- Query by accessible role, label, or visible text.
+- Test behavior, not implementation details.
+- Cover keyboard interactions.
+- Run axe checks for rendered interactive components.
+- Avoid broad snapshots.
+
+See `COMPONENT_CONVENTIONS.md` §Testing for the binding component-test rules
+and a worked example.
+
+---
+
+## 5. Playwright Journeys
+
+Every `@e2e` acceptance scenario maps to a Playwright test. Each critical flow
+uses production-like routing and API behavior and covers applicable loading,
+empty, error, success, unauthorized, and not-found states.
+
+Run an axe scan on each governed flow and attach useful diagnostics on failure.
+
+---
+
+## 6. Visual Comparisons
+
+Only approved screens/states become golden visual baselines. Tests declare:
+
+- route and state
+- viewport and browser project
+- theme
+- stabilized test data
+- masked volatile regions
+
+Generate and compare baselines in the same controlled CI environment. Snapshot
+updates require review.
+
+---
+
+## 7. Architecture Checks
+
+CI verifies:
+
+- MVVM boundary rules (no API calls in components, no cross-feature imports,
+  no `shared/` → `features/` imports)
+- type checking
+- linting separately from the production build
+
+---
+
+## 8. Manual Verification
+
+For significant UI changes, record:
+
+- keyboard-only walkthrough
+- screen-reader check of the primary flow
+- 200% zoom/reflow
+- responsive viewports from `design.md`
+- light/dark/high-contrast behavior where applicable

--- a/docs/ui/design/BRAND.md
+++ b/docs/ui/design/BRAND.md
@@ -7,6 +7,16 @@ change the visual language of the application. Replace every `TBD` that affects
 the feature being built. This file defines project-wide visual intent; each
 feature's `design.md` defines its local application.
 
+## Brand Sources
+
+List the external brand guides, design systems, or style documents used to
+complete this contract, by repository-relative path or URL. Brand sources are
+advisory inputs — the completed sections below are what bind.
+
+| Source | Location | Notes |
+|---|---|---|
+| TBD | TBD | TBD |
+
 ## Brand Character
 
 - Product or service name: TBD

--- a/features/starter_ui/design.md
+++ b/features/starter_ui/design.md
@@ -38,9 +38,12 @@ Describe how `docs/ui/design/BRAND.md` applies to this feature:
 - Shape, depth, and icon treatment:
 - Motion and reduced-motion behavior:
 
-## Reference Images and Mockups
+## Reference Images, Mockups, and Prototypes
 
 Store feature references in `design/references/` and list them here.
+References include static images (screenshots, sketches, wireframes,
+mockups) and interactive prototypes — for example an AI-generated HTML
+prototype or a design-tool export.
 
 | File | What to learn from it | What not to copy | Authority |
 |---|---|---|---|
@@ -49,6 +52,10 @@ Store feature references in `design/references/` and list them here.
 References are advisory unless a specific property is promoted here to an
 accepted requirement. They never override accessibility, security, accepted
 behavior, API contracts, or the approved brand contract.
+
+Prototype code is reference material only. It is never imported, copied, or
+extended in `src/`; behavior a prototype demonstrates transfers only by
+promotion here and then into `acceptance.feature` and `plan.md`.
 
 ## Component and Content Notes
 

--- a/features/starter_ui/design/references/README.md
+++ b/features/starter_ui/design/references/README.md
@@ -1,10 +1,14 @@
 # Design References
 
-Place screenshots, sketches, wireframes, or mockups for this feature here.
-Use descriptive names and document every retained file in the parent
-`design.md`.
+Place screenshots, sketches, wireframes, mockups, or interactive prototypes
+(for example an AI-generated HTML prototype or a design-tool export) for
+this feature here. Use descriptive names and document every retained file in
+the parent `design.md`.
 
 These files are advisory by default. They do not override accessibility,
 security, accepted behavior, API contracts, or `docs/ui/design/BRAND.md`.
 Promote a specific visual property to a requirement only by naming it
 explicitly in `design.md`.
+
+Prototype code is reference material only — it is never imported, copied, or
+extended in `src/`.

--- a/features/starter_ui_nextjs/design.md
+++ b/features/starter_ui_nextjs/design.md
@@ -35,13 +35,19 @@ Apply `docs/ui/design/BRAND.md` explicitly:
 
 ## References
 
+Images (screenshots, sketches, wireframes, mockups) and interactive
+prototypes — for example an AI-generated HTML prototype or a design-tool
+export — both belong in `design/references/`.
+
 | File in `design/references/` | Learn from | Do not copy | Authority |
 |---|---|---|---|
 | None yet | | | Advisory |
 
 References are advisory unless this document promotes a named property to an
 accepted requirement. They never override accessibility, security, behavior,
-API contracts, or the brand contract.
+API contracts, or the brand contract. Prototype code is reference material
+only — it is never imported, copied, or extended in `src/`; promoted behavior
+transfers through `acceptance.feature` and `plan.md`.
 
 ## Design Acceptance
 

--- a/features/starter_ui_nextjs/design/references/README.md
+++ b/features/starter_ui_nextjs/design/references/README.md
@@ -1,7 +1,11 @@
 # Design References
 
-Place feature screenshots, sketches, wireframes, and mockups here. Document
-each file and its intended lesson in the parent `design.md`.
+Place feature screenshots, sketches, wireframes, mockups, and interactive
+prototypes (for example an AI-generated HTML prototype or a design-tool
+export) here. Document each file and its intended lesson in the parent
+`design.md`.
 
 References are advisory by default and cannot override accessibility,
 security, accepted behavior, backend API contracts, or the project brand.
+Prototype code is reference material only — it is never imported, copied, or
+extended in `src/`.

--- a/plans/UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md
+++ b/plans/UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md
@@ -1,0 +1,252 @@
+# UI Docs Parity and Design References Plan
+
+> **Status:** Approved source of truth
+> **Approved:** 2026-08-11
+> **Implementation status:** Not started
+> **Scope:** Make each per-stack UI architecture doc set (`react`, `angular`,
+> `nextjs`) individually fully functional, and extend the feature design
+> reference contract to cover interactive prototypes (including
+> Claude-generated design files), without changing the advisory status of
+> `design.md`.
+
+---
+
+## 1. Purpose
+
+Two observations triggered this plan:
+
+1. `docs/ui/architecture/nextjs/` ships 8 documents while `react/` and
+   `angular/` ship 3 each. Some of that asymmetry is intentional
+   (server-first concerns), some of it is a real gap (styling and testing).
+2. The UI skills read `features/<feature>/design.md` and inventory
+   `features/<feature>/design/references/`, but the reference contract is
+   image-centric (screenshots, sketches, wireframes, mockups). There is no
+   convention for interactive prototypes — e.g. an HTML prototype generated
+   by Claude, or an exported design-tool file.
+
+This document is the implementation source of truth once approved. If
+implementation reveals a material decision that conflicts with this plan,
+update and re-approve this document before proceeding.
+
+---
+
+## 2. Current State (verified)
+
+### 2.1 Doc inventory
+
+Shared, installed for every UI type (`governed` list in all three agent
+manifests): `MVVM_CONTRACT.md` (including §6 Next.js Layer Mapping),
+`ACCESSIBILITY_STANDARDS.md`, `NFRS_CONVENTIONS.md`, `ADR/TEMPLATE.md`,
+`docs/ui/design/BRAND.md`, plus `docs/ui/evaluation/` at L4+.
+
+| Document | react | angular | nextjs |
+|---|---|---|---|
+| TECH_STACK.md | yes | yes | yes |
+| COMPONENT_CONVENTIONS.md | yes | yes | yes |
+| STATE_MANAGEMENT.md | yes | yes | yes |
+| STYLING.md | — | — | yes |
+| TESTING.md | — | — | yes |
+| APPLICATION_STRUCTURE.md | — | — | yes |
+| API_BOUNDARY.md | — | — | yes |
+| SERVER_CLIENT_BOUNDARIES.md | — | — | yes |
+
+Manifests install per-stack docs by directory
+(`docs/ui/architecture/react/` etc.), so new files in these folders ship
+automatically with no manifest change. The per-type rules files
+(`claude-md/ui-react.md`, `copilot-instructions/ui-react.md`,
+`agents-md/ui-react.md`, and the l4/l5/src variants) list the per-stack docs
+**by name** and must be updated in lockstep across all three agents.
+
+### 2.2 Intentional vs. gap
+
+Intentionally nextjs-only (do **not** replicate):
+
+- `API_BOUNDARY.md`, `SERVER_CLIENT_BOUNDARIES.md` — server-first App Router
+  concerns with no react/vite or angular equivalent.
+- `APPLICATION_STRUCTURE.md` — App Router layout. For react/angular the
+  equivalent contract already exists as `MVVM_CONTRACT.md` §3 Feature Slice
+  Structure.
+
+Real gaps:
+
+- **Styling.** Angular has no styling guidance anywhere (its TECH_STACK has
+  no styling section). React is self-contradictory:
+  `react/TECH_STACK.md` §2 mandates Tailwind-only ("No custom global
+  stylesheets"), while `react/COMPONENT_CONVENTIONS.md` §2 shows
+  `MyComponent.module.css`, §5 names CSS-module class conventions, and §6
+  says "use CSS modules or a design token system." Neither stack maps
+  `docs/ui/design/BRAND.md` tokens to implementation the way
+  `nextjs/STYLING.md` does.
+- **Testing.** React/angular testing guidance is scattered across
+  TECH_STACK §Testing (tool table) and COMPONENT_CONVENTIONS §Testing
+  (component-test rules). Next.js has a dedicated `TESTING.md` covering test
+  layers, API-boundary tests, journeys, and visual comparisons. Backend
+  stacks also ship a dedicated `TESTING.md` (one of the 6 overlay docs), so
+  a per-stack TESTING.md is the established pattern.
+
+### 2.3 Design references and skills (verified behavior)
+
+- `govkit init` for a UI starter scaffolds `design.md` **and**
+  `design/references/README.md` (starter copy is recursive).
+- All three UI skills read `features/<feature>/design.md`;
+  `ui/architecture-preflight` explicitly inventories
+  `features/<feature>/design/references/`; `ui/spec-planning` §5.5 requires
+  listing "every screenshot/mockup reference."
+- References are **advisory** unless `design.md` promotes a named property
+  to a requirement. `govkit validate` does not gate `design.md` —
+  `tests/test_validate.py::test_ui_nextjs_design_artifact_is_advisory_to_completeness`
+  locks this in. This plan does not change that contract.
+- The references README names only static artifacts: "screenshots, sketches,
+  wireframes, or mockups."
+
+---
+
+## 3. Decisions
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| D1 | Parity approach | Targeted gap-fill, not 8-file structural parity | 3 of the 5 nextjs-only docs are server-first concerns; copying them would manufacture artificial parity and contradict the standalone-type design in `UI_NEXTJS_STANDALONE_PLAN.md` |
+| D2 | React styling source of truth | Tailwind (per TECH_STACK) — **approved** | TECH_STACK declares the stack; the CSS-module mentions in COMPONENT_CONVENTIONS predate it and are the stale side of the contradiction. Aligns react with nextjs brand-token practice |
+| D3 | Prototype storage | Keep a single `design/references/` folder; prototypes are another reference kind | Avoids changing the skills' inventory contract and the starter layout; the `design.md` table's Authority column already carries the semantics |
+| D4 | Prototype authority | Advisory by default, same as images; promotion only via `design.md`; prototype **code is never imported, copied, or extended in `src/`** | Prototypes (including Claude-generated HTML) are throwaway design communication. Without an explicit rule, an agent will treat runnable HTML as implementation reference |
+| D5 | `design.md` gating | Unchanged (advisory to validate) | Test-locked contract; enforcement pressure comes from skills and the doctor advisory check (Increment 5) |
+| D6 | Angular styling posture | Component-scoped styles + BRAND tokens via CSS custom properties; no Tailwind mandate — **approved** | Matches Angular idiom; Tailwind is a react/nextjs stack choice, not a UI-wide one |
+| D7 | External brand guides | An external brand guide is a **source input to `BRAND.md`**, never to STYLING.md. STYLING.md carries mechanism only (how tokens are wired per stack), never brand values | `BRAND.md` is the `govkit:editable` project-wide brand contract with a defined authority order; duplicating values into STYLING.md would create a second, ungoverned source of truth |
+
+---
+
+## 4. Increments
+
+Each increment is independently shippable and follows test-first: add or
+update the failing payload-consistency/parity tests, then make them pass.
+Ruff runs scoped to changed files only.
+
+### Increment 1 — STYLING.md for react and angular; resolve the react contradiction
+
+- Add `docs/ui/architecture/react/STYLING.md`: Tailwind + `clsx`/`tailwind-merge`
+  usage, BRAND.md token mapping (CSS custom properties → Tailwind theme),
+  dark-mode/reduced-motion posture, what is forbidden (inline layout styles,
+  ad-hoc hex values outside the token layer).
+- Add `docs/ui/architecture/angular/STYLING.md`: component-scoped styles,
+  BRAND.md token mapping via CSS custom properties, same forbidden list
+  adapted to Angular.
+- Fix `react/COMPONENT_CONVENTIONS.md` §2/§5/§6 to match D2 (remove
+  CSS-module file-structure entry and naming rule; point at STYLING.md).
+- Both STYLING.md docs state D7 explicitly: `docs/ui/design/BRAND.md` is the
+  single source of brand values; STYLING.md examples use semantic token
+  names, never literal brand values.
+- Add a short "Brand sources" line to the `BRAND.md` template intro: when an
+  external brand guide exists, record its location (repo-relative path or
+  URL) so agents and reviewers can trace where the completed values came
+  from. The external document itself stays advisory — the completed
+  `BRAND.md` is what binds, per its existing Reference Authority order.
+- Update every rules file that lists the per-stack docs by name, in lockstep
+  across `agents/claude-code`, `agents/codex`, `agents/copilot`
+  (`ui-react.md`, `ui-angular.md`, their `l4-`/`l5-`/`src-` variants, and
+  copilot `instructions/` where applicable).
+- Tests: extend the payload tests that pin per-stack doc inventories and
+  rules-file doc lists; `pytest -k parity`.
+
+### Increment 2 — TESTING.md for react and angular
+
+- Add `docs/ui/architecture/react/TESTING.md` and
+  `docs/ui/architecture/angular/TESTING.md`, structured like
+  `nextjs/TESTING.md` (test layers table, API-boundary tests at the HTTP
+  adapter, component-test rules, Playwright journeys mapped from `@e2e`
+  scenarios, axe integration, visual comparisons) with content sourced from
+  the existing TECH_STACK §Testing and COMPONENT_CONVENTIONS §Testing
+  sections. Tooling stays exactly what each TECH_STACK already declares.
+- Slim COMPONENT_CONVENTIONS §Testing to component-specific rules plus a
+  pointer to TESTING.md (no duplicated normative text).
+- Update the same rules-file doc lists as Increment 1, all three agents.
+- Tests: same suites as Increment 1.
+
+### Increment 3 — record the intentional asymmetry
+
+- Add a repo-side `docs/ui/architecture/README.md` (not installed — the
+  manifests' `governed` lists name entries explicitly) stating: which docs
+  are shared, which are per-stack, why `API_BOUNDARY.md`,
+  `SERVER_CLIENT_BOUNDARIES.md`, and `APPLICATION_STRUCTURE.md` are
+  nextjs-only, and that react/angular application structure lives in
+  `MVVM_CONTRACT.md` §3. Add a matching note to `CLAUDE.md`'s payload
+  section so a future "parity" pass doesn't re-open this.
+- Tests: a payload test asserting the README is **not** in any manifest
+  `governed`/`files` entry (guards against accidental install).
+
+### Increment 4 — prototypes and Claude-generated design files in the reference contract
+
+- Update the `design.md` template's "Reference Images and Mockups" section
+  in **both** `features/starter_ui/` and `features/starter_ui_nextjs/`:
+  rename to "Reference Images, Mockups, and Prototypes"; note that the table
+  covers interactive prototypes; add the D4 rule verbatim: references are
+  advisory, and prototype code is never imported, copied, or extended in
+  `src/` — behavior transfers only by promotion in `design.md` and then into
+  `acceptance.feature`/`plan.md`.
+- Update `design/references/README.md` in both starters: accepted kinds now
+  include interactive HTML prototypes (e.g. generated by Claude or another
+  AI tool) and design-tool exports; require descriptive filenames and a
+  `design.md` table row per retained file; restate advisory-by-default and
+  the no-code-reuse rule.
+- Update the three UI skills — `spec-planning` (§5.5 "every
+  screenshot/mockup/prototype reference"), `architecture-preflight`
+  (inventory step names prototypes; advisory wording covers them),
+  `implementation-plan` (checklist wording) — **byte-identical frontmatter,
+  lockstep bodies across all three agents** (9 SKILL.md files).
+- Tests: extend `tests/test_agent_skills.py` (currently asserts `design.md`
+  appears in skill text) to assert the prototype wording; add a fixture test
+  that the two starters' `design.md` sections and references READMEs stay
+  consistent with each other; `pytest -k parity`.
+
+### Increment 5 — doctor advisory check (approved in scope)
+
+- New doctor check (WARN, never FAIL, preserving D5): for each UI feature,
+  flag files present under `features/<feature>/design/references/` that are
+  not listed in `design.md`'s reference table, and table rows whose file
+  does not exist. A real filesystem-vs-content comparison, not a text
+  assertion.
+- TDD in `tests/test_doctor.py`; respects the existing finding/severity
+  model and `govkit doctor` output format.
+
+---
+
+## 5. Explicit non-goals
+
+- No change to `validate`'s 5-artifact completeness contract or design.md's
+  advisory status.
+- No `APPLICATION_STRUCTURE.md`, `API_BOUNDARY.md`, or
+  `SERVER_CLIENT_BOUNDARIES.md` for react/angular.
+- No new folder layout under `features/<feature>/design/`.
+- No integration with any specific design tool's file format; the contract
+  is tool-agnostic (a "Claude Design" HTML export is just a reference file).
+
+---
+
+## 6. Acceptance criteria
+
+1. `react/` and `angular/` each ship `STYLING.md` and `TESTING.md`; the
+   react styling contradiction is gone (single source of truth per D2).
+2. All rules files listing per-stack docs name the new files, identically
+   across the three agents; `pytest -k parity` passes.
+3. Both UI starters' `design.md` and `design/references/README.md` name
+   prototypes, carry the no-code-reuse rule, and stay mutually consistent.
+4. All three UI skills mention prototype references; SKILL.md frontmatter
+   remains byte-identical across agents.
+5. Full suite (`pytest`) green; `./full_test` green; wheel-smoke unaffected
+   (no new top-level asset dirs, so no `force-include` change needed).
+
+---
+
+## 7. Approval record
+
+All three open questions were answered 2026-08-11:
+
+1. **D2** — approved: Tailwind is the react styling source of truth; the
+   CSS-module mentions in COMPONENT_CONVENTIONS are removed.
+2. **Increment 5** — approved in scope: the doctor advisory check ships as
+   part of this plan.
+3. **D6** — approved: Angular uses component-scoped styles with BRAND
+   tokens; no Tailwind mandate for Angular.
+
+A follow-up question about external brand guides was resolved as **D7**:
+brand guides feed `BRAND.md`, not STYLING.md, and Increment 1 adds the
+"Brand sources" traceability line to the `BRAND.md` template.

--- a/plans/UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md
+++ b/plans/UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md
@@ -2,12 +2,49 @@
 
 > **Status:** Approved source of truth
 > **Approved:** 2026-08-11
-> **Implementation status:** Not started
+> **Implementation status:** Complete (2026-08-11, branch
+> `feat/ui-docs-parity-design-references`)
 > **Scope:** Make each per-stack UI architecture doc set (`react`, `angular`,
 > `nextjs`) individually fully functional, and extend the feature design
 > reference contract to cover interactive prototypes (including
 > Claude-generated design files), without changing the advisory status of
 > `design.md`.
+
+---
+
+## Implementation Record
+
+All five increments implemented test-first, one commit each:
+
+1. `feat(payload): ship STYLING.md for react and angular UI stacks` — also
+   fixed react TECH_STACK's stale governance paths discovered en route.
+2. `feat(payload): ship TESTING.md for react and angular UI stacks` — also
+   fixed angular COMPONENT_CONVENTIONS naming Vitest/`vi.mocked`/vitest-axe
+   against TECH_STACK's declared Jest stack (same read-order contradiction
+   class as react's CSS modules), and pointed calibrate's `step.testing` at
+   the per-stack TESTING.md for all UI types.
+3. `docs(payload): record the intentional nextjs docs asymmetry`.
+4. `feat(payload): cover interactive prototypes in the design reference
+   contract` — the two starters keep their intentionally different design.md
+   shapes, so the consistency tests are semantic (both carry the prototype
+   wording and the D4 rule), not byte identity.
+5. `feat(doctor): warn when design references and design.md drift (D020)`.
+
+Anti-drift tests live in `tests/test_ui_stack_docs.py` plus additions to
+`tests/test_calibrate.py`, `tests/test_agent_skills.py`, and
+`tests/test_doctor.py`. Verification: fast loop 2280 passed; e2e tier 134
+passed (16 environment skips: JDK-dependent ArchUnit tests); `pytest -k
+parity` green; skill bodies byte-identical across agents.
+
+Deviation from §4 as written: the instruction-file doc lists are asserted
+as "reachable" (explicit path or a directory-wide "read all files under
+docs/ui/architecture/" instruction) because the copilot L4 and all L5
+instruction files use the directory-wide form and need no per-file edits.
+
+Observation recorded for a future pass (out of scope here):
+`features/ui_task_dashboard/` — a shared worked example for ui-react and
+ui-angular at L4 — ships no `design.md` while both starters and the skills
+treat it as the sixth UI artifact.
 
 ---
 

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -196,6 +196,22 @@ def test_ui_skills_enforce_nextjs_boundary_and_design(skill_path: Path):
 
 
 @pytest.mark.parametrize(
+    "skill_path",
+    [p for p in UI_SKILLS if p.parent.name != "adr-author"],
+    ids=lambda p: f"{p.parents[3].name}/{p.parent.name}",
+)
+def test_ui_skills_cover_prototype_references(skill_path: Path):
+    """UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md increment 4: the
+    planning skills inventory prototypes (including AI-generated HTML
+    prototypes) alongside screenshots/mockups, as advisory references
+    whose code is never imported into src/."""
+    text = skill_path.read_text(encoding="utf-8")
+    assert "prototype" in text.lower(), (
+        f"{skill_path.parent.name} must cover prototype references"
+    )
+
+
+@pytest.mark.parametrize(
     "skill", ("adr-author", "architecture-preflight", "spec-planning", "implementation-plan"),
 )
 def test_ui_nextjs_skill_content_parity(skill: str):

--- a/tests/test_calibrate.py
+++ b/tests/test_calibrate.py
@@ -125,6 +125,18 @@ class TestBuildChecklist:
         assert "docs/ui/design/BRAND.md" in paths
         assert len(steps) == 10
 
+    @pytest.mark.parametrize("ui_type,stack", [("ui-react", "react"), ("ui-angular", "angular")])
+    def test_ui_testing_step_targets_per_stack_testing_doc(self, tmp_path, ui_type, stack):
+        """react/angular ship a per-stack TESTING.md (plan increment 2), so
+        the testing step calibrates that doc — not the evaluation criteria
+        it pointed at when no per-stack testing doc existed."""
+        from cli.calibrate import build_checklist
+
+        marker = _write_marker(tmp_path, options={"type": ui_type, "ci": "github"}, stack=None)
+        steps = build_checklist(tmp_path, marker)
+        testing = next(s for s in steps if s.id == "step.testing")
+        assert testing.file_path == f"docs/ui/architecture/{stack}/TESTING.md"
+
     def test_no_internal_pr_references_in_user_facing_text(self, tmp_path):
         """Calibration steps are user-facing; they must not leak internal
         roadmap/PR references (e.g. "PR 5+", "PR 6a wires the consumers")."""

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1291,10 +1291,120 @@ class TestD018StalePathScopedRules:
         assert "src/orders" in text or "src/billing" in text
 
     def test_silent_on_a_clean_multi_service_install(self, tmp_path):
-        from cli.doctor import run_doctor
 
         _multi_service_repo(tmp_path)
         _write_marker(tmp_path, agent="codex")
+
+
+# ---------------------------------------------------------------------------
+# D020 — design references drift (UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN
+# increment 5)
+# ---------------------------------------------------------------------------
+
+
+def _ui_feature_with_design(target: Path, name: str = "dashboard",
+                            design_body: str | None = None) -> Path:
+    """A UI feature dir holding a design.md and a design/references/ folder."""
+    feature = target / "features" / name
+    refs = feature / "design" / "references"
+    refs.mkdir(parents=True)
+    (refs / "README.md").write_text("# Design References\n", encoding="utf-8")
+    if design_body is None:
+        design_body = (
+            "# Feature Design\n\n"
+            "## Reference Images, Mockups, and Prototypes\n\n"
+            "| File | What to learn from it | What not to copy | Authority |\n"
+            "|---|---|---|---|\n"
+            "| None yet | | | Advisory |\n"
+        )
+    (feature / "design.md").write_text(design_body, encoding="utf-8")
+    return feature
+
+
+class TestD020DesignReferenceDrift:
+    """design.md's reference table and the files in design/references/ drift
+    silently: a dropped-in mockup nobody documented, or a documented file
+    someone deleted. D020 surfaces both as warnings — design.md stays
+    advisory to validate (test_validate.py pins that), so doctor never
+    errors on it."""
+
+    def _marker(self, target: Path) -> None:
+        _write_marker(
+            target,
+            options={"type": "ui-react", "ci": "github"},
+            stack=None,
+        )
+
+    def test_undocumented_reference_file_warns(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._marker(tmp_path)
+        feature = _ui_feature_with_design(tmp_path)
+        (feature / "design" / "references" / "checkout-mockup.png").write_bytes(b"\x89PNG")
+
+        hits = [f for f in run_doctor(tmp_path) if f.id == "D020"]
+        assert hits and hits[0].severity == "warning"
+        assert hits[0].category == "design-reference-unlisted"
+        assert "checkout-mockup.png" in hits[0].message
+        assert "design.md" in hits[0].suggested_action
+
+    def test_documented_but_deleted_reference_warns(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._marker(tmp_path)
+        _ui_feature_with_design(tmp_path, design_body=(
+            "# Feature Design\n\n"
+            "## Reference Images, Mockups, and Prototypes\n\n"
+            "| File | What to learn from it | What not to copy | Authority |\n"
+            "|---|---|---|---|\n"
+            "| `login-flow.html` | screen order | markup | Advisory |\n"
+        ))
+
+        hits = [f for f in run_doctor(tmp_path) if f.id == "D020"]
+        assert hits and hits[0].severity == "warning"
+        assert hits[0].category == "design-reference-missing"
+        assert "login-flow.html" in hits[0].message
+
+    def test_documented_and_present_is_silent(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._marker(tmp_path)
+        feature = _ui_feature_with_design(tmp_path, design_body=(
+            "# Feature Design\n\n"
+            "## Reference Images, Mockups, and Prototypes\n\n"
+            "| File | What to learn from it | What not to copy | Authority |\n"
+            "|---|---|---|---|\n"
+            "| `checkout-mockup.png` | layout | exact colors | Advisory |\n"
+        ))
+        (feature / "design" / "references" / "checkout-mockup.png").write_bytes(b"\x89PNG")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D020"] == []
+
+    def test_references_readme_is_not_a_reference(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._marker(tmp_path)
+        _ui_feature_with_design(tmp_path)
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D020"] == []
+
+    def test_none_yet_placeholder_is_not_a_missing_file(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        self._marker(tmp_path)
+        _ui_feature_with_design(tmp_path)  # default body carries "None yet"
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D020"] == []
+
+    def test_feature_without_design_md_is_silent(self, tmp_path):
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path)  # backend marker, no design.md anywhere
+        feature = tmp_path / "features" / "billing"
+        feature.mkdir(parents=True)
+        (feature / "acceptance.feature").write_text("Feature: Billing\n", encoding="utf-8")
+
+        assert [f for f in run_doctor(tmp_path) if f.id == "D020"] == []
 
         assert [f for f in run_doctor(tmp_path) if f.id == "D018"] == []
 

--- a/tests/test_ui_stack_docs.py
+++ b/tests/test_ui_stack_docs.py
@@ -155,6 +155,45 @@ class TestAsymmetryReadme:
         )
 
 
+UI_STARTERS = ("starter_ui", "starter_ui_nextjs")
+
+
+class TestDesignReferenceContract:
+    """Plan increment 4 (D3/D4): design references cover interactive
+    prototypes — including AI-generated HTML prototypes — stored in the
+    same design/references/ folder, advisory by default, with prototype
+    code never imported into src/. The two UI starters keep intentionally
+    different design.md shapes, so consistency here is semantic (both carry
+    the contract), not byte identity."""
+
+    @pytest.mark.parametrize("starter", UI_STARTERS)
+    def test_design_md_covers_prototypes(self, starter):
+        text = _read(REPO_ROOT / "features" / starter / "design.md")
+        assert "prototype" in text.lower(), (
+            f"features/{starter}/design.md must extend the reference table "
+            "to interactive prototypes"
+        )
+        assert "never imported" in text, (
+            f"features/{starter}/design.md must state the no-code-reuse "
+            "rule: prototype code is never imported, copied, or extended "
+            "in src/"
+        )
+
+    @pytest.mark.parametrize("starter", UI_STARTERS)
+    def test_references_readme_accepts_prototypes(self, starter):
+        text = _read(
+            REPO_ROOT / "features" / starter / "design" / "references" / "README.md"
+        )
+        assert "prototype" in text.lower(), (
+            f"features/{starter}/design/references/README.md must name "
+            "interactive prototypes among accepted reference kinds"
+        )
+        assert "never imported" in text, (
+            f"features/{starter}/design/references/README.md must carry the "
+            "no-code-reuse rule for prototype files"
+        )
+
+
 class TestAgentInstructionDocLists:
     """A doc added to the payload but unreachable from the instruction files
     is invisible to the agents that are supposed to read it. Reachable means

--- a/tests/test_ui_stack_docs.py
+++ b/tests/test_ui_stack_docs.py
@@ -1,0 +1,132 @@
+"""Anti-drift tests for the per-stack UI architecture doc sets.
+
+UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md. Each per-stack folder under
+`docs/ui/architecture/` (react, angular, nextjs) must be individually fully
+functional: a core doc set every stack ships, plus intentionally
+nextjs-only server-first docs. Styling history made the gap visible —
+Angular shipped no styling guidance at all, and react's TECH_STACK.md
+mandated Tailwind while COMPONENT_CONVENTIONS.md still showed CSS modules,
+so generated code followed whichever doc the agent read first.
+
+These tests pin: the core per-stack inventory, BRAND.md as the single
+source of brand values (plan decision D7 — STYLING.md carries mechanism,
+never brand values), the removal of react's CSS-module contradiction (D2),
+and the per-stack doc lists in every agent's base and L4 instruction files.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+UI_ARCH = REPO_ROOT / "docs" / "ui" / "architecture"
+
+UI_STACKS = ("react", "angular", "nextjs")
+
+# Docs every per-stack folder ships. nextjs additionally ships the
+# server-first docs (APPLICATION_STRUCTURE, API_BOUNDARY,
+# SERVER_CLIENT_BOUNDARIES) that have no react/angular equivalent —
+# react/angular structure lives in MVVM_CONTRACT.md §3.
+CORE_STACK_DOCS = (
+    "TECH_STACK.md",
+    "COMPONENT_CONVENTIONS.md",
+    "STATE_MANAGEMENT.md",
+    "STYLING.md",
+)
+
+# Per-agent instruction-file directory, per cli/agent_layout.py naming.
+AGENT_INSTRUCTION_DIRS = {
+    "claude-code": "claude-md",
+    "codex": "agents-md",
+    "copilot": "copilot-instructions",
+}
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing: {path.relative_to(REPO_ROOT)}"
+    return path.read_text(encoding="utf-8")
+
+
+class TestCoreStackDocInventory:
+    @pytest.mark.parametrize("stack", UI_STACKS)
+    @pytest.mark.parametrize("doc", CORE_STACK_DOCS)
+    def test_stack_ships_core_doc(self, stack, doc):
+        path = UI_ARCH / stack / doc
+        assert path.is_file(), (
+            f"docs/ui/architecture/{stack}/{doc} missing — every UI stack "
+            f"ships the core doc set ({', '.join(CORE_STACK_DOCS)})"
+        )
+        assert path.stat().st_size > 0, f"{path.name} is empty"
+
+
+class TestStylingContract:
+    @pytest.mark.parametrize("stack", UI_STACKS)
+    def test_styling_names_brand_contract_as_source_of_truth(self, stack):
+        """D7: brand values live in BRAND.md; STYLING.md maps them to the
+        stack's mechanism and must say so."""
+        text = _read(UI_ARCH / stack / "STYLING.md")
+        assert "docs/ui/design/BRAND.md" in text, (
+            f"{stack}/STYLING.md must name docs/ui/design/BRAND.md as the source of brand values"
+        )
+
+    def test_react_component_conventions_no_css_module_references(self):
+        """D2: Tailwind (per TECH_STACK.md) is react's styling source of
+        truth; the stale CSS-module mentions are the contradiction."""
+        text = _read(UI_ARCH / "react" / "COMPONENT_CONVENTIONS.md")
+        for stale in ("module.css", "CSS module", "CSS modules"):
+            assert stale not in text, (
+                f"react/COMPONENT_CONVENTIONS.md still references '{stale}' — "
+                "contradicts TECH_STACK.md's Tailwind-only styling stack"
+            )
+
+    def test_react_component_conventions_points_at_styling_doc(self):
+        text = _read(UI_ARCH / "react" / "COMPONENT_CONVENTIONS.md")
+        assert "STYLING.md" in text, (
+            "react/COMPONENT_CONVENTIONS.md must point at STYLING.md for "
+            "styling rules instead of restating them"
+        )
+
+    def test_angular_styling_is_component_scoped(self):
+        """D6: Angular styles are component-scoped with BRAND tokens; no
+        Tailwind mandate."""
+        text = _read(UI_ARCH / "angular" / "STYLING.md")
+        assert "component-scoped" in text.lower(), (
+            "angular/STYLING.md must define the component-scoped styling "
+            "posture approved as plan decision D6"
+        )
+
+
+class TestBrandSourcesTraceability:
+    def test_brand_template_has_brand_sources_line(self):
+        """D7: the BRAND.md template records where external brand guides
+        live, so completed values are traceable to their source."""
+        text = _read(REPO_ROOT / "docs" / "ui" / "design" / "BRAND.md")
+        assert "Brand sources" in text, (
+            "docs/ui/design/BRAND.md must carry a 'Brand sources' line for "
+            "recording external brand guides used to complete it"
+        )
+
+
+class TestAgentInstructionDocLists:
+    """A doc added to the payload but unreachable from the instruction files
+    is invisible to the agents that are supposed to read it. Reachable means
+    either the exact path appears in the file's doc list, or the file
+    instructs reading all files under docs/ui/architecture/ (the copilot L4
+    and all L5 instruction files use the directory-wide form)."""
+
+    @pytest.mark.parametrize("agent", sorted(AGENT_INSTRUCTION_DIRS))
+    @pytest.mark.parametrize("ui_type,stack", [("ui-react", "react"), ("ui-angular", "angular")])
+    @pytest.mark.parametrize("prefix", ["", "l4-"])
+    def test_instruction_file_reaches_styling_doc(self, agent, ui_type, stack, prefix):
+        path = (
+            REPO_ROOT / "agents" / agent / AGENT_INSTRUCTION_DIRS[agent] / f"{prefix}{ui_type}.md"
+        )
+        text = _read(path)
+        explicit = f"docs/ui/architecture/{stack}/STYLING.md" in text
+        directory_wide = "all files under `docs/ui/architecture/" in text
+        assert explicit or directory_wide, (
+            f"{path.relative_to(REPO_ROOT)} must make "
+            f"docs/ui/architecture/{stack}/STYLING.md reachable — list it "
+            "explicitly or instruct reading all files under "
+            "docs/ui/architecture/"
+        )

--- a/tests/test_ui_stack_docs.py
+++ b/tests/test_ui_stack_docs.py
@@ -32,6 +32,7 @@ CORE_STACK_DOCS = (
     "COMPONENT_CONVENTIONS.md",
     "STATE_MANAGEMENT.md",
     "STYLING.md",
+    "TESTING.md",
 )
 
 # Per-agent instruction-file directory, per cli/agent_layout.py naming.
@@ -86,6 +87,18 @@ class TestStylingContract:
             "styling rules instead of restating them"
         )
 
+    def test_angular_component_conventions_use_jest_not_vitest(self):
+        """angular/TECH_STACK.md declares Jest + Angular Testing Library;
+        COMPONENT_CONVENTIONS.md historically said Vitest with vi.mocked/
+        vitest-axe examples — the same read-order contradiction as react's
+        CSS modules."""
+        text = _read(UI_ARCH / "angular" / "COMPONENT_CONVENTIONS.md")
+        for stale in ("Vitest", "vi.mocked", "vitest-axe"):
+            assert stale not in text, (
+                f"angular/COMPONENT_CONVENTIONS.md still references '{stale}' — "
+                "contradicts TECH_STACK.md's Jest testing stack"
+            )
+
     def test_angular_styling_is_component_scoped(self):
         """D6: Angular styles are component-scoped with BRAND tokens; no
         Tailwind mandate."""
@@ -117,16 +130,17 @@ class TestAgentInstructionDocLists:
     @pytest.mark.parametrize("agent", sorted(AGENT_INSTRUCTION_DIRS))
     @pytest.mark.parametrize("ui_type,stack", [("ui-react", "react"), ("ui-angular", "angular")])
     @pytest.mark.parametrize("prefix", ["", "l4-"])
-    def test_instruction_file_reaches_styling_doc(self, agent, ui_type, stack, prefix):
+    @pytest.mark.parametrize("doc", ["STYLING.md", "TESTING.md"])
+    def test_instruction_file_reaches_added_docs(self, agent, ui_type, stack, prefix, doc):
         path = (
             REPO_ROOT / "agents" / agent / AGENT_INSTRUCTION_DIRS[agent] / f"{prefix}{ui_type}.md"
         )
         text = _read(path)
-        explicit = f"docs/ui/architecture/{stack}/STYLING.md" in text
+        explicit = f"docs/ui/architecture/{stack}/{doc}" in text
         directory_wide = "all files under `docs/ui/architecture/" in text
         assert explicit or directory_wide, (
             f"{path.relative_to(REPO_ROOT)} must make "
-            f"docs/ui/architecture/{stack}/STYLING.md reachable — list it "
+            f"docs/ui/architecture/{stack}/{doc} reachable — list it "
             "explicitly or instruct reading all files under "
             "docs/ui/architecture/"
         )

--- a/tests/test_ui_stack_docs.py
+++ b/tests/test_ui_stack_docs.py
@@ -120,6 +120,41 @@ class TestBrandSourcesTraceability:
         )
 
 
+class TestAsymmetryReadme:
+    """docs/ui/architecture/README.md records why the nextjs folder ships
+    more docs than react/angular, so a future 'parity' pass doesn't
+    manufacture server-first docs for SPA stacks. It is repo-side only —
+    the manifests' governed lists name entries explicitly and must not
+    pick it up."""
+
+    def test_readme_names_the_intentionally_nextjs_only_docs(self):
+        text = _read(UI_ARCH / "README.md")
+        for doc in (
+            "APPLICATION_STRUCTURE.md",
+            "API_BOUNDARY.md",
+            "SERVER_CLIENT_BOUNDARIES.md",
+        ):
+            assert doc in text, f"README.md must name nextjs-only doc {doc}"
+        assert "MVVM_CONTRACT.md" in text, (
+            "README.md must say react/angular structure lives in MVVM_CONTRACT.md"
+        )
+
+    @pytest.mark.parametrize("agent", sorted(AGENT_INSTRUCTION_DIRS))
+    def test_readme_is_not_installed_by_any_manifest(self, agent):
+        manifest_text = (
+            REPO_ROOT / "agents" / agent / "manifest.json"
+        ).read_text(encoding="utf-8")
+        assert "docs/ui/architecture/README.md" not in manifest_text, (
+            f"{agent}: the asymmetry README is repo-side documentation and "
+            "must not be installed"
+        )
+        # Would sweep the README (and anything else) into every UI install.
+        assert '"docs/ui/architecture/"' not in manifest_text, (
+            f"{agent}: manifests must name docs/ui/architecture/ entries "
+            "explicitly, never the whole directory"
+        )
+
+
 class TestAgentInstructionDocLists:
     """A doc added to the payload but unreachable from the instruction files
     is invisible to the agents that are supposed to read it. Reachable means

--- a/tests/test_ui_stack_docs.py
+++ b/tests/test_ui_stack_docs.py
@@ -109,6 +109,20 @@ class TestStylingContract:
         )
 
 
+class TestTopLevelReadme:
+    """The top-level README's per-stack doc lists must include the docs
+    this plan added — a doc absent from the README is invisible to users
+    browsing the repo."""
+
+    @pytest.mark.parametrize("stack", ["react", "angular"])
+    @pytest.mark.parametrize("doc", ["STYLING.md", "TESTING.md"])
+    def test_readme_links_added_stack_docs(self, stack, doc):
+        text = _read(REPO_ROOT / "README.md")
+        assert f"docs/ui/architecture/{stack}/{doc}" in text, (
+            f"README.md must link docs/ui/architecture/{stack}/{doc}"
+        )
+
+
 class TestBrandSourcesTraceability:
     def test_brand_template_has_brand_sources_line(self):
         """D7: the BRAND.md template records where external brand guides


### PR DESCRIPTION
## What

Makes each per-stack UI architecture doc set (react/angular/nextjs) individually fully functional and extends the feature design-reference contract to interactive prototypes, per the approved plan in `plans/UI_DOCS_PARITY_AND_DESIGN_REFERENCES_PLAN.md`.

## Why

nextjs shipped 8 architecture docs while react/angular shipped 3. Part of that gap was real: Angular had no styling guidance anywhere, react''s TECH_STACK mandated Tailwind while COMPONENT_CONVENTIONS still showed CSS modules, and testing guidance was scattered. Separately, the design-reference contract was image-only — an AI-generated HTML prototype had no defined handling, and nothing stopped prototype code from being treated as implementation.

## Changes

- **New per-stack docs**: `STYLING.md` and `TESTING.md` for react and angular. React styling is Tailwind (D2); Angular is component-scoped styles over BRAND tokens, no Tailwind mandate (D6). Both listed in every base/L4 instruction file across all three agents.
- **Contradiction fixes**: react CSS-module references removed; angular COMPONENT_CONVENTIONS said Vitest/`vi.mocked`/`vitest-axe` against TECH_STACK''s declared Jest stack — now aligned; react TECH_STACK''s stale governance paths corrected.
- **BRAND.md**: new "Brand Sources" section (D7) — external brand guides are traceable inputs; brand values bind only via the completed contract.
- **Intentional asymmetry recorded**: repo-side `docs/ui/architecture/README.md` explains why `APPLICATION_STRUCTURE`/`API_BOUNDARY`/`SERVER_CLIENT_BOUNDARIES` stay nextjs-only; a test proves no manifest installs it.
- **Prototype contract (D3/D4)**: both UI starters'' `design.md` + references READMEs accept interactive prototypes, advisory by default; prototype code is never imported into `src/`. The three UI planning skills inventory prototypes, byte-identical across agents.
- **Doctor D020**: warns (never errors) when `design/references/` files and `design.md`''s table drift in either direction.
- **Calibrate**: the UI testing step now targets the per-stack `TESTING.md` instead of falling back to eval criteria.
- **README**: per-stack doc lists, visual-direction entries, and prototype wording updated.
- **Tests**: new `tests/test_ui_stack_docs.py` anti-drift suite plus additions to `test_calibrate.py`, `test_agent_skills.py`, `test_doctor.py`.

## Testing

- `./run_tests` — 2280 passed
- `./full_test` — e2e tier 134 passed (16 environment skips: JDK-dependent ArchUnit tests)
- `pytest -k parity` — green; UI skill bodies remain byte-identical across agents
- `ruff check` clean on changed Python files

🤖 Generated with [Claude Code](https://claude.com/claude-code)