### PR TITLE
fix: repair shipped payload and CI defects that break adopters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,14 @@ When a change affects behavior, contributors should update the relevant document
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/<your-username>/governed-ai-delivery.git`
 3. Create a branch for your change
-4. Install in development mode: `pip install -e ".[dev]"`
+4. Install in development mode: `pip install -e ".[test]"`
 5. Run the CLI: `govkit list`
 
 ### Maintainers
 
 1. Clone the repository
 2. Create a branch from `main`
-3. Install in development mode: `pip install -e ".[dev]"`
+3. Install in development mode: `pip install -e ".[test]"`
 4. Run the CLI: `govkit list`
 
 ---
@@ -149,6 +149,19 @@ CI templates in `ci/` are installed into target projects. Changes should:
 * Be applied consistently across supported CI platforms where relevant
 * Be documented in `ci/README.md`
 * Be tested against worked examples or a representative target project
+
+**Gates that invoke `govkit` must install it, at the shipping version.** A gate
+running `govkit doctor` or `govkit validate` needs its own `pip install
+govkit~=<version>` step — the runner has no govkit on `PATH`, and an unpinned
+install would couple a customer's merge criteria to whatever PyPI serves that
+morning while their payload prose stays frozen at install time.
+
+The pin must equal the version in `pyproject.toml`, which
+`tests/test_ci_govkit_dependency.py` enforces. **A release that bumps the
+version must update the `govkit~=` pin in every CI template in the same
+commit**, or the suite fails. CI templates are governed files, so `govkit
+upgrade` rewrites them — which is what keeps a tightened contract from reaching
+an adopter's gate without an explicit upgrade.
 
 ---
 

--- a/agents/claude-code/claude-md/l4-ui-angular.md
+++ b/agents/claude-code/claude-md/l4-ui-angular.md
@@ -79,6 +79,21 @@ Hard constraints. Never violate without an accepted ADR.
 
 ---
 
+## Mandatory Feature Structure
+
+Every feature must live under `features/<feature_name>/` with these artifacts:
+
+- `acceptance.feature`
+- `nfrs.md`
+- `eval_criteria.yaml`
+- `plan.md`
+- `architecture_preflight.md`
+- `design.md`
+
+Implementation must not begin unless all six artifacts exist and are complete.
+
+---
+
 ## Feature Workflow
 
 Every feature follows this mandatory sequence:

--- a/agents/claude-code/claude-md/l4-ui-react.md
+++ b/agents/claude-code/claude-md/l4-ui-react.md
@@ -75,6 +75,21 @@ These are hard constraints. Never violate without an accepted ADR.
 
 ---
 
+## Mandatory Feature Structure
+
+Every feature must live under `features/<feature_name>/` with these artifacts:
+
+- `acceptance.feature`
+- `nfrs.md`
+- `eval_criteria.yaml`
+- `plan.md`
+- `architecture_preflight.md`
+- `design.md`
+
+Implementation must not begin unless all six artifacts exist and are complete.
+
+---
+
 ## Feature Workflow
 
 Every feature follows this mandatory sequence:

--- a/agents/claude-code/rules/generic/repo-scope-backend.md
+++ b/agents/claude-code/rules/generic/repo-scope-backend.md
@@ -8,7 +8,7 @@ These rules apply to all files in this backend project.
 
 Before planning any feature, verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] "This feature is contained to" has a checked box (single repo OR multi-repo)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: "Multi-Repository Details" table is filled with all repos, owners, modules, and contracts
 - [ ] "Primary Owner" field names the orchestrating repo
 - [ ] "Key Cross-Repo Contracts" lists the integration points

--- a/agents/claude-code/rules/generic/repo-scope-ui.md
+++ b/agents/claude-code/rules/generic/repo-scope-ui.md
@@ -8,7 +8,7 @@ These rules apply to all files in this UI project.
 
 Before planning any feature, verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] "This feature is contained to" has a checked box (single repo OR multi-repo)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: "Multi-Repository Details" table is filled with all repos, owners, modules, and contracts
 - [ ] "Primary Owner" field names the orchestrating repo
 - [ ] "Key Cross-Repo Contracts" lists the integration points

--- a/agents/claude-code/rules/generic/spec-compliance.md
+++ b/agents/claude-code/rules/generic/spec-compliance.md
@@ -12,9 +12,11 @@ Every feature must live under `features/<feature_name>/` with these required art
 
 - `acceptance.feature` — Gherkin scenarios with Given/When/Then steps
 - `nfrs.md` — Non-functional requirements (no TBD entries permitted; sections per `NFRS_CONVENTIONS.md`)
+- `eval_criteria.yaml` — Evaluation configuration validated against the agent's schema
+- `architecture_preflight.md` — Pre-implementation alignment check
 - `plan.md` — Implementation plan with increments, tests, and deliverables
 
-Implementation must not begin unless all three artifacts exist and are complete.
+Implementation must not begin unless all five artifacts exist and are complete.
 
 ## Gherkin Conventions
 
@@ -28,6 +30,8 @@ Before writing any implementation code:
 
 - Verify `nfrs.md` contains no TBD entries
 - Verify `acceptance.feature` has complete scenarios
+- Verify `eval_criteria.yaml` exists and validates against the schema
+- Verify `architecture_preflight.md` exists and its status is not Blocked
 - Verify `plan.md` exists with defined increments and tests
 
 If any artifact is incomplete, stop and request completion before proceeding.

--- a/agents/claude-code/skills/backend/adr-author/SKILL.md
+++ b/agents/claude-code/skills/backend/adr-author/SKILL.md
@@ -27,7 +27,7 @@ Short, action-oriented statement describing the decision.
 
 ## Status
 
-Proposed / Approved / Rejected / Deprecated
+Proposed | Accepted | Rejected | Superseded
 
 ## Consequences
 

--- a/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/claude-code/skills/backend/architecture-preflight/SKILL.md
@@ -56,7 +56,7 @@ Before proceeding to ADR determination, validate repository scope. See: `docs/RE
 
 Verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] One box is checked: "This repository only" OR "Multiple repositories" (with table)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: all repos, owners, modules, and contracts are documented
 - [ ] "Primary Owner" and "Key Cross-Repo Contracts" are listed
 

--- a/agents/claude-code/skills/ui/adr-author/SKILL.md
+++ b/agents/claude-code/skills/ui/adr-author/SKILL.md
@@ -9,7 +9,7 @@ You are authoring an Architecture Decision Record for a UI architectural decisio
 
 Read all existing accepted ADRs in `docs/ui/architecture/ADR/` before writing. Do not contradict an accepted ADR without explicitly superseding it.
 
-Use the template at `governance/ui/templates/architecture_preflight.md` and produce the ADR in `docs/ui/architecture/ADR/`.
+Use the template at `docs/ui/architecture/ADR/TEMPLATE.md` and produce the ADR in `docs/ui/architecture/ADR/`.
 
 ---
 

--- a/agents/claude-code/skills/ui/architecture-preflight/SKILL.md
+++ b/agents/claude-code/skills/ui/architecture-preflight/SKILL.md
@@ -63,7 +63,7 @@ Before proceeding to component and state management decisions, validate reposito
 
 Verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] One box is checked: "This repository only" OR "Multiple repositories" (with table)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: all repos, owners, modules, and contracts are documented
 - [ ] "Primary Owner" and "Key Cross-Repo Contracts" are listed
 

--- a/agents/codex/agents-md/l4-ui-angular.md
+++ b/agents/codex/agents-md/l4-ui-angular.md
@@ -82,6 +82,21 @@ Hard constraints. Never violate without an accepted ADR.
 
 ---
 
+## Mandatory Feature Structure
+
+Every feature must live under `features/<feature_name>/` with these artifacts:
+
+- `acceptance.feature`
+- `nfrs.md`
+- `eval_criteria.yaml`
+- `plan.md`
+- `architecture_preflight.md`
+- `design.md`
+
+Implementation must not begin unless all six artifacts exist and are complete.
+
+---
+
 ## Feature Workflow
 
 Every feature follows this mandatory sequence:

--- a/agents/codex/agents-md/l4-ui-react.md
+++ b/agents/codex/agents-md/l4-ui-react.md
@@ -78,6 +78,21 @@ These are hard constraints. Never violate without an accepted ADR.
 
 ---
 
+## Mandatory Feature Structure
+
+Every feature must live under `features/<feature_name>/` with these artifacts:
+
+- `acceptance.feature`
+- `nfrs.md`
+- `eval_criteria.yaml`
+- `plan.md`
+- `architecture_preflight.md`
+- `design.md`
+
+Implementation must not begin unless all six artifacts exist and are complete.
+
+---
+
 ## Feature Workflow
 
 Every feature follows this mandatory sequence:

--- a/agents/codex/rules/generic/repo-scope-backend.md
+++ b/agents/codex/rules/generic/repo-scope-backend.md
@@ -8,7 +8,7 @@ These rules apply to all files in this backend project.
 
 Before planning any feature, verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] "This feature is contained to" has a checked box (single repo OR multi-repo)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: "Multi-Repository Details" table is filled with all repos, owners, modules, and contracts
 - [ ] "Primary Owner" field names the orchestrating repo
 - [ ] "Key Cross-Repo Contracts" lists the integration points

--- a/agents/codex/rules/generic/repo-scope-ui.md
+++ b/agents/codex/rules/generic/repo-scope-ui.md
@@ -8,7 +8,7 @@ These rules apply to all files in this UI project.
 
 Before planning any feature, verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] "This feature is contained to" has a checked box (single repo OR multi-repo)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: "Multi-Repository Details" table is filled with all repos, owners, modules, and contracts
 - [ ] "Primary Owner" field names the orchestrating repo
 - [ ] "Key Cross-Repo Contracts" lists the integration points

--- a/agents/codex/rules/generic/spec-compliance.md
+++ b/agents/codex/rules/generic/spec-compliance.md
@@ -12,9 +12,11 @@ Every feature must live under `features/<feature_name>/` with these required art
 
 - `acceptance.feature` — Gherkin scenarios with Given/When/Then steps
 - `nfrs.md` — Non-functional requirements (no TBD entries permitted; sections per `NFRS_CONVENTIONS.md`)
+- `eval_criteria.yaml` — Evaluation configuration validated against the agent's schema
+- `architecture_preflight.md` — Pre-implementation alignment check
 - `plan.md` — Implementation plan with increments, tests, and deliverables
 
-Implementation must not begin unless all three artifacts exist and are complete.
+Implementation must not begin unless all five artifacts exist and are complete.
 
 ## Gherkin Conventions
 
@@ -28,6 +30,8 @@ Before writing any implementation code:
 
 - Verify `nfrs.md` contains no TBD entries
 - Verify `acceptance.feature` has complete scenarios
+- Verify `eval_criteria.yaml` exists and validates against the schema
+- Verify `architecture_preflight.md` exists and its status is not Blocked
 - Verify `plan.md` exists with defined increments and tests
 - Verify "Repository Scope" section in `nfrs.md` is complete (see Repository Scope Enforcement rule)
 

--- a/agents/codex/skills/backend/adr-author/SKILL.md
+++ b/agents/codex/skills/backend/adr-author/SKILL.md
@@ -27,7 +27,7 @@ Short, action-oriented statement describing the decision.
 
 ## Status
 
-Proposed / Approved / Rejected / Deprecated
+Proposed | Accepted | Rejected | Superseded
 
 ## Consequences
 

--- a/agents/codex/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/codex/skills/backend/architecture-preflight/SKILL.md
@@ -56,7 +56,7 @@ Before proceeding to ADR determination, validate repository scope. See: `docs/RE
 
 Verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] One box is checked: "This repository only" OR "Multiple repositories" (with table)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: all repos, owners, modules, and contracts are documented
 - [ ] "Primary Owner" and "Key Cross-Repo Contracts" are listed
 

--- a/agents/codex/skills/ui/adr-author/SKILL.md
+++ b/agents/codex/skills/ui/adr-author/SKILL.md
@@ -9,7 +9,7 @@ You are authoring an Architecture Decision Record for a UI architectural decisio
 
 Read all existing accepted ADRs in `docs/ui/architecture/ADR/` before writing. Do not contradict an accepted ADR without explicitly superseding it.
 
-Use the template at `governance/ui/templates/architecture_preflight.md` and produce the ADR in `docs/ui/architecture/ADR/`.
+Use the template at `docs/ui/architecture/ADR/TEMPLATE.md` and produce the ADR in `docs/ui/architecture/ADR/`.
 
 ---
 

--- a/agents/codex/skills/ui/architecture-preflight/SKILL.md
+++ b/agents/codex/skills/ui/architecture-preflight/SKILL.md
@@ -63,7 +63,7 @@ Before proceeding to component and state management decisions, validate reposito
 
 Verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] One box is checked: "This repository only" OR "Multiple repositories" (with table)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: all repos, owners, modules, and contracts are documented
 - [ ] "Primary Owner" and "Key Cross-Repo Contracts" are listed
 

--- a/agents/copilot/copilot-instructions/l4-ui-angular.md
+++ b/agents/copilot/copilot-instructions/l4-ui-angular.md
@@ -58,9 +58,9 @@ See `docs/ui/architecture/MVVM_CONTRACT.md` for full rules.
 
 Every feature must live under `features/<feature_name>/` with:
 
-* `acceptance.feature`, `nfrs.md`, `eval_criteria.yaml`, `plan.md`, `architecture_preflight.md`
+* `acceptance.feature`, `nfrs.md`, `eval_criteria.yaml`, `plan.md`, `architecture_preflight.md`, `design.md`
 
-Implementation must not begin until all artifacts exist and are complete.
+Implementation must not begin until all six artifacts exist and are complete.
 
 ---
 

--- a/agents/copilot/copilot-instructions/l4-ui-react.md
+++ b/agents/copilot/copilot-instructions/l4-ui-react.md
@@ -64,8 +64,9 @@ Every feature must live under `features/<feature_name>/` with these artifacts:
 * `eval_criteria.yaml`
 * `plan.md`
 * `architecture_preflight.md`
+* `design.md`
 
-Implementation must not begin unless all artifacts exist and are complete.
+Implementation must not begin unless all six artifacts exist and are complete.
 
 ---
 

--- a/agents/copilot/instructions/generic/repo-scope-backend.instructions.md
+++ b/agents/copilot/instructions/generic/repo-scope-backend.instructions.md
@@ -12,7 +12,7 @@ These instructions apply when planning any backend feature that may span multipl
 
 Before planning any feature, verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] "This feature is contained to" has a checked box (single repo OR multi-repo)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: "Multi-Repository Details" table is filled with all repos, owners, modules, and contracts
 - [ ] "Primary Owner" field names the orchestrating repo
 - [ ] "Key Cross-Repo Contracts" lists the integration points

--- a/agents/copilot/instructions/generic/repo-scope-ui.instructions.md
+++ b/agents/copilot/instructions/generic/repo-scope-ui.instructions.md
@@ -12,7 +12,7 @@ These instructions apply when planning any UI feature that may span multiple rep
 
 Before planning any feature, verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] "This feature is contained to" has a checked box (single repo OR multi-repo)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: "Multi-Repository Details" table is filled with all repos, owners, modules, and contracts
 - [ ] "Primary Owner" field names the orchestrating repo
 - [ ] "Key Cross-Repo Contracts" lists the integration points

--- a/agents/copilot/instructions/generic/spec-compliance.instructions.md
+++ b/agents/copilot/instructions/generic/spec-compliance.instructions.md
@@ -16,9 +16,11 @@ Every feature must live under `features/<feature_name>/` with these required art
 
 - `acceptance.feature` — Gherkin scenarios with Given/When/Then steps
 - `nfrs.md` — Non-functional requirements (no TBD entries permitted; sections per `NFRS_CONVENTIONS.md`)
+- `eval_criteria.yaml` — Evaluation configuration validated against the agent's schema
+- `architecture_preflight.md` — Pre-implementation alignment check
 - `plan.md` — Implementation plan with increments, tests, and deliverables
 
-Implementation must not begin unless all three artifacts exist and are complete.
+Implementation must not begin unless all five artifacts exist and are complete.
 
 ## Gherkin Conventions
 
@@ -32,6 +34,8 @@ Before writing any implementation code:
 
 - Verify `nfrs.md` contains no TBD entries
 - Verify `acceptance.feature` has complete scenarios
+- Verify `eval_criteria.yaml` exists and validates against the schema
+- Verify `architecture_preflight.md` exists and its status is not Blocked
 - Verify `plan.md` exists with defined increments and tests
 - Verify "Repository Scope" section in `nfrs.md` is complete (see Repository Scope Enforcement rule)
 

--- a/agents/copilot/skills/backend/adr-author/SKILL.md
+++ b/agents/copilot/skills/backend/adr-author/SKILL.md
@@ -27,7 +27,7 @@ Short, action-oriented statement describing the decision.
 
 ## Status
 
-Proposed / Approved / Rejected / Deprecated
+Proposed | Accepted | Rejected | Superseded
 
 ## Consequences
 

--- a/agents/copilot/skills/backend/architecture-preflight/SKILL.md
+++ b/agents/copilot/skills/backend/architecture-preflight/SKILL.md
@@ -56,7 +56,7 @@ Before proceeding to ADR determination, validate repository scope. See: `docs/RE
 
 Verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] One box is checked: "This repository only" OR "Multiple repositories" (with table)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: all repos, owners, modules, and contracts are documented
 - [ ] "Primary Owner" and "Key Cross-Repo Contracts" are listed
 

--- a/agents/copilot/skills/ui/adr-author/SKILL.md
+++ b/agents/copilot/skills/ui/adr-author/SKILL.md
@@ -9,7 +9,7 @@ You are authoring an Architecture Decision Record for a UI architectural decisio
 
 Read all existing accepted ADRs in `docs/ui/architecture/ADR/` before writing. Do not contradict an accepted ADR without explicitly superseding it.
 
-Use the template at `governance/ui/templates/architecture_preflight.md` and produce the ADR in `docs/ui/architecture/ADR/`.
+Use the template at `docs/ui/architecture/ADR/TEMPLATE.md` and produce the ADR in `docs/ui/architecture/ADR/`.
 
 ---
 

--- a/agents/copilot/skills/ui/architecture-preflight/SKILL.md
+++ b/agents/copilot/skills/ui/architecture-preflight/SKILL.md
@@ -63,7 +63,7 @@ Before proceeding to component and state management decisions, validate reposito
 
 Verify the "Repository Scope" section in `features/<feature>/nfrs.md` is complete:
 
-- [ ] One box is checked: "This repository only" OR "Multiple repositories" (with table)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo: all repos, owners, modules, and contracts are documented
 - [ ] "Primary Owner" and "Key Cross-Repo Contracts" are listed
 

--- a/ci/azure/data-common-gate.yml
+++ b/ci/azure/data-common-gate.yml
@@ -54,9 +54,7 @@ stages:
               script: |
                 set -euo pipefail
                 python -m pip install --upgrade pip
-                if ! command -v govkit >/dev/null 2>&1; then
-                  python -m pip install govkit
-                fi
+                python -m pip install govkit~=0.18.0
 
           - task: Bash@3
             displayName: Run GovKit validation

--- a/ci/azure/eval-gate.yml
+++ b/ci/azure/eval-gate.yml
@@ -39,10 +39,15 @@ stages:
           - script: |
               python - <<'EOF'
               import yaml, glob, sys
+              from pathlib import Path
 
               errors = []
               for path in glob.glob("features/*/plan.md"):
-                  feature = path.split("/")[1]
+                  feature = Path(path).parent.name
+                  # Starters ship placeholder predictions by design; cli/features.py
+                  # skips them and so must this gate.
+                  if feature.startswith("starter_"):
+                      continue
                   with open(path) as f:
                       content = f.read()
                   # Look for the evaluation_prediction YAML block

--- a/ci/azure/l3-ui-nextjs-quality-gate.yml
+++ b/ci/azure/l3-ui-nextjs-quality-gate.yml
@@ -25,6 +25,14 @@ stages:
           - script: npm ci
             displayName: Install dependencies
 
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.11'
+            displayName: Set up Python
+
+          - script: pip install govkit~=0.18.0
+            displayName: Install GovKit
+
           - script: govkit doctor --target .
             displayName: Enforce API and database boundary
 

--- a/ci/azure/ui-nextjs-quality-gate.yml
+++ b/ci/azure/ui-nextjs-quality-gate.yml
@@ -25,6 +25,14 @@ stages:
           - script: npm ci
             displayName: Install dependencies
 
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.11'
+            displayName: Set up Python
+
+          - script: pip install govkit~=0.18.0
+            displayName: Install GovKit
+
           - script: govkit doctor --target .
             displayName: Enforce API and database boundary
 

--- a/ci/github/data-common-gate.yml
+++ b/ci/github/data-common-gate.yml
@@ -41,9 +41,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          if ! command -v govkit >/dev/null 2>&1; then
-            python -m pip install govkit
-          fi
+          python -m pip install govkit~=0.18.0
 
       - name: Run GovKit validation
         run: |

--- a/ci/github/eval-gate.yml
+++ b/ci/github/eval-gate.yml
@@ -42,10 +42,15 @@ jobs:
         run: |
           python - <<'EOF'
           import yaml, glob, sys
+          from pathlib import Path
 
           errors = []
           for path in glob.glob("features/*/plan.md"):
-              feature = path.split("/")[1]
+              feature = Path(path).parent.name
+              # Starters ship placeholder predictions by design; cli/features.py
+              # skips them and so must this gate.
+              if feature.startswith("starter_"):
+                  continue
               with open(path) as f:
                   content = f.read()
               # Look for the evaluation_prediction YAML block

--- a/ci/github/l3-ui-nextjs-quality-gate.yml
+++ b/ci/github/l3-ui-nextjs-quality-gate.yml
@@ -21,6 +21,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install GovKit
+        run: pip install govkit~=0.18.0
+
       - name: Enforce API and database boundary
         run: govkit doctor --target .
 

--- a/ci/github/ui-nextjs-quality-gate.yml
+++ b/ci/github/ui-nextjs-quality-gate.yml
@@ -21,6 +21,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install GovKit
+        run: pip install govkit~=0.18.0
+
       - name: Enforce API and database boundary
         run: govkit doctor --target .
 

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -21,14 +21,17 @@ artifacts and that those artifacts meet minimum quality thresholds.
 Level-aware: Level 3 checks fewer artifacts and skips evaluation scoring.
 Level 4 checks all 5 artifacts with full evaluation enforcement.
 
-Uses only the Python standard library. Full JSON Schema validation of
-eval_criteria.yaml is deferred to CI or `check-jsonschema` if installed.
+Depends only on the standard library plus pyyaml, a declared runtime dependency
+(see `pyproject.toml`). Full JSON Schema validation of eval_criteria.yaml is
+deferred to CI or `check-jsonschema` if installed.
 """
 
 import re
 import subprocess
 from enum import Enum
 from pathlib import Path
+
+import yaml
 
 from .features import list_user_features
 from .marker import TYPE_AREA, read_govkit_marker
@@ -285,6 +288,91 @@ def check_eval_criteria(feature_dir: Path) -> tuple[CheckStatus, str]:
 # unrelated earlier block's `: null` was reported as a prediction null.
 _RE_YAML_BLOCK = re.compile(r"```ya?ml\s*\n(.*?)```", re.DOTALL)
 
+# A score group declares its mean under one of these keys. Backend plans use
+# `first:`/`virtues:` with `average:`; the UI template nests scores under
+# `component_tests.FIRST_scores` and declares `predicted_average`.
+_AVERAGE_KEYS = ("average", "predicted_average")
+
+# Declared averages are recorded to one or two decimals, so 31/7 = 4.4285… is
+# legitimately written 4.4. Tolerate rounding; catch a fabricated figure.
+_AVERAGE_TOLERANCE = 0.05
+
+# FIRST_SCORING_RUBRIC.md and VIRTUE_SCORING_RUBRIC.md both say:
+# "Fail: average < 4.0 OR any individual score below 3". Only the average half
+# was ever enforced.
+_MIN_INDIVIDUAL_SCORE = 3
+
+
+def _as_number(value: object) -> float | None:
+    """Numeric value, excluding bool (which is an int subclass in Python)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _declared_average(node: dict) -> float | None:
+    for key in _AVERAGE_KEYS:
+        number = _as_number(node.get(key))
+        if number is not None:
+            return number
+    return None
+
+
+def _subtree_scores(node: dict) -> list[float]:
+    """Every `score:` beneath this node, not descending into a nested group that
+    declares its own average — so `first` and `virtues` stay separate."""
+    scores = []
+    for key, value in node.items():
+        if key == "score":
+            number = _as_number(value)
+            if number is not None:
+                scores.append(number)
+        elif isinstance(value, dict) and _declared_average(value) is None:
+            scores.extend(_subtree_scores(value))
+    return scores
+
+
+def _score_groups(node: object, label: str = "evaluation_prediction") -> list[tuple]:
+    """(label, scores, declared_average) for every subtree declaring an average."""
+    groups: list[tuple] = []
+    if not isinstance(node, dict):
+        return groups
+    declared = _declared_average(node)
+    if declared is not None:
+        groups.append((label, _subtree_scores(node), declared))
+    for key, value in node.items():
+        if isinstance(value, dict):
+            groups.extend(_score_groups(value, key))
+    return groups
+
+
+def _prediction_score_problems(block: str) -> tuple[list[str], list[str]]:
+    """Cross-check each declared average against the scores beside it.
+
+    The declared `average:` was previously read and never verified, so a plan
+    could claim 4.5 over scores averaging 3.1. Groups that declare an average
+    without individual scores are left alone — those plans stay valid.
+    """
+    try:
+        parsed = yaml.safe_load(block)
+    except yaml.YAMLError:
+        return [], []  # eval-gate reports unparseable blocks; don't double-fail here
+    prediction = parsed.get("evaluation_prediction") if isinstance(parsed, dict) else None
+
+    inconsistent, low_scores = [], []
+    for label, scores, declared in _score_groups(prediction):
+        if not scores:
+            continue
+        computed = sum(scores) / len(scores)
+        if abs(computed - declared) > _AVERAGE_TOLERANCE:
+            inconsistent.append(
+                f"{label} declares {declared:g} but its scores average {computed:.2f}"
+            )
+        low_scores.extend(
+            f"{label}={score:g}" for score in scores if score < _MIN_INDIVIDUAL_SCORE
+        )
+    return inconsistent, low_scores
+
 
 def check_plan_eval_prediction(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that plan.md has an evaluation_prediction block with averages >= 4.0."""
@@ -316,6 +404,18 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[CheckStatus, str]:
 
     if below_threshold:
         return CheckStatus.FAIL, f"{_PLAN_MD} evaluation_prediction average(s) below 4.0: {', '.join(below_threshold)}"
+
+    inconsistent, low_scores = _prediction_score_problems(block)
+    if inconsistent:
+        return CheckStatus.FAIL, (
+            f"{_PLAN_MD} evaluation_prediction is internally inconsistent — "
+            + "; ".join(inconsistent)
+        )
+    if low_scores:
+        return CheckStatus.FAIL, (
+            f"{_PLAN_MD} evaluation_prediction has individual score(s) below 3: "
+            + ", ".join(low_scores)
+        )
     return CheckStatus.PASS, f"{_PLAN_MD} evaluation_prediction averages OK ({', '.join(averages)})"
 
 

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -137,13 +137,31 @@ def check_gherkin_syntax(feature_dir: Path) -> tuple[CheckStatus, str]:
     return CheckStatus.PASS, f"{_ACCEPTANCE_FEATURE} has valid Gherkin structure"
 
 
+# A line that *talks about* TBD rather than leaving one. `**TBD**` is the
+# emphasised form starters use ("Replace every **TBD** with a real value");
+# "TBD entries" is how the govkit rule itself is phrased. Both are documentation,
+# not placeholders — the bare \bTBD\b scan matched govkit's own worked example,
+# failing `govkit validate` on a file govkit ships.
+_RE_TBD_SELF_REFERENCE = re.compile(r"\*\*TBD\*\*|\bTBD entries\b")
+
+
 def check_nfrs_no_tbd(feature_dir: Path) -> tuple[CheckStatus, str]:
-    """Check that nfrs.md has no remaining TBD entries."""
+    """Check that nfrs.md has no remaining TBD placeholders.
+
+    Placeholders occur in several real shapes across `features/*/nfrs.md` — a bare
+    list item, a value after a colon, a table cell, and mid-sentence ("Baseline TBD
+    after 2 weeks") — so the scan stays deliberately broad. Only the two
+    self-referential forms above are exempt.
+    """
     path = feature_dir / _NFRS_MD
     if not path.exists():
         return CheckStatus.FAIL, f"{_NFRS_MD} not found"
     lines = path.read_text(encoding="utf-8").splitlines()
-    tbd_lines = [i + 1 for i, ln in enumerate(lines) if re.search(r"\bTBD\b", ln)]
+    tbd_lines = [
+        i + 1
+        for i, ln in enumerate(lines)
+        if re.search(r"\bTBD\b", ln) and not _RE_TBD_SELF_REFERENCE.search(ln)
+    ]
     if tbd_lines:
         return CheckStatus.FAIL, f"{_NFRS_MD} contains TBD entries (lines {', '.join(map(str, tbd_lines))})"
     return CheckStatus.PASS, f"{_NFRS_MD} has no TBD entries"

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -278,6 +278,14 @@ def check_eval_criteria(feature_dir: Path) -> tuple[CheckStatus, str]:
     return CheckStatus.PASS, f"{_EVAL_CRITERIA_YAML} valid against {schema.name}"
 
 
+# One fenced YAML block. Non-greedy *within* a block so an earlier fence cannot
+# absorb a later one — the prediction block is then selected by content, not by
+# being first. A single `.*?evaluation_prediction:.*?` pattern anchored on the
+# first fence in the file and ran straight past intervening fences, so an
+# unrelated earlier block's `: null` was reported as a prediction null.
+_RE_YAML_BLOCK = re.compile(r"```ya?ml\s*\n(.*?)```", re.DOTALL)
+
+
 def check_plan_eval_prediction(feature_dir: Path) -> tuple[CheckStatus, str]:
     """Check that plan.md has an evaluation_prediction block with averages >= 4.0."""
     path = feature_dir / _PLAN_MD
@@ -285,14 +293,12 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[CheckStatus, str]:
         return CheckStatus.FAIL, f"{_PLAN_MD} not found"
     text = path.read_text(encoding="utf-8")
 
-    block_match = re.search(
-        r"```ya?ml\s*\n(.*?evaluation_prediction:.*?)```",
-        text, re.DOTALL,
+    block = next(
+        (b for b in _RE_YAML_BLOCK.findall(text) if "evaluation_prediction:" in b),
+        None,
     )
-    if not block_match:
+    if block is None:
         return CheckStatus.FAIL, f"{_PLAN_MD} missing evaluation_prediction block"
-
-    block = block_match.group(1)
 
     null_matches = re.findall(r":\s*null\b", block)
     if null_matches:

--- a/docs/REPO_SCOPE_ANALYSIS_GUIDANCE.md
+++ b/docs/REPO_SCOPE_ANALYSIS_GUIDANCE.md
@@ -12,9 +12,7 @@ Before proceeding to boundary analysis or ADR determination, validate repository
 
 Verify the "Repository Scope" section in `features/<feature_name>/nfrs.md` is **complete and explicit**:
 
-- [ ] One of these is checked:
-  - [ ] "This repository only"
-  - [ ] "Multiple repositories" (with table filled in)
+- [ ] **Scope:** declares `single-repo` or `multi-repo`
 - [ ] If multi-repo:
   - [ ] "Multi-Repository Details" table lists all repos, owner teams, modules/services, and contracts
   - [ ] "Primary Owner" field identifies the orchestrating repo

--- a/features/starter_data/nfrs.md
+++ b/features/starter_data/nfrs.md
@@ -10,9 +10,13 @@ Replace every **TBD** with a real value before this feature ships.
 
 ## Repository Scope
 
-- [ ] **This repository only**
-- [ ] **Multiple repositories** — list each repo, its owner, the modules
-  involved, and the contracts exposed:
+**Scope:** `single-repo`
+<!-- Replace `single-repo` with `multi-repo` if this feature spans multiple repositories, then complete the table below -->
+
+### Multi-Repository Details
+
+*Complete only if scope is `multi-repo`.* List each repo, its owner, the
+modules involved, and the contracts exposed:
 
 | Repo | Owner | Module | Contract |
 |---|---|---|---|

--- a/features/ui_task_dashboard/nfrs.md
+++ b/features/ui_task_dashboard/nfrs.md
@@ -65,4 +65,4 @@
 - `@accessibility`-tagged scenarios must have jest-axe assertions in component tests and axe scans in Playwright E2E tests
 - `@e2e`-tagged scenarios must have passing Playwright tests before merge
 - `@nfr-performance` targets must be verified via Lighthouse CI in the CI pipeline
-- No TBD entries are permitted in this file before Architecture Preflight begins
+- Every placeholder must be replaced with a concrete value before Architecture Preflight begins

--- a/plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md
+++ b/plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md
@@ -1,0 +1,117 @@
+# Autonomous Bug-Fix Agent — Feasibility Analysis
+
+**Status:** Analysis only — no implementation planned
+**Scope:** Target repos governed at L4; agent opens PR, human reviews and merges
+**Date:** 2026-08-13
+
+> **Question asked.** Can a bug-fix agent that invokes Claude Code headless (`-p`) work autonomously against a repo with govkit installed at L4 — diagnose, fix, and open a PR with no human intervention?
+
+> **Answer.** Yes, but only by stepping outside govkit's lifecycle — and the current design has no way to tell the difference. The interesting risk is not that the agent gets blocked. It is that it doesn't.
+
+---
+
+## 1. govkit's enforcement has three layers, and only one is real
+
+| Layer | What's there | Bearing on headless |
+|---|---|---|
+| **Harness** | **Nothing.** No `.claude/settings.json`, no hooks, no `permissions`, no output styles anywhere in the payload. | Nothing mechanically constrains the agent. Governance is not enforced by the runtime. |
+| **Prose** | **79 blocking-phrase occurrences across 26 files** in `agents/claude-code/`, mirrored verbatim to codex and copilot. | This is what actually stops a `-p` run — and it fires *before any code is written*. |
+| **CI** | Real gates, but **no human gate in any shipped template.** No `environment:`, no `workflow_dispatch:`, no `pull_request_review:`, no CODEOWNERS. | Orthogonal to the bug fix — see §3. |
+
+Two structural facts that matter more than they look:
+
+- **CI templates are not live on install.** `cli/install_common.py:394` copies them to `<target>/ci/github/*.yml`, not `.github/workflows/`. Per `ci/README.md`, a human must copy them and set `REPO_OWNER`. Whatever a given target repo enforces depends on what that team wired up.
+- **`--dangerously-skip-permissions` does nothing for the gates that matter.** The blocking gates are not permission prompts; they are instructions to emit a request and halt. No CLI flag addresses them.
+
+---
+
+## 2. The four gates that will actually stop the run (L4 backend)
+
+| # | Gate | Source | Self-clearable? |
+|---|---|---|---|
+| 1 | "If required inputs are missing, stop and ask." / "If alignment is unclear, stop and ask." | `agents/claude-code/claude-md/l4-backend-api.md:25`, `:190` | No. `:190` sits under *Output Expectations* — it applies to every output, not just planning. |
+| 2 | "Implementation must not begin unless all five artifacts exist." | `agents/claude-code/claude-md/l4-backend-api.md:39`, and `agents/claude-code/rules/generic/spec-compliance.md:17`, which **applies to all files in the project** | Only by authoring the specs itself — see §4. |
+| 3 | Repo-scope **HALT** | `agents/claude-code/rules/generic/repo-scope-backend.md:16` | No — and it has a payload bug (§6). |
+| 4 | ADR must be **Accepted** before implementation | `agents/claude-code/claude-md/l4-backend-api.md:86` | **No. Hard stop.** Nothing in the payload lets a non-human set `Status: Accepted`; `docs/backend/architecture/ADR/TEMPLATE.md` §10 wants named Architect / Security / Product signatures. ADR triggers include *"a shared schema, API contract, event definition, or data model is introduced or modified"* — reachable on a real bug fix. |
+
+Every skill also opens with *"if it is not provided, ask before proceeding"*, and in multi-service repos `agents/claude-code/skills/backend/spec-planning/SKILL.md:29` says **"ask which service to plan for … Do not guess."**
+
+**There is no defect lane.** Zero occurrences of `bug|hotfix|defect|triage` as a workflow across the entire payload. `govkit init` accepts only `--starter {backend,cli,ui-react,ui-angular,ui-nextjs,data}`. The vocabulary is "feature" everywhere: *"This lifecycle applies to every feature."*
+
+---
+
+## 3. The asymmetry that makes it work anyway
+
+A **code-only PR** — the fix plus a regression test, touching no `features/` directory — passes CI:
+
+- `cli/validate.py:648` iterates *existing* feature dirs. Untouched features still pass, so `govkit validate` stays green.
+- The `governance-artifacts` job in `ci/github/quality-gate.yml` only fails a feature that has `plan.md` but no `architecture_preflight.md`. Untouched features are fine.
+- The L3 quality gate's commit-format regex already accepts `fix(scope): …`.
+
+So **CI does not require a feature folder for a bug fix.** The entire blockage is agent-facing prose. That is the crack this use case fits through — but note what it means: the governance model's opinion about this PR is expressed only in text the agent may or may not obey, and nothing downstream can tell whether it did.
+
+---
+
+## 4. The real failure mode: self-certification, not stalling
+
+With no human to answer, a capable agent will not stall — it will **self-serve**. It creates `features/bug_1234/` and authors all five artifacts itself. And **every L4 gate passes**, because every gate is a shape check on prose the agent just wrote:
+
+- `check_plan_eval_prediction` (`cli/validate.py:281`) regex-scrapes `average: ([\d.]+)` from a YAML block the agent authored. Write `4.5`, pass. **The 4.0 quality floor is self-attestation, not measurement.**
+- `check_nfrs_no_tbd` greps for `TBD`. The agent writes plausible NFRs, pass.
+- `check_gherkin_nfr_coverage` cross-references NFR sections against `@nfr-*` tags — the agent controls both sides of the comparison.
+
+`ci/README.md` is admirably candid about this: FIRST scores, Virtue scores, and accessibility are listed as **"prediction-only"** — the gate reads numbers the agent itself wrote.
+
+The consequence when a human reviews the PR: that reviewer receives a three-line bug fix **plus five documents of AI-authored governance prose they must audit to know whether any of it is true**. Governance cost moves from the agent to the reviewer, and the artifacts' signal value goes to zero — a green `validate` means "the agent filled in the boxes," nothing more. That is strictly worse than shipping no artifacts at all.
+
+**Worth sitting with:** govkit's own `extensions/skill-oriented-agent-architecture/docs/backend/architecture/AUTHORITY_AND_APPROVAL_CONTRACT.md:164-171` — the authority model it ships for customer-built agent systems — lists as *prohibited patterns*: **"Permission declarations inside prompt text"** and **"Treating chat acknowledgment … as approval."** That is an exact description of how govkit's own delivery governance works. The framework holds the systems its users build to a standard its own delivery layer does not meet. Closing that gap is the real product question behind the bug-fix agent.
+
+---
+
+## 5. What works today, if this ships now
+
+Given L4 with a human merge gate, the viable path is deliberate and narrow:
+
+1. **Constrain to the code-only path.** Fix plus regression test. No `features/` directory, ever. Frame the bug as remediating an *existing* feature's spec, not as new work.
+2. **Override the prose gates explicitly and visibly** via `--append-system-prompt` — an auditable statement that this run is in defect-remediation mode and must not author feature artifacts. Do it in the open, not by hoping the model ignores its own rules.
+3. **Make stalling a first-class success outcome.** This is the single most important decision. When the agent hits a gate it cannot clear (an ADR trigger, an ambiguous root cause), it must **exit non-zero naming the unmet gate** rather than inventing its way past it. Every gate in §2 is currently self-clearable by a sufficiently motivated model; the calling harness, not govkit, has to be what says no.
+4. **Commit format:** `fix(scope): description`. The L3 gate validates format across **every commit in `origin/main..HEAD`**, not just the tip.
+5. **If the target is `ui-nextjs`**, `govkit doctor` runs in CI and D016's static DB scan is unwaivable — it fails on any `.sql` file, any `db/` or `migrations/` directory, or any `DATABASE_URL`-style key including in `.env.example`.
+
+---
+
+## 6. Two payload defects found along the way (independent of autonomy)
+
+- **Repo-scope false HALT.** `agents/claude-code/rules/generic/repo-scope-backend.md:16` tells the agent to look for a *checked box*, but every shipped starter and worked example writes ``**Scope:** `single-repo` `` with no checkbox anywhere. A literal-minded agent HALTs on a correctly-filled file — **with a human present.** This is a live bug today, not an autonomy concern. Mirrored in `repo-scope-ui.md:16` and the preflight skills.
+- **Inconsistent plan-approval wording.** `agents/claude-code/claude-md/l4-ui-react.md:88` says *"Do not begin implementation until Phases 1–3 are complete and approved"*; `l4-ui-angular.md` and `l4-ui-nextjs.md` describe the same 5-phase workflow and silently omit the approval sentence.
+
+---
+
+## 7. Where this lands against existing plans
+
+`plans/HARNESS_GAP_ROADMAP.md` Initiative 2 ("Runtime legibility for the agent") already scopes this exact use case. Its *Done when* reads:
+
+> A govkit-governed project can hand the agent a reported bug and have it reproduce, fix, and validate against the running app — at minimum for the UI path — with evidence attached to the PR.
+
+Marked P1, Large, unstarted. The bug-fix agent is the forcing function for it.
+
+The gap that roadmap entry **does not** name, and that this analysis surfaces: **govkit has no delivery-side actor model.** "The Architect" and "the feature owner" appear throughout the payload as entities the agent must request things from, but neither is ever defined, and neither has any mechanism to signal approval that a machine could read. `governance/` contains schemas and templates only — no policy document, no roles file, no approval matrix — despite `l4-backend-api.md:16` instructing the agent to operate aligned to "governance rules under `governance/`".
+
+Until an approval can be *represented*, "autonomous but governed" has nowhere to live. The agent's only options are to stall or to forge.
+
+---
+
+## Open decisions
+
+1. Does a defect lane belong in govkit — a `fix`-shaped artifact set lighter than the five-artifact feature contract — or does the bug-fix agent stay outside the governance model by design?
+2. Should govkit gain a machine-readable approval representation (signed marker, CI-verified provenance) so `Accepted` is something other than a human typing a name into a template?
+3. Should any prediction-only gate become measured? The 4.0 floor is the most-cited element of govkit's value proposition and is currently unfalsifiable.
+
+---
+
+## Verification for any follow-on work
+
+- `./run_tests` (fast, ~20s), then `./full_test` for the e2e tier.
+- `pytest -k parity` plus `tests/test_agent_skills.py` — any payload change must land across all three agents in lockstep.
+- `.\scripts\smoke.ps1 -Agents claude-code -Levels 4 -Force` for a real apply-plus-validate sandbox.
+- For the repo-scope bug specifically: a failing test first, asserting the preflight and rule text accept the ``**Scope:** `single-repo` `` form the starters actually ship.

--- a/tests/test_adr_contract_consistency.py
+++ b/tests/test_adr_contract_consistency.py
@@ -1,0 +1,118 @@
+"""The ADR-authoring skills must teach the vocabulary and template the gates use.
+
+Two defects, both shipped to all three agents:
+
+1. **Status vocabulary drift.** `skills/backend/adr-author/SKILL.md` prescribed
+   `Proposed / Approved / Rejected / Deprecated`, while both ADR templates
+   prescribe `Proposed | Accepted | Rejected | Superseded`. The token the L4
+   governance rule gates implementation on — *"ADRs ... must be Accepted before
+   implementation proceeds"* — was absent from the vocabulary the ADR-authoring
+   skill handed the agent, and the skill told the agent to follow a template it
+   then contradicted. An agent resolving that contradiction has to invent.
+
+2. **Wrong template path.** All three `skills/ui/adr-author/SKILL.md` pointed at
+   `governance/ui/templates/architecture_preflight.md` — the *preflight* template,
+   not `docs/ui/architecture/ADR/TEMPLATE.md`.
+
+Fixing these authorizes nothing and closes no self-attestation gap. It removes an
+incoherence, which is worth doing on its own terms.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ADR_TEMPLATES = {
+    "backend": REPO_ROOT / "docs" / "backend" / "architecture" / "ADR" / "TEMPLATE.md",
+    "ui": REPO_ROOT / "docs" / "ui" / "architecture" / "ADR" / "TEMPLATE.md",
+}
+
+ADR_SKILLS = [
+    (layer, REPO_ROOT / "agents" / agent / "skills" / layer / "adr-author" / "SKILL.md")
+    for agent in ("claude-code", "codex", "copilot")
+    for layer in ("backend", "ui")
+]
+
+# Status tokens the templates do NOT define. `Deprecated` and a capitalised
+# `Approved` used as a status both drift from `Superseded` / `Accepted`.
+STALE_STATUS_TOKENS = ["Approved / Rejected", "Deprecated"]
+
+# The token `claude-md/l4-*.md` gates implementation on.
+GATE_TOKEN = "Accepted"
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def _canonical_statuses(layer: str) -> list[str]:
+    """Parse the `## Status` line out of the shipped ADR template."""
+    text = ADR_TEMPLATES[layer].read_text(encoding="utf-8")
+    match = re.search(r"^## Status\s*\n(.+)$", text, re.MULTILINE)
+    assert match, f"{_rel(ADR_TEMPLATES[layer])} has no parseable '## Status' line"
+    return [s.strip() for s in match.group(1).split("|")]
+
+
+@pytest.mark.parametrize("layer", sorted(ADR_TEMPLATES))
+def test_template_defines_the_gate_token(layer: str):
+    """Guard the premise: the gate keys on `Accepted`, so the template must offer it."""
+    assert GATE_TOKEN in _canonical_statuses(layer), (
+        f"{_rel(ADR_TEMPLATES[layer])} status vocabulary lacks '{GATE_TOKEN}', "
+        "which l4-*.md gates implementation on"
+    )
+
+
+def test_adr_skills_discovered():
+    """Non-vacuous guard."""
+    assert len(ADR_SKILLS) == 6, ADR_SKILLS
+    for _, path in ADR_SKILLS:
+        assert path.is_file(), f"missing {_rel(path)}"
+
+
+@pytest.mark.parametrize("layer, skill", ADR_SKILLS, ids=lambda v: v if isinstance(v, str) else _rel(v))
+def test_skill_uses_no_stale_status_token(layer: str, skill: Path):
+    text = skill.read_text(encoding="utf-8")
+    found = [t for t in STALE_STATUS_TOKENS if t in text]
+    assert not found, (
+        f"{_rel(skill)} uses status token(s) {found} that "
+        f"{_rel(ADR_TEMPLATES[layer])} does not define "
+        f"(canonical: {_canonical_statuses(layer)})"
+    )
+
+
+@pytest.mark.parametrize("layer, skill", ADR_SKILLS, ids=lambda v: v if isinstance(v, str) else _rel(v))
+def test_skill_teaches_the_gate_token(layer: str, skill: Path):
+    assert GATE_TOKEN in skill.read_text(encoding="utf-8"), (
+        f"{_rel(skill)} never mentions '{GATE_TOKEN}' — the status the L4 "
+        "governance rule requires before implementation may proceed"
+    )
+
+
+@pytest.mark.parametrize("layer, skill", ADR_SKILLS, ids=lambda v: v if isinstance(v, str) else _rel(v))
+def test_skill_points_at_an_adr_template(layer: str, skill: Path):
+    text = skill.read_text(encoding="utf-8")
+    assert "architecture/ADR/TEMPLATE.md" in text, (
+        f"{_rel(skill)} does not reference an ADR template path "
+        f"(expected something ending 'architecture/ADR/TEMPLATE.md')"
+    )
+    assert "templates/architecture_preflight.md" not in text, (
+        f"{_rel(skill)} points at the architecture-preflight template as though "
+        "it were the ADR template"
+    )
+
+
+@pytest.mark.parametrize("layer", ["backend", "ui"])
+def test_adr_skill_body_parity_across_agents(layer: str):
+    """[[feedback_agent_parity]] — the ADR skill must not drift between agents."""
+    bodies = {
+        path: path.read_text(encoding="utf-8")
+        for lyr, path in ADR_SKILLS
+        if lyr == layer
+    }
+    assert len(set(bodies.values())) == 1, (
+        f"{layer} adr-author SKILL.md differs across agents: "
+        f"{[_rel(p) for p in bodies]}"
+    )

--- a/tests/test_artifact_contract_consistency.py
+++ b/tests/test_artifact_contract_consistency.py
@@ -1,0 +1,126 @@
+"""Agent-facing artifact contracts must agree with the validator that enforces them.
+
+`cli/validate.py` enforces five artifacts at L4. The payload shipped four different
+counts beside it:
+
+* `rules/generic/spec-compliance.md` — "all **three** artifacts", installed to
+  `.claude/rules/govkit/spec-compliance.md` at L4/L5, right next to a governance
+  rule saying five.
+* `claude-md/l4-ui-*.md` and `agents-md/l4-ui-*.md` — **no artifact contract at
+  all**, while copilot's equivalent lists five. A claude-code L4 ui-react install
+  therefore had the 3-artifact rule as its *only* statement.
+* `features/README.md` and `claude-md/l4-ui-nextjs.md` — six for UI (the five plus
+  `design.md`).
+
+This is deliberately an **inclusion list**, not a repo-wide markdown scan. Most of
+the ~166 files naming these artifacts restate them correctly for their own level
+and type (L3 states none; the preflight template lists four because a preflight
+cannot require itself). A general "vertical parity" axis would need a per-file
+exemption allowlist that becomes its own drift surface. These are the files whose
+counts are known to contradict the validator.
+
+`design.md` is asserted only in **prose** for UI. It is deliberately advisory to
+`govkit validate` — see `tests/test_validate.py::
+test_ui_nextjs_design_artifact_is_advisory_to_completeness` and the comment at
+`cli/doctor.py`. Nothing here should make it enforced.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from cli.validate import L4_REQUIRED_ARTIFACTS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+UI_DESIGN_ARTIFACT = "design.md"
+
+# Generic rule shipped to every type at L4/L5 — must state the universal five.
+SPEC_COMPLIANCE_PATHS = [
+    REPO_ROOT / "agents" / "claude-code" / "rules" / "generic" / "spec-compliance.md",
+    REPO_ROOT / "agents" / "codex" / "rules" / "generic" / "spec-compliance.md",
+    REPO_ROOT
+    / "agents"
+    / "copilot"
+    / "instructions"
+    / "generic"
+    / "spec-compliance.instructions.md",
+]
+
+# Per-type L4 UI root instructions — must state the five plus design.md.
+UI_L4_PATHS = [
+    REPO_ROOT / "agents" / "claude-code" / "claude-md" / f"l4-{t}.md"
+    for t in ("ui-react", "ui-angular")
+] + [
+    REPO_ROOT / "agents" / "codex" / "agents-md" / f"l4-{t}.md"
+    for t in ("ui-react", "ui-angular")
+] + [
+    REPO_ROOT / "agents" / "copilot" / "copilot-instructions" / f"l4-{t}.md"
+    for t in ("ui-react", "ui-angular")
+]
+
+STALE_COUNTS = ["all three artifacts", "all four artifacts"]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def test_validator_contract_is_five():
+    """Guard the premise. If the enforced set changes, these expectations must be
+    revisited deliberately rather than silently drifting."""
+    assert len(L4_REQUIRED_ARTIFACTS) == 5, L4_REQUIRED_ARTIFACTS
+    assert UI_DESIGN_ARTIFACT not in L4_REQUIRED_ARTIFACTS, (
+        "design.md became validator-enforced; that reverses a pinned decision "
+        "and would fail features/ui_task_dashboard/, which ships without it"
+    )
+
+
+@pytest.mark.parametrize("path", SPEC_COMPLIANCE_PATHS, ids=_rel)
+def test_spec_compliance_lists_every_enforced_artifact(path: Path):
+    text = path.read_text(encoding="utf-8")
+    missing = [a for a in L4_REQUIRED_ARTIFACTS if a not in text]
+    assert not missing, (
+        f"{_rel(path)} omits enforced artifact(s) {missing} — an agent obeying "
+        "this rule stops short of what `govkit validate` requires"
+    )
+
+
+@pytest.mark.parametrize("path", SPEC_COMPLIANCE_PATHS + UI_L4_PATHS, ids=_rel)
+def test_no_stale_artifact_count(path: Path):
+    text = path.read_text(encoding="utf-8").lower()
+    found = [c for c in STALE_COUNTS if c in text]
+    assert not found, (
+        f"{_rel(path)} states {found} but the validator enforces "
+        f"{len(L4_REQUIRED_ARTIFACTS)}"
+    )
+
+
+@pytest.mark.parametrize("path", UI_L4_PATHS, ids=_rel)
+def test_ui_l4_declares_the_full_artifact_set(path: Path):
+    """claude-code and codex shipped no artifact contract for L4 UI at all, so the
+    generic 3-artifact rule was the user's only statement of the requirement."""
+    text = path.read_text(encoding="utf-8")
+    expected = list(L4_REQUIRED_ARTIFACTS) + [UI_DESIGN_ARTIFACT]
+    missing = [a for a in expected if a not in text]
+    assert not missing, (
+        f"{_rel(path)} does not name {missing} — UI features require the five "
+        "enforced artifacts plus design.md (features/README.md)"
+    )
+
+
+def test_ui_l4_artifact_contract_is_consistent_across_agents():
+    """[[feedback_agent_parity]] — all three agents must state the same UI contract."""
+    for variant in ("ui-react", "ui-angular"):
+        paths = [p for p in UI_L4_PATHS if p.name == f"l4-{variant}.md"]
+        assert len(paths) == 3, f"expected 3 agents for {variant}, got {paths}"
+        sets = {}
+        for p in paths:
+            text = p.read_text(encoding="utf-8")
+            sets[p] = frozenset(
+                a for a in list(L4_REQUIRED_ARTIFACTS) + [UI_DESIGN_ARTIFACT] if a in text
+            )
+        assert len(set(sets.values())) == 1, (
+            f"l4-{variant} artifact sets differ across agents: "
+            + ", ".join(f"{_rel(p)}={sorted(s)}" for p, s in sets.items())
+        )

--- a/tests/test_ci_govkit_dependency.py
+++ b/tests/test_ci_govkit_dependency.py
@@ -1,0 +1,83 @@
+"""A shipped CI gate that runs `govkit` must also install it, at a bounded version.
+
+Four gates invoked `govkit doctor` / `govkit validate` while setting up only Node
+(`ci/{github,azure}/ui-nextjs-quality-gate.yml` and their `l3-` variants). On a
+clean runner those steps exit 127, so the Next.js quality gate was red for every
+adopter that wired it up.
+
+The two gates that *did* install govkit installed it unpinned, which couples a
+customer's merge criteria to whatever PyPI serves that morning — while the payload
+prose beside it is frozen at install time. CI templates are `governed`, so
+`govkit upgrade` rewrites them; pinning to the shipping version means a contract
+change reaches a customer's gate only through an explicit upgrade.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CI_DIRS = [REPO_ROOT / "ci" / "github", REPO_ROOT / "ci" / "azure"]
+
+# `govkit <subcommand>` as an executed command, not a prose mention.
+INVOKES_RE = re.compile(r"^\s*(?:-\s*script:\s*|run:\s*)?govkit\s+(doctor|validate|apply|init)\b", re.MULTILINE)
+# A pinned install: govkit~=X.Y.Z (compatible-release, patch-only within the minor)
+PINNED_RE = re.compile(r"pip install\s+['\"]?govkit~=(\d+\.\d+\.\d+)['\"]?")
+# Any install at all, pinned or not.
+ANY_INSTALL_RE = re.compile(r"pip install\s+\S*govkit")
+
+
+def _project_version() -> str:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        return tomllib.load(fh)["project"]["version"]
+
+
+def _gates_invoking_govkit() -> list[Path]:
+    found = []
+    for d in CI_DIRS:
+        for path in sorted(d.glob("*.yml")):
+            if INVOKES_RE.search(path.read_text(encoding="utf-8")):
+                found.append(path)
+    return found
+
+
+GATES = _gates_invoking_govkit()
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def test_found_gates_that_invoke_govkit():
+    """Non-vacuous guard: if the detection regex stops matching, every
+    parametrized test below silently collects zero cases and passes."""
+    assert len(GATES) >= 6, (
+        f"expected at least 6 gates invoking govkit, found {[_rel(p) for p in GATES]}"
+    )
+
+
+@pytest.mark.parametrize("gate", GATES, ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_gate_installs_govkit_before_invoking_it(gate: Path):
+    text = gate.read_text(encoding="utf-8")
+    assert ANY_INSTALL_RE.search(text), (
+        f"{_rel(gate)} runs a govkit subcommand but never installs govkit — "
+        "on a clean runner the step exits 127"
+    )
+
+
+@pytest.mark.parametrize("gate", GATES, ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_gate_pins_govkit_to_shipping_version(gate: Path):
+    """An unpinned install makes a customer's merge criteria depend on whatever
+    PyPI served that morning, against payload prose frozen at install time."""
+    text = gate.read_text(encoding="utf-8")
+    match = PINNED_RE.search(text)
+    assert match, (
+        f"{_rel(gate)} installs govkit without a bounded version — "
+        "use `pip install govkit~=<version>` so the gate cannot change under the customer"
+    )
+    assert match.group(1) == _project_version(), (
+        f"{_rel(gate)} pins govkit~={match.group(1)} but this project ships "
+        f"{_project_version()} — the shipped gate and the shipping validator must agree"
+    )

--- a/tests/test_eval_gate_checks.py
+++ b/tests/test_eval_gate_checks.py
@@ -1,0 +1,139 @@
+"""Behavior tests for the eval-gate embedded prediction checker.
+
+The gate globs `features/*/plan.md` with no `starter_*` exclusion, while
+`cli/features.py::list_user_features` filters starters and
+`ci/*/data-common-gate.yml` skips them explicitly in shell. The manifest ships
+`features/starter_backend/` — whose `plan.md` carries an all-`null` prediction
+block *by design* — alongside this gate, so a team following the gate's own
+header instruction ("copy this file to .github/workflows/") gets a red gate on
+day one, for a file govkit itself wrote.
+
+Following `tests/test_dbt_gate_checks.py`: extract the heredoc, execute it against
+fixtures, and pin the two platform embeddings identical so they cannot drift.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_PATHS = {
+    "github": REPO_ROOT / "ci" / "github" / "eval-gate.yml",
+    "azure": REPO_ROOT / "ci" / "azure" / "eval-gate.yml",
+}
+
+GOOD_PREDICTION = """```yaml
+evaluation_prediction:
+  first:
+    fast:           { score: 5, evidence: "no io" }
+    isolated:       { score: 4, evidence: "no shared state" }
+    repeatable:     { score: 4, evidence: "deterministic" }
+    self_verifying: { score: 5, evidence: "explicit asserts" }
+    timely:         { score: 4, evidence: "tests first" }
+    average: 4.4
+  virtues:
+    working:   { score: 5, evidence: "green" }
+    unique:    { score: 4, evidence: "one owner" }
+    simple:    { score: 4, evidence: "few paths" }
+    clear:     { score: 4, evidence: "named well" }
+    easy:      { score: 4, evidence: "small delta" }
+    developed: { score: 4, evidence: "typed" }
+    brief:     { score: 4, evidence: "terse" }
+    average: 4.14
+  thresholds_met: true
+```
+"""
+
+LOW_PREDICTION = GOOD_PREDICTION.replace("{ score: 5, evidence: \"no io\" }", "{ score: 1, evidence: \"slow\" }").replace(
+    "average: 4.4", "average: 3.0"
+)
+
+
+def _extract_first_heredoc(gate_path: Path) -> str:
+    """Pull the first python heredoc body out of the gate, de-indented."""
+    raw = gate_path.read_text(encoding="utf-8")
+    marker = "python - <<'EOF'\n"
+    start = raw.index(marker) + len(marker)
+    body = []
+    for line in raw[start:].splitlines():
+        if line.strip() == "EOF":
+            break
+        body.append(line)
+    return textwrap.dedent("\n".join(body)) + "\n"
+
+
+def _run_gate(tmp_path: Path, features: dict[str, str]) -> subprocess.CompletedProcess:
+    for name, plan in features.items():
+        d = tmp_path / "features" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "plan.md").write_text(f"# Plan\n\n{plan}", encoding="utf-8")
+    script = tmp_path / "_gate.py"
+    script.write_text(_extract_first_heredoc(GATE_PATHS["github"]), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(script)], cwd=tmp_path, capture_output=True, text=True
+    )
+
+
+def test_heredoc_extraction_is_not_empty():
+    """Non-vacuous guard: if the marker changes, every test below would run an
+    empty script and trivially pass."""
+    body = _extract_first_heredoc(GATE_PATHS["github"])
+    assert "evaluation_prediction" in body and "glob" in body, body[:400]
+
+
+def test_complete_prediction_passes(tmp_path: Path):
+    result = _run_gate(tmp_path, {"real_feature": GOOD_PREDICTION})
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_below_threshold_prediction_fails(tmp_path: Path):
+    result = _run_gate(tmp_path, {"real_feature": LOW_PREDICTION})
+    assert result.returncode == 1, result.stdout + result.stderr
+
+
+def test_shipped_starter_does_not_fail_the_gate(tmp_path: Path):
+    """`features/starter_backend/plan.md` ships an all-null prediction block on
+    purpose. The gate must skip starters the way `list_user_features` does."""
+    starter_plan = (REPO_ROOT / "features" / "starter_backend" / "plan.md").read_text(
+        encoding="utf-8"
+    )
+    (tmp_path / "features" / "starter_backend").mkdir(parents=True)
+    (tmp_path / "features" / "starter_backend" / "plan.md").write_text(
+        starter_plan, encoding="utf-8"
+    )
+    script = tmp_path / "_gate.py"
+    script.write_text(_extract_first_heredoc(GATE_PATHS["github"]), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(script)], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        "eval-gate fails on govkit's own shipped starter:\n" + result.stdout + result.stderr
+    )
+
+
+def test_starter_skipped_but_real_feature_still_checked(tmp_path: Path):
+    """The exclusion must not become a blanket escape — a real feature alongside
+    a starter is still evaluated."""
+    starter_plan = (REPO_ROOT / "features" / "starter_backend" / "plan.md").read_text(
+        encoding="utf-8"
+    )
+    (tmp_path / "features" / "starter_backend").mkdir(parents=True)
+    (tmp_path / "features" / "starter_backend" / "plan.md").write_text(
+        starter_plan, encoding="utf-8"
+    )
+    result = _run_gate(tmp_path, {"real_feature": LOW_PREDICTION})
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "real_feature" in result.stdout, result.stdout
+
+
+def test_platform_embeddings_are_identical():
+    github = _extract_first_heredoc(GATE_PATHS["github"])
+    azure = _extract_first_heredoc(GATE_PATHS["azure"])
+    assert github == azure, (
+        "github and azure eval-gate checkers have drifted; they must stay identical"
+    )

--- a/tests/test_repo_scope_form.py
+++ b/tests/test_repo_scope_form.py
@@ -1,0 +1,147 @@
+"""Repository Scope declaration must use one form across the whole payload.
+
+Three vocabularies shipped for the same concept:
+
+1. Rule files said `"This feature is contained to" has a checked box` — a phrase
+   that appears in **no** shipped artifact, so a literal-minded agent HALTs on a
+   correctly-filled `nfrs.md`.
+2. Preflight skills and the guidance doc said `One box is checked: "This
+   repository only" OR "Multiple repositories"` — matching only `starter_data`.
+3. Every other starter, the worked example, and `ci/*/repo-scope-check.yml`
+   use ``**Scope:** `single-repo` ``.
+
+The CI gate is authoritative: it greps `^\\*\\*Scope:\\*\\*` and fails without it.
+These tests pin form 3 everywhere, and pin the starters to what that gate accepts
+so `govkit init` cannot emit a feature that fails its own repository's gate.
+
+Per [[feedback_agent_parity]], the rule text is checked across all three agents.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The form the shipped CI gate accepts: **Scope:** `single-repo` | `multi-repo`
+SCOPE_LINE_RE = re.compile(r"^\*\*Scope:\*\*\s*`(single-repo|multi-repo)`", re.MULTILINE)
+
+# Phrases that reference a representation nothing in the payload emits.
+STALE_PHRASES = [
+    "This feature is contained to",
+    'One box is checked: "This repository only"',
+]
+
+RULE_PATHS = [
+    REPO_ROOT / "agents" / "claude-code" / "rules" / "generic" / f"repo-scope-{layer}.md"
+    for layer in ("backend", "ui")
+] + [
+    REPO_ROOT / "agents" / "codex" / "rules" / "generic" / f"repo-scope-{layer}.md"
+    for layer in ("backend", "ui")
+] + [
+    REPO_ROOT
+    / "agents"
+    / "copilot"
+    / "instructions"
+    / "generic"
+    / f"repo-scope-{layer}.instructions.md"
+    for layer in ("backend", "ui")
+]
+
+PREFLIGHT_PATHS = [
+    REPO_ROOT / "agents" / agent / "skills" / layer / "architecture-preflight" / "SKILL.md"
+    for agent in ("claude-code", "codex", "copilot")
+    for layer in ("backend", "ui")
+]
+
+GUIDANCE_PATH = REPO_ROOT / "docs" / "REPO_SCOPE_ANALYSIS_GUIDANCE.md"
+
+STARTER_NFRS = sorted((REPO_ROOT / "features").glob("starter_*/nfrs.md"))
+
+GATE_PATHS = [
+    REPO_ROOT / "ci" / "github" / "repo-scope-check.yml",
+    REPO_ROOT / "ci" / "azure" / "repo-scope-check.yml",
+]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def test_starter_nfrs_discovered():
+    """Guard against the glob silently matching nothing (a vacuous suite)."""
+    assert len(STARTER_NFRS) >= 4, (
+        f"expected several starter nfrs.md files, found {[_rel(p) for p in STARTER_NFRS]}"
+    )
+
+
+@pytest.mark.parametrize("gate_path", GATE_PATHS, ids=lambda p: p.parent.name)
+def test_gate_still_requires_the_scope_line(gate_path: Path):
+    """Pin this suite to the shipped gate.
+
+    If the gate ever stops enforcing `**Scope:**`, these tests are asserting a
+    contract nothing enforces and must be revisited rather than silently passing.
+    """
+    assert r"^\*\*Scope:\*\*" in gate_path.read_text(encoding="utf-8"), (
+        f"{_rel(gate_path)} no longer greps for '**Scope:**' — "
+        "the canonical repo-scope form changed; update this test suite deliberately"
+    )
+
+
+@pytest.mark.parametrize("nfrs_path", STARTER_NFRS, ids=lambda p: p.parent.name)
+def test_starter_nfrs_uses_scope_declaration(nfrs_path: Path):
+    """`govkit init` copies a starter verbatim into a non-`starter_*` directory,
+    where the CI gate no longer skips it. A starter that lacks the `**Scope:**`
+    line therefore produces a feature that fails repo-scope-check on day one."""
+    text = nfrs_path.read_text(encoding="utf-8")
+    assert SCOPE_LINE_RE.search(text), (
+        f"{_rel(nfrs_path)} has no '**Scope:** `single-repo`' line — a feature "
+        "created from this starter fails ci/*/repo-scope-check.yml"
+    )
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    RULE_PATHS + PREFLIGHT_PATHS + [GUIDANCE_PATH],
+    ids=_rel,
+)
+def test_no_stale_scope_vocabulary(doc_path: Path):
+    """Agent-facing text must not instruct the agent to look for a representation
+    the payload never emits — that produces a false HALT on a correct file."""
+    text = doc_path.read_text(encoding="utf-8")
+    found = [phrase for phrase in STALE_PHRASES if phrase in text]
+    assert not found, (
+        f"{_rel(doc_path)} references a repo-scope form nothing emits: {found}"
+    )
+
+
+@pytest.mark.parametrize("doc_path", RULE_PATHS + PREFLIGHT_PATHS, ids=_rel)
+def test_agent_text_names_the_canonical_form(doc_path: Path):
+    """The rule and preflight text must name the form the starters and the gate
+    actually use, so the completeness check the agent runs can succeed."""
+    text = doc_path.read_text(encoding="utf-8")
+    assert "**Scope:**" in text, (
+        f"{_rel(doc_path)} never mentions the '**Scope:**' declaration the "
+        "starters emit and ci/*/repo-scope-check.yml enforces"
+    )
+
+
+def test_rule_scope_check_is_identical_across_agents():
+    """[[feedback_agent_parity]] — the completeness checklist must not drift
+    between the three agents."""
+    by_layer: dict[str, dict[Path, str]] = {"backend": {}, "ui": {}}
+    for path in RULE_PATHS:
+        layer = "backend" if "backend" in path.name else "ui"
+        text = path.read_text(encoding="utf-8")
+        start = text.find("## Repository Scope Clarity")
+        assert start != -1, f"{_rel(path)} missing '## Repository Scope Clarity'"
+        end = text.find("\n---", start)
+        by_layer[layer][path] = text[start : end if end != -1 else len(text)].strip()
+
+    for layer, sections in by_layer.items():
+        distinct = set(sections.values())
+        assert len(distinct) == 1, (
+            f"{layer} repo-scope checklist differs across agents: "
+            f"{[_rel(p) for p in sections]}"
+        )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -660,6 +660,129 @@ class TestCheckPlanEvalPrediction:
         ok, msg = check_plan_eval_prediction(tmp_path)
         assert ok is CheckStatus.PASS, msg
 
+
+class TestPredictionInternalConsistency:
+    """The declared `average:` was never checked against the scores beside it, so
+    a plan could claim 4.5 over scores averaging 3.1. Cross-check only where
+    individual scores are present; declared-only plans stay valid."""
+
+    def test_declared_average_contradicting_its_scores_fails(self, tmp_path):
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yaml
+            evaluation_prediction:
+              first:
+                fast: {score: 3, evidence: "x"}
+                isolated: {score: 3, evidence: "x"}
+                repeatable: {score: 3, evidence: "x"}
+                self_verifying: {score: 3, evidence: "x"}
+                timely: {score: 3, evidence: "x"}
+                average: 4.5
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.FAIL
+        assert "first" in msg and "4.5" in msg
+
+    def test_rounded_declared_average_is_tolerated(self, tmp_path):
+        """31/7 = 4.4285... declared as 4.4 — one-decimal rounding, not a lie.
+        `features/ui_task_dashboard/plan.md` declares 4.71 for 33/7 = 4.7142..."""
+        write(tmp_path / "plan.md", VALID_PLAN)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.PASS, msg
+
+    def test_declared_only_plan_still_passes(self, tmp_path):
+        """Backward compatibility: no individual scores means nothing to cross-check."""
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yaml
+            evaluation_prediction:
+              first:
+                average: 4.6
+              virtues:
+                average: 4.4
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.PASS, msg
+
+    def test_individual_score_below_three_fails(self, tmp_path):
+        """FIRST_SCORING_RUBRIC.md: 'Fail: average < 4.0 OR any individual score
+        below 3'. Only the average half was enforced."""
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yaml
+            evaluation_prediction:
+              first:
+                fast: {score: 5, evidence: "x"}
+                isolated: {score: 5, evidence: "x"}
+                repeatable: {score: 5, evidence: "x"}
+                self_verifying: {score: 5, evidence: "x"}
+                timely: {score: 2, evidence: "flaky"}
+                average: 4.4
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.FAIL
+        assert "below 3" in msg
+
+    def test_ui_shape_is_cross_checked(self, tmp_path):
+        """governance/ui/templates/plan.md nests scores under
+        `component_tests.FIRST_scores` and declares `predicted_average`."""
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yaml
+            evaluation_prediction:
+              component_tests:
+                FIRST_scores:
+                  fast: { score: 3, rationale: "" }
+                  isolated: { score: 3, rationale: "" }
+                  repeatable: { score: 3, rationale: "" }
+                  self_verifying: { score: 3, rationale: "" }
+                  timely: { score: 3, rationale: "" }
+                predicted_average: 4.8
+              accessibility:
+                predicted_axe_violations: 0
+                wcag_level: AA
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.FAIL
+        assert "component_tests" in msg
+
+    def test_ui_shape_consistent_prediction_passes(self, tmp_path):
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yaml
+            evaluation_prediction:
+              component_tests:
+                FIRST_scores:
+                  fast: { score: 5, rationale: "" }
+                  isolated: { score: 4, rationale: "" }
+                  repeatable: { score: 4, rationale: "" }
+                  self_verifying: { score: 5, rationale: "" }
+                  timely: { score: 4, rationale: "" }
+                predicted_average: 4.4
+              accessibility:
+                predicted_axe_violations: 0
+                wcag_level: AA
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.PASS, msg
+
+    def test_shipped_worked_example_still_passes(self, tmp_path):
+        """Non-vacuous guard against tightening the check past govkit's own payload."""
+        repo_root = Path(__file__).resolve().parent.parent
+        example = repo_root / "features" / "ui_task_dashboard"
+        ok, msg = check_plan_eval_prediction(example)
+        assert ok is CheckStatus.PASS, msg
+
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_plan_eval_prediction(tmp_path)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -289,6 +289,54 @@ class TestCheckNfrsNoTbd:
         ok, msg = check_nfrs_no_tbd(tmp_path)
         assert ok is CheckStatus.PASS  # \bTBD\b won't match TBDATA
 
+    def test_self_referential_prose_is_not_a_placeholder(self, tmp_path):
+        """`features/ui_task_dashboard/nfrs.md` documents the rule in prose, and
+        the bare \\bTBD\\b scan matched its own documentation — failing
+        `govkit validate` on govkit's own shipped worked example."""
+        write(tmp_path / "nfrs.md", """\
+            ## Performance
+            - p95 latency < 200ms
+            - No TBD entries are permitted in this file before Architecture Preflight begins
+
+            Replace every **TBD** with a real value before this feature ships.
+        """)
+        ok, msg = check_nfrs_no_tbd(tmp_path)
+        assert ok is CheckStatus.PASS, msg
+
+    def test_placeholder_still_caught_beside_prose(self, tmp_path):
+        """The exemption must not become an escape hatch."""
+        write(tmp_path / "nfrs.md", """\
+            ## Performance
+            - No TBD entries are permitted in this file
+
+            ## Availability
+            - TBD
+        """)
+        ok, msg = check_nfrs_no_tbd(tmp_path)
+        assert ok is CheckStatus.FAIL
+        assert "5" in msg  # the bare placeholder line, not the prose line
+
+    def test_placeholder_shapes_used_by_real_features(self, tmp_path):
+        """Table cells and mid-sentence placeholders are real forms in
+        features/*/nfrs.md and must all still fail."""
+        for line in (
+            "- TBD",
+            "Lineage destination: TBD (Datahub / OpenLineage — pick one).",
+            "| Consent tracking | TBD (does source carry consent flags?) |",
+            "| Rolling 7-day median | Baseline TBD after 2 weeks |",
+        ):
+            write(tmp_path / "nfrs.md", f"## Performance\n{line}\n")
+            ok, msg = check_nfrs_no_tbd(tmp_path)
+            assert ok is CheckStatus.FAIL, f"placeholder not caught: {line!r}"
+
+    def test_shipped_worked_example_has_no_placeholders(self, tmp_path):
+        """Non-vacuous end-to-end guard: the worked example ships in every
+        ui-react/ui-angular manifest and is not starter-prefixed, so
+        `list_user_features` validates it in customer repos."""
+        repo_root = Path(__file__).resolve().parent.parent
+        ok, msg = check_nfrs_no_tbd(repo_root / "features" / "ui_task_dashboard")
+        assert ok is CheckStatus.PASS, msg
+
 
 # ---------------------------------------------------------------------------
 # check_nfrs_sections

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -621,6 +621,45 @@ class TestCheckPlanEvalPrediction:
         assert ok is CheckStatus.FAIL
         assert "3.5" in msg
 
+    def test_unrelated_earlier_yaml_block_is_not_absorbed(self, tmp_path):
+        """The block pattern anchored on the *first* ```yaml fence and let `.*?`
+        run past intervening fences, so an unrelated earlier block's `: null` was
+        reported as an evaluation_prediction null."""
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yaml
+            rollout:
+              canary_percent: null
+            ```
+
+            ```yaml
+            evaluation_prediction:
+              first:
+                average: 4.6
+              virtues:
+                average: 4.4
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.PASS, msg
+
+    def test_yml_fence_is_accepted(self, tmp_path):
+        """```yml is as valid as ```yaml and must resolve the same block."""
+        write(tmp_path / "plan.md", """\
+            # Plan
+
+            ```yml
+            evaluation_prediction:
+              first:
+                average: 4.6
+              virtues:
+                average: 4.4
+            ```
+        """)
+        ok, msg = check_plan_eval_prediction(tmp_path)
+        assert ok is CheckStatus.PASS, msg
+
     def test_missing_file(self, tmp_path):
         tmp_path.mkdir(exist_ok=True)
         ok, msg = check_plan_eval_prediction(tmp_path)


### PR DESCRIPTION
## What

Fixes eight defects in the govkit payload and CI templates — six of which break adopters today, with a human present — plus a self-consistency gap in `govkit validate`.

## Why

While assessing whether an autonomous bug-fix agent could work against a govkit-governed L4 repo, a review of the enforcement surface turned up shipped defects unrelated to autonomy. They share a shape: **govkit's own payload fails govkit's own gates.**

- `govkit validate` fails on `features/ui_task_dashboard/`, a worked example govkit installs into every ui-react/ui-angular repo. It is a project artifact, so `upgrade` can never repair it.
- Four Next.js CI gates run `govkit doctor`/`govkit validate` with no Python and no install — exit 127 on a clean runner.
- `govkit init --starter data` emits a `nfrs.md` that fails `repo-scope-check`.
- The repo-scope rule tells the agent to look for a phrase that appears in no shipped artifact, so it HALTs on correctly-filled files.

Separately, `check_plan_eval_prediction` read a declared `average:` and never compared it with the scores in the same block, so a plan could claim 4.5 over scores averaging 3.1.

## Changes

**Payload (all three agents, in lockstep)**
- Reconcile repo-scope rule, preflight skills and guidance to the ``**Scope:** `single-repo` `` form the starters emit and `repo-scope-check` enforces; normalise `starter_data`
- `spec-compliance.md` said "all three artifacts" while the validator enforces five, installed side by side at L4/L5 — now lists all five
- claude-code and codex shipped **no** artifact contract for L4 UI while copilot listed five; all three now state the five plus `design.md`
- ADR skills taught `Proposed / Approved / Rejected / Deprecated`; the templates and the gate require `Accepted`. UI ADR skill pointed at the *preflight* template

**CI templates**
- Add a pinned `govkit~=0.18.0` install to the four gates that invoke govkit without one; replace two unpinned installs
- `eval-gate` now skips `starter_*` (it failed on govkit's own starter) and derives feature names with `Path.parent.name` instead of `split("/")`, which crashed on Windows

**Validator (`cli/validate.py`)**
- Prediction-block pattern no longer spans yaml fences (an unrelated earlier block's `: null` was reported as a prediction null)
- Cross-check each declared average against the scores beneath it, tolerance `0.05` for legitimate rounding; enforce the rubric's "no individual score below 3", which was never checked
- `check_nfrs_no_tbd` exempts self-referential prose (`**TBD**`, "TBD entries") while still catching all four real placeholder shapes

**Docs**
- `CONTRIBUTING.md`: record that a version bump must update the `govkit~=` pin in every CI template; fix `pip install -e ".[dev]"` → `".[test]"` (no `[dev]` extra exists)
- `plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md`: the assessment this work came out of

`design.md` is deliberately **not** added to any enforced list — `ui_task_dashboard` ships without it and its advisory status is pinned by an existing test.

## Testing

```bash
./run_tests    # 2401 passed
./full_test    # + 134 e2e passed (16 skips: no JDK/Maven locally)
```

Five new suites, each written failing-first: `test_repo_scope_form.py`, `test_ci_govkit_dependency.py`, `test_artifact_contract_consistency.py`, `test_adr_contract_consistency.py`, `test_eval_gate_checks.py` (extracts the gate heredoc and executes it against fixtures), plus two new classes in `test_validate.py`.

Verified against the real CLI on a sandbox L4 install, not just unit tests:

```bash
govkit validate --target <sandbox>
# honest plan          -> PASS  evaluation_prediction averages OK (4.8, 4.71)
# declared 4.95        -> FAIL  virtues declares 4.95 but its scores average 4.71
# one score of 2       -> FAIL  individual score(s) below 3: first=2
# ui_task_dashboard    -> 7/7 PASS (previously failed on its own documentation)
```

Note for reviewers: CI has not run these changes on Linux before this PR — everything above was executed on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)