### PR TITLE
feat: add the defect lane — a risk-tiered fix contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **Defect lane.** A change that restores already-established behavior now
+  carries one schema-backed record — `fixes/<id>/fix.yaml` — instead of the
+  five-artifact feature contract. `govkit fix init <id>` scaffolds it,
+  `govkit validate` checks it, and `/govkit-fix-record` walks the agent through
+  eligibility before any code is written. L4+; L3 keeps no artifact model.
+- `governance/schemas/fix_record.schema.json` — area-agnostic, shipped as a
+  governed file to every project type.
+- `ci/{github,azure}/fix-lane-gate.yml` — the only gate with the diff, and so
+  the only one that can catch a source change carrying no governance at all.
+  Inactive until `SOURCE_PATHS` is configured, mirroring `repo-scope-check`.
+
+### Changed
+
+- `govkit validate` now reports a second artifact family alongside features,
+  following the extensions precedent: silent when absent, own exit code.
+- `PARITY_TEST.md`'s skill inventory said 11 skills / 33 files against an actual
+  12 / 36. Corrected, and a test now pins it so the stated count cannot drift.
+- `ci/README.md`'s workflow matrix listed three Next.js rows twice.
+
 ## [0.18.0] — 2026-08-12
 
 The React and Angular UI doc sets become individually fully functional —

--- a/PARITY_TEST.md
+++ b/PARITY_TEST.md
@@ -58,7 +58,7 @@ What "leakage" specifically means:
 
 Every `SKILL.md` across `agents/{claude-code,codex,copilot}/skills/**/` ships **frontmatter that is byte-identical** for the same skill across agents. The Open Skills format is the lowest common denominator — `name:` + `description:` only, no `argument-hint:` or `user-invocable:` extensions.
 
-The 11 skills (7 backend + 4 UI) × 3 agents = 33 SKILL.md files. `tests/test_govkit.py::TestNoUiDimensionInManifests` and the skill-resolution tests lock this in.
+The 12 skills (8 backend + 4 UI) × 3 agents = 36 SKILL.md files. `tests/test_govkit.py::TestNoUiDimensionInManifests` and the skill-resolution tests lock this in.
 
 ### 4. Agent-specific loader behavior
 

--- a/README.md
+++ b/README.md
@@ -185,8 +185,9 @@ Backend installs ship no UI artifacts; UI installs ship no backend artifacts. Th
 | `govkit apply` | Install / scaffold governance into your project. Detects your stack, writes the `.govkit` marker. |
 | `govkit calibrate` | Guided, type-aware review to make installed defaults match your repo. UI reviews include brand readiness; `--non-interactive` writes a checklist file and `--only <step>` revisits one decision. |
 | `govkit doctor` | Read-only **governance-fit** checks (rule globs, CI/stack/language/framework fit, stale baselines, extensions, and the Next.js database boundary). Run once you have source code, and in CI. Monorepo-aware. |
-| `govkit validate` | Level-aware **per-feature** compliance check (artifact existence, Gherkin structure, NFR coverage, eval-criteria schema, prediction thresholds). No-op at L3. |
+| `govkit validate` | Level-aware compliance check over **features** (artifact existence, Gherkin structure, NFR coverage, eval-criteria schema, prediction thresholds) and **fix records** (schema, eligibility conditions). No-op at L3. |
 | `govkit init <feature>` | Scaffold a new feature folder from the appropriate starter (L4+). |
+| `govkit fix init <id>` | Scaffold a defect-lane fix record at `fixes/<id>/fix.yaml` (L4+) — one artifact instead of five, for a change that restores already-established behavior. |
 | `govkit stack` | `stack list` shows bundled tech-stack overlays; `stack apply <id>` swaps the stack on an existing install. |
 | `govkit extension` | `extension list` shows bundled extension packs; `extension add <id> --target <path>` copies one into your project's `extensions/<id>/`. |
 | `govkit upgrade` | Refresh the files govkit owns (contracts, CI gates, templates) to a new version without touching the files you own. |
@@ -354,6 +355,63 @@ The lifecycle is identical across agents; only the invocation syntax differs.
 | Implementation plan | `/govkit-implementation-plan my_feature` | `/govkit-implementation-plan` | `$govkit-implementation-plan my_feature` |
 
 Copilot infers the feature from context rather than taking it as an argument; Codex invokes skills with a `$` prefix.
+
+---
+
+## The defect lifecycle
+
+Not every change is a feature. A bug fix that **restores behavior something
+already established** carries one record instead of five artifacts.
+
+The distinction is not size — it is whether the behavior was already specified.
+A three-line change that introduces a capability is a feature; a hundred-line
+change that makes the code finally do what the contract always said is a defect.
+
+### Step 1: Confirm it qualifies
+
+All four must hold. If any fails, use the feature lifecycle above instead — and,
+where the contract requires one, an ADR.
+
+| # | Condition | How it is checked |
+|---|---|---|
+| 1 | Restores behavior an existing requirement, contract, ADR, or spec established | You declare it; `govkit validate` requires the cited source to resolve |
+| 2 | Includes a reproduction or regression test | `validate` requires the test path to resolve; CI requires the diff to carry one |
+| 3 | Introduces no new intended behavior | You declare it |
+| 4 | Does not change architecture, security/auth, data handling, public contracts, NFRs, or cross-service ownership | Declared per area, and contradicted from the changed paths where govkit owns the namespace |
+
+### Step 2: Write the failing test
+
+Reproduce the defect first. A fix whose test never failed has not been shown to
+fix anything.
+
+### Step 3: Scaffold the record
+
+```bash
+govkit fix init task-filter-reset --target .
+```
+
+Then complete `fixes/task-filter-reset/fix.yaml`. Ask the agent for help with
+`/govkit-fix-record`.
+
+### Step 4: Fix, validate, and open the PR
+
+```bash
+govkit validate --target .
+```
+
+**Be clear about what this buys.** Conditions 1 and 3 are declarations the
+tooling cannot verify — `validate` checks that your cited source resolves, not
+that it says what you claim. The record makes those claims explicit and narrow
+so a reviewer can check them in seconds. That is a real gain over five documents
+of prose, and it is not the same thing as proof.
+
+### Closing the code-only gap
+
+`govkit validate` iterates artifacts that already exist, so a PR that changes
+source and creates none passes it untouched. `ci/*/fix-lane-gate.yml` is the
+only gate that can see that, because it is the only one with the diff. It is
+**inactive until you set `SOURCE_PATHS`** in the workflow, so a fresh install
+stays green — see [ci/README.md](ci/README.md).
 
 ---
 

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -47,7 +47,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/govkit/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".claude/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_backend/",
@@ -58,7 +59,8 @@
             "docs/backend/guides/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -84,7 +86,8 @@
             { "src": "skills/backend/adr-author/", "dest": ".claude/skills/govkit-adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".claude/skills/govkit-genai-preflight/" },
             { "src": "skills/backend/eval-suite-planning/", "dest": ".claude/skills/govkit-eval-suite-planning/" },
-            { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/govkit-multi-agent-design/" }
+            { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/govkit-multi-agent-design/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_backend_l5/",
@@ -94,7 +97,8 @@
             "docs/backend/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -121,7 +125,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/govkit/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".claude/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_cli/"
@@ -131,7 +136,8 @@
             "docs/backend/guides/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -157,7 +163,8 @@
             { "src": "skills/backend/adr-author/", "dest": ".claude/skills/govkit-adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".claude/skills/govkit-genai-preflight/" },
             { "src": "skills/backend/eval-suite-planning/", "dest": ".claude/skills/govkit-eval-suite-planning/" },
-            { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/govkit-multi-agent-design/" }
+            { "src": "skills/backend/multi-agent-design/", "dest": ".claude/skills/govkit-multi-agent-design/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_cli_l5/"
@@ -166,7 +173,8 @@
             "docs/backend/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -193,7 +201,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/govkit/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".claude/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -201,7 +210,8 @@
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -215,7 +225,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".claude/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".claude/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -228,7 +239,8 @@
             "docs/ui/architecture/react/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -255,7 +267,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/govkit/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".claude/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -263,7 +276,8 @@
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -277,7 +291,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".claude/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".claude/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -290,7 +305,8 @@
             "docs/ui/architecture/angular/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -317,14 +333,16 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/govkit/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".claude/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui_nextjs/"
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -338,7 +356,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".claude/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".claude/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".claude/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".claude/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui_nextjs/"
@@ -350,7 +369,8 @@
             "docs/ui/architecture/nextjs/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -377,13 +397,15 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".claude/rules/govkit/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".claude/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".claude/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".claude/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_data/"
           ],
           "governed": [
-            "governance/data/schemas/"
+            "governance/data/schemas/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       }
@@ -431,13 +453,19 @@
           "shared": [],
           "governed": [],
           "by_type": {
-            "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
-            "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
-            "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml"] },
+            "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
             "data":       {
-              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
+                "ci/github/fix-lane-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
@@ -459,7 +487,8 @@
                 "ci/github/deepeval-gate.yml",
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
-                "ci/github/promptfoo-gate.yml"
+                "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -477,7 +506,8 @@
                 "ci/github/deepeval-gate.yml",
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
-                "ci/github/promptfoo-gate.yml"
+                "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -494,7 +524,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
@@ -503,7 +534,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/github/ui-nextjs-quality-gate.yml",
@@ -511,7 +543,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] }
           }
         }
@@ -558,13 +591,19 @@
           "shared": [],
           "governed": [],
           "by_type": {
-            "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
-            "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
-            "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml"] },
+            "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
             "data":       {
-              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
+                "ci/azure/fix-lane-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
@@ -586,7 +625,8 @@
                 "ci/azure/deepeval-gate.yml",
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
-                "ci/azure/promptfoo-gate.yml"
+                "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -604,7 +644,8 @@
                 "ci/azure/deepeval-gate.yml",
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
-                "ci/azure/promptfoo-gate.yml"
+                "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -621,7 +662,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
@@ -630,7 +672,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/azure/ui-nextjs-quality-gate.yml",
@@ -638,7 +681,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] }
           }
         }

--- a/agents/claude-code/rules/generic/spec-compliance.md
+++ b/agents/claude-code/rules/generic/spec-compliance.md
@@ -18,6 +18,24 @@ Every feature must live under `features/<feature_name>/` with these required art
 
 Implementation must not begin unless all five artifacts exist and are complete.
 
+## Defect fixes
+
+A change that *restores* behavior an existing requirement, contract, ADR, or
+spec already established may use the fix lane instead of the five artifacts
+above: one record at `fixes/<id>/fix.yaml`, scaffolded by `govkit fix init <id>`.
+
+It qualifies only when all four hold:
+
+- It restores established behavior, and names the source that established it
+- It includes a reproduction or regression test
+- It introduces no new intended behavior
+- It does not change architecture, security/auth, data handling, public
+  contracts, NFRs, or cross-service ownership
+
+If any of those fails, the change belongs in the feature lane above — and, where
+the contract requires one, behind an ADR. Declaring a risk flag `true` does not
+waive it; it moves the change out of this lane.
+
 ## Gherkin Conventions
 
 - Every `acceptance.feature` must have a `Feature:` keyword, at least one `Scenario:`, and Given/When/Then steps

--- a/agents/claude-code/skills/backend/fix-record/SKILL.md
+++ b/agents/claude-code/skills/backend/fix-record/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: govkit-fix-record
+description: Author a fix record for a defect that restores already-established behavior. Use when the user reports a bug, asks to fix a defect, or invokes /govkit-fix-record.
+---
+
+# Fix Record
+
+Author the fix record for a reported defect. When invoked, determine the defect from the user's request; if it is not described, ask before proceeding.
+
+A defect that restores behavior something already established carries one record — `fixes/<id>/fix.yaml` — instead of the five-artifact feature contract. A change that introduces behavior does not qualify, however small it looks.
+
+## Check eligibility first
+
+All four conditions must hold. Decide this **before** writing any code or any record — a change that fails one belongs in the feature lane, and finding that out after the fix is written wastes the work.
+
+1. **It restores established behavior.** Name the requirement, contract, ADR, or spec that established it. If nothing did, this is new behavior.
+2. **A reproduction test is possible.** You will write a test that fails before the fix and passes after.
+3. **It introduces no new intended behavior.** Fixing a defect by adding a capability is not a fix.
+4. **It does not change** architecture, security or auth, data handling, a public contract, an NFR, or cross-service ownership.
+
+If any condition fails, stop and say which one, then direct the user to `/govkit-architecture-preflight` and the feature lane. Do not author a fix record for a change that does not qualify — the lane is narrow on purpose, and widening it by assertion is the failure mode it exists to prevent.
+
+## Inputs to read
+
+Feature specs (to find what established the behavior):
+- `features/<feature_name>/acceptance.feature`
+- `features/<feature_name>/nfrs.md`
+
+Architecture standards:
+- `docs/{{docs_area}}/architecture/` (all files)
+- `docs/{{docs_area}}/architecture/ADR/` — an accepted ADR is a valid source
+
+Repository facts:
+- `.govkit/skill_context.yaml` — read `architecture.layers` for the folder hints in this repo, and `architecture.source_root` / `architecture.services` for where source lives. Do not assume a folder shape; read the recorded one.
+
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
+## Instructions
+
+1. Reproduce the defect. Identify the smallest change that restores the established behavior.
+2. Write the reproduction test **first**, and confirm it fails. Tests define the specification; a fix whose test never failed has not been shown to fix anything.
+3. Run `govkit fix init <id>` to scaffold the record. Use a short slug naming the defect, not the fix.
+4. Complete every field. `expectation.source` and `reproduction.test` must be real repo-relative paths — `govkit validate` resolves them, and an unresolvable source means condition 1 was asserted rather than met.
+5. Set every `risk` flag honestly. A `true` is not a waiver; it moves the change to the feature lane. If you find yourself wanting to set one `false` to stay in the lane, that is the signal you are in the wrong lane.
+6. Implement the fix. Confirm the reproduction test now passes and no other test broke.
+7. Run `govkit validate --target .` and resolve anything it reports.
+
+## Output
+
+Write `fixes/<id>/fix.yaml` with:
+
+- `summary` — the defect in the language of the affected behavior, not the language of the code
+- `expectation.source` + `reference` — what established the behavior, and where in it
+- `failure.observed` — what actually happens, and `reported_in` if there is a report
+- `surface.paths` — the files the fix changes. Not the test; that is `reproduction.test`.
+- `reproduction.test` + `scenario` — the test and the case within it
+- `risk.*` — all six flags
+- `introduces_new_behavior: false`
+
+Two of these are declarations the tooling cannot verify: that the fix restores established behavior, and that it introduces none. `govkit validate` checks that the source path resolves, not that it says what you claim. State them precisely so a reviewer can check them quickly — that is what the record buys, and it is worth being straight about the limit rather than treating a green validate as proof.
+
+Write the test before the fix, and the record before the implementation. No implementation code in this step beyond the failing test.

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -47,13 +47,15 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".agents/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_data/"
           ],
           "governed": [
-            "governance/data/schemas/"
+            "governance/data/schemas/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -80,7 +82,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".agents/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_backend/",
@@ -91,7 +94,8 @@
             "docs/backend/guides/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -117,7 +121,8 @@
             { "src": "skills/backend/adr-author/", "dest": ".agents/skills/govkit-adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".agents/skills/govkit-genai-preflight/" },
             { "src": "skills/backend/eval-suite-planning/", "dest": ".agents/skills/govkit-eval-suite-planning/" },
-            { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/govkit-multi-agent-design/" }
+            { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/govkit-multi-agent-design/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_backend_l5/",
@@ -127,7 +132,8 @@
             "docs/backend/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -154,7 +160,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".agents/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".agents/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".agents/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_cli/"
@@ -164,7 +171,8 @@
             "docs/backend/guides/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -190,7 +198,8 @@
             { "src": "skills/backend/adr-author/", "dest": ".agents/skills/govkit-adr-author/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".agents/skills/govkit-genai-preflight/" },
             { "src": "skills/backend/eval-suite-planning/", "dest": ".agents/skills/govkit-eval-suite-planning/" },
-            { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/govkit-multi-agent-design/" }
+            { "src": "skills/backend/multi-agent-design/", "dest": ".agents/skills/govkit-multi-agent-design/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_cli_l5/"
@@ -199,7 +208,8 @@
             "docs/backend/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -230,7 +240,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".agents/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -238,7 +249,8 @@
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -256,7 +268,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".agents/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".agents/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -269,7 +282,8 @@
             "docs/ui/architecture/react/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -300,7 +314,8 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".agents/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -308,7 +323,8 @@
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -326,7 +342,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".agents/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".agents/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -339,7 +356,8 @@
             "docs/ui/architecture/angular/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -369,14 +387,16 @@
             { "src": "rules/generic/spec-compliance.md", "dest": ".agents/rules/spec-compliance.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".agents/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui_nextjs/"
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -393,7 +413,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".agents/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".agents/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".agents/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".agents/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui_nextjs/"
@@ -405,7 +426,8 @@
             "docs/ui/architecture/nextjs/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       }
@@ -453,13 +475,19 @@
           "shared": [],
           "governed": [],
           "by_type": {
-            "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
-            "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
-            "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml"] },
+            "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
             "data":       {
-              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
+                "ci/github/fix-lane-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
@@ -481,7 +509,8 @@
                 "ci/github/deepeval-gate.yml",
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
-                "ci/github/promptfoo-gate.yml"
+                "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -499,7 +528,8 @@
                 "ci/github/deepeval-gate.yml",
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
-                "ci/github/promptfoo-gate.yml"
+                "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -516,7 +546,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
@@ -525,7 +556,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/github/ui-nextjs-quality-gate.yml",
@@ -533,7 +565,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] }
           }
         }
@@ -580,13 +613,19 @@
           "shared": [],
           "governed": [],
           "by_type": {
-            "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
-            "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
-            "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml"] },
+            "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
             "data":       {
-              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
+                "ci/azure/fix-lane-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
@@ -608,7 +647,8 @@
                 "ci/azure/deepeval-gate.yml",
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
-                "ci/azure/promptfoo-gate.yml"
+                "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -626,7 +666,8 @@
                 "ci/azure/deepeval-gate.yml",
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
-                "ci/azure/promptfoo-gate.yml"
+                "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -643,7 +684,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
@@ -652,7 +694,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/azure/ui-nextjs-quality-gate.yml",
@@ -660,7 +703,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] }
           }
         }

--- a/agents/codex/rules/generic/spec-compliance.md
+++ b/agents/codex/rules/generic/spec-compliance.md
@@ -18,6 +18,24 @@ Every feature must live under `features/<feature_name>/` with these required art
 
 Implementation must not begin unless all five artifacts exist and are complete.
 
+## Defect fixes
+
+A change that *restores* behavior an existing requirement, contract, ADR, or
+spec already established may use the fix lane instead of the five artifacts
+above: one record at `fixes/<id>/fix.yaml`, scaffolded by `govkit fix init <id>`.
+
+It qualifies only when all four hold:
+
+- It restores established behavior, and names the source that established it
+- It includes a reproduction or regression test
+- It introduces no new intended behavior
+- It does not change architecture, security/auth, data handling, public
+  contracts, NFRs, or cross-service ownership
+
+If any of those fails, the change belongs in the feature lane above — and, where
+the contract requires one, behind an ADR. Declaring a risk flag `true` does not
+waive it; it moves the change out of this lane.
+
 ## Gherkin Conventions
 
 - Every `acceptance.feature` must have a `Feature:` keyword, at least one `Scenario:`, and Given/When/Then steps

--- a/agents/codex/skills/backend/fix-record/SKILL.md
+++ b/agents/codex/skills/backend/fix-record/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: govkit-fix-record
+description: Author a fix record for a defect that restores already-established behavior. Use when the user reports a bug, asks to fix a defect, or invokes /govkit-fix-record.
+---
+
+# Fix Record
+
+Author the fix record for a reported defect. When invoked, determine the defect from the user's request; if it is not described, ask before proceeding.
+
+A defect that restores behavior something already established carries one record — `fixes/<id>/fix.yaml` — instead of the five-artifact feature contract. A change that introduces behavior does not qualify, however small it looks.
+
+## Check eligibility first
+
+All four conditions must hold. Decide this **before** writing any code or any record — a change that fails one belongs in the feature lane, and finding that out after the fix is written wastes the work.
+
+1. **It restores established behavior.** Name the requirement, contract, ADR, or spec that established it. If nothing did, this is new behavior.
+2. **A reproduction test is possible.** You will write a test that fails before the fix and passes after.
+3. **It introduces no new intended behavior.** Fixing a defect by adding a capability is not a fix.
+4. **It does not change** architecture, security or auth, data handling, a public contract, an NFR, or cross-service ownership.
+
+If any condition fails, stop and say which one, then direct the user to `/govkit-architecture-preflight` and the feature lane. Do not author a fix record for a change that does not qualify — the lane is narrow on purpose, and widening it by assertion is the failure mode it exists to prevent.
+
+## Inputs to read
+
+Feature specs (to find what established the behavior):
+- `features/<feature_name>/acceptance.feature`
+- `features/<feature_name>/nfrs.md`
+
+Architecture standards:
+- `docs/{{docs_area}}/architecture/` (all files)
+- `docs/{{docs_area}}/architecture/ADR/` — an accepted ADR is a valid source
+
+Repository facts:
+- `.govkit/skill_context.yaml` — read `architecture.layers` for the folder hints in this repo, and `architecture.source_root` / `architecture.services` for where source lives. Do not assume a folder shape; read the recorded one.
+
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
+## Instructions
+
+1. Reproduce the defect. Identify the smallest change that restores the established behavior.
+2. Write the reproduction test **first**, and confirm it fails. Tests define the specification; a fix whose test never failed has not been shown to fix anything.
+3. Run `govkit fix init <id>` to scaffold the record. Use a short slug naming the defect, not the fix.
+4. Complete every field. `expectation.source` and `reproduction.test` must be real repo-relative paths — `govkit validate` resolves them, and an unresolvable source means condition 1 was asserted rather than met.
+5. Set every `risk` flag honestly. A `true` is not a waiver; it moves the change to the feature lane. If you find yourself wanting to set one `false` to stay in the lane, that is the signal you are in the wrong lane.
+6. Implement the fix. Confirm the reproduction test now passes and no other test broke.
+7. Run `govkit validate --target .` and resolve anything it reports.
+
+## Output
+
+Write `fixes/<id>/fix.yaml` with:
+
+- `summary` — the defect in the language of the affected behavior, not the language of the code
+- `expectation.source` + `reference` — what established the behavior, and where in it
+- `failure.observed` — what actually happens, and `reported_in` if there is a report
+- `surface.paths` — the files the fix changes. Not the test; that is `reproduction.test`.
+- `reproduction.test` + `scenario` — the test and the case within it
+- `risk.*` — all six flags
+- `introduces_new_behavior: false`
+
+Two of these are declarations the tooling cannot verify: that the fix restores established behavior, and that it introduces none. `govkit validate` checks that the source path resolves, not that it says what you claim. State them precisely so a reviewer can check them quickly — that is what the record buys, and it is worth being straight about the limit rather than treating a green validate as proof.
+
+Write the test before the fix, and the record before the implementation. No implementation code in this step beyond the failing test.

--- a/agents/copilot/instructions/generic/spec-compliance.instructions.md
+++ b/agents/copilot/instructions/generic/spec-compliance.instructions.md
@@ -22,6 +22,24 @@ Every feature must live under `features/<feature_name>/` with these required art
 
 Implementation must not begin unless all five artifacts exist and are complete.
 
+## Defect fixes
+
+A change that *restores* behavior an existing requirement, contract, ADR, or
+spec already established may use the fix lane instead of the five artifacts
+above: one record at `fixes/<id>/fix.yaml`, scaffolded by `govkit fix init <id>`.
+
+It qualifies only when all four hold:
+
+- It restores established behavior, and names the source that established it
+- It includes a reproduction or regression test
+- It introduces no new intended behavior
+- It does not change architecture, security/auth, data handling, public
+  contracts, NFRs, or cross-service ownership
+
+If any of those fails, the change belongs in the feature lane above — and, where
+the contract requires one, behind an ADR. Declaring a risk flag `true` does not
+waive it; it moves the change out of this lane.
+
 ## Gherkin Conventions
 
 - Every `acceptance.feature` must have a `Feature:` keyword, at least one `Scenario:`, and Given/When/Then steps

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -47,13 +47,15 @@
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/govkit/spec-compliance.instructions.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".github/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".github/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_data/"
           ],
           "governed": [
-            "governance/data/schemas/"
+            "governance/data/schemas/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -80,7 +82,8 @@
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/govkit/spec-compliance.instructions.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".github/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".github/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_backend/",
@@ -91,7 +94,8 @@
             "docs/backend/guides/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -110,7 +114,8 @@
             { "src": "skills/backend/", "dest": ".github/skills/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".github/skills/govkit-genai-preflight/" },
             { "src": "skills/backend/eval-suite-planning/", "dest": ".github/skills/govkit-eval-suite-planning/" },
-            { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/govkit-multi-agent-design/" }
+            { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/govkit-multi-agent-design/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_backend_l5/",
@@ -120,7 +125,8 @@
             "docs/backend/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -147,7 +153,8 @@
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/govkit/spec-compliance.instructions.md" },
             { "src": "skills/backend/spec-planning/", "dest": ".github/skills/govkit-spec-planning/" },
             { "src": "skills/backend/architecture-preflight/", "dest": ".github/skills/govkit-architecture-preflight/" },
-            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/govkit-implementation-plan/" }
+            { "src": "skills/backend/implementation-plan/", "dest": ".github/skills/govkit-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_cli/"
@@ -157,7 +164,8 @@
             "docs/backend/guides/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -176,7 +184,8 @@
             { "src": "skills/backend/", "dest": ".github/skills/" },
             { "src": "skills/backend/genai-preflight/", "dest": ".github/skills/govkit-genai-preflight/" },
             { "src": "skills/backend/eval-suite-planning/", "dest": ".github/skills/govkit-eval-suite-planning/" },
-            { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/govkit-multi-agent-design/" }
+            { "src": "skills/backend/multi-agent-design/", "dest": ".github/skills/govkit-multi-agent-design/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_cli_l5/"
@@ -185,7 +194,8 @@
             "docs/backend/",
             "governance/backend/schemas/",
             "governance/backend/templates/",
-            "governance/schemas/evaluation_prediction.schema.json"
+            "governance/schemas/evaluation_prediction.schema.json",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -215,7 +225,8 @@
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/govkit/spec-compliance.instructions.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".github/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -223,7 +234,8 @@
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -240,7 +252,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".github/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".github/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -253,7 +266,8 @@
             "docs/ui/architecture/react/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -283,7 +297,8 @@
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/govkit/spec-compliance.instructions.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".github/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -291,7 +306,8 @@
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -308,7 +324,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".github/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".github/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui/",
@@ -321,7 +338,8 @@
             "docs/ui/architecture/angular/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       },
@@ -351,14 +369,16 @@
             { "src": "instructions/generic/spec-compliance.instructions.md", "dest": ".github/instructions/govkit/spec-compliance.instructions.md" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".github/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui_nextjs/"
           ],
           "governed": [
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         },
         "level_5": {
@@ -375,7 +395,8 @@
             { "src": "skills/ui/adr-author/", "dest": ".github/skills/govkit-ui-adr-author/" },
             { "src": "skills/ui/spec-planning/", "dest": ".github/skills/govkit-ui-spec-planning/" },
             { "src": "skills/ui/architecture-preflight/", "dest": ".github/skills/govkit-ui-architecture-preflight/" },
-            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" }
+            { "src": "skills/ui/implementation-plan/", "dest": ".github/skills/govkit-ui-implementation-plan/" },
+            { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
             "features/starter_ui_nextjs/"
@@ -387,7 +408,8 @@
             "docs/ui/architecture/nextjs/",
             "docs/ui/design/",
             "docs/ui/evaluation/",
-            "governance/ui/"
+            "governance/ui/",
+            "governance/schemas/fix_record.schema.json"
           ]
         }
       }
@@ -435,13 +457,19 @@
           "shared": [],
           "governed": [],
           "by_type": {
-            "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
-            "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml"] },
-            "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml"] },
-            "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml"] },
+            "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
+            "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
+                "ci/github/fix-lane-gate.yml"] },
             "data":       {
-              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml"],
+              "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
+                "ci/github/fix-lane-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
@@ -463,7 +491,8 @@
                 "ci/github/deepeval-gate.yml",
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
-                "ci/github/promptfoo-gate.yml"
+                "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -481,7 +510,8 @@
                 "ci/github/deepeval-gate.yml",
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
-                "ci/github/promptfoo-gate.yml"
+                "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -498,7 +528,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
@@ -507,7 +538,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/github/ui-nextjs-quality-gate.yml",
@@ -515,7 +547,8 @@
               "ci/github/deepeval-gate.yml",
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
-              "ci/github/promptfoo-gate.yml"
+              "ci/github/promptfoo-gate.yml",
+                "ci/github/fix-lane-gate.yml"
             ] }
           }
         }
@@ -562,13 +595,19 @@
           "shared": [],
           "governed": [],
           "by_type": {
-            "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
-            "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml"] },
-            "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml"] },
-            "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml"] },
+            "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
+            "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
+                "ci/azure/fix-lane-gate.yml"] },
             "data":       {
-              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml"],
+              "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
+                "ci/azure/fix-lane-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
@@ -590,7 +629,8 @@
                 "ci/azure/deepeval-gate.yml",
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
-                "ci/azure/promptfoo-gate.yml"
+                "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -608,7 +648,8 @@
                 "ci/azure/deepeval-gate.yml",
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
-                "ci/azure/promptfoo-gate.yml"
+                "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -625,7 +666,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
@@ -634,7 +676,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/azure/ui-nextjs-quality-gate.yml",
@@ -642,7 +685,8 @@
               "ci/azure/deepeval-gate.yml",
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
-              "ci/azure/promptfoo-gate.yml"
+              "ci/azure/promptfoo-gate.yml",
+                "ci/azure/fix-lane-gate.yml"
             ] }
           }
         }

--- a/agents/copilot/skills/backend/fix-record/SKILL.md
+++ b/agents/copilot/skills/backend/fix-record/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: govkit-fix-record
+description: Author a fix record for a defect that restores already-established behavior. Use when the user reports a bug, asks to fix a defect, or invokes /govkit-fix-record.
+---
+
+# Fix Record
+
+Author the fix record for a reported defect. When invoked, determine the defect from the user's request; if it is not described, ask before proceeding.
+
+A defect that restores behavior something already established carries one record — `fixes/<id>/fix.yaml` — instead of the five-artifact feature contract. A change that introduces behavior does not qualify, however small it looks.
+
+## Check eligibility first
+
+All four conditions must hold. Decide this **before** writing any code or any record — a change that fails one belongs in the feature lane, and finding that out after the fix is written wastes the work.
+
+1. **It restores established behavior.** Name the requirement, contract, ADR, or spec that established it. If nothing did, this is new behavior.
+2. **A reproduction test is possible.** You will write a test that fails before the fix and passes after.
+3. **It introduces no new intended behavior.** Fixing a defect by adding a capability is not a fix.
+4. **It does not change** architecture, security or auth, data handling, a public contract, an NFR, or cross-service ownership.
+
+If any condition fails, stop and say which one, then direct the user to `/govkit-architecture-preflight` and the feature lane. Do not author a fix record for a change that does not qualify — the lane is narrow on purpose, and widening it by assertion is the failure mode it exists to prevent.
+
+## Inputs to read
+
+Feature specs (to find what established the behavior):
+- `features/<feature_name>/acceptance.feature`
+- `features/<feature_name>/nfrs.md`
+
+Architecture standards:
+- `docs/{{docs_area}}/architecture/` (all files)
+- `docs/{{docs_area}}/architecture/ADR/` — an accepted ADR is a valid source
+
+Repository facts:
+- `.govkit/skill_context.yaml` — read `architecture.layers` for the folder hints in this repo, and `architecture.source_root` / `architecture.services` for where source lives. Do not assume a folder shape; read the recorded one.
+
+## Multi-service repos
+
+Read `.govkit/skill_context.yaml` before planning. When it lists more than
+one entry under `architecture.services`, this repo holds several services
+and every path in your output has to land inside one of them:
+
+```yaml
+architecture:
+  source_root: ''
+  services:
+    - name: billing
+      root: src/billing
+    - name: orders
+      root: src/orders
+```
+
+1. Work out which service the feature belongs to. Take it from the request
+   when it names one — by service name, or by a path under that service's
+   `root`.
+2. If the request names none, **ask which service to plan for** and list the
+   names. Do not guess, and do not plan across all of them at once.
+3. Prefix every file path in your output with that service's `root`. A task
+   touching `services/pricing.py` in the `orders` service is
+   `src/orders/services/pricing.py`.
+4. Name the chosen service in the plan summary, so a reader knows which part
+   of the repo the plan applies to.
+
+When `architecture.services` is absent, the repo holds a single service.
+Use `architecture.source_root` as the prefix instead — an empty value means
+the layer folders sit at the repo root and paths need no prefix.
+
+## Instructions
+
+1. Reproduce the defect. Identify the smallest change that restores the established behavior.
+2. Write the reproduction test **first**, and confirm it fails. Tests define the specification; a fix whose test never failed has not been shown to fix anything.
+3. Run `govkit fix init <id>` to scaffold the record. Use a short slug naming the defect, not the fix.
+4. Complete every field. `expectation.source` and `reproduction.test` must be real repo-relative paths — `govkit validate` resolves them, and an unresolvable source means condition 1 was asserted rather than met.
+5. Set every `risk` flag honestly. A `true` is not a waiver; it moves the change to the feature lane. If you find yourself wanting to set one `false` to stay in the lane, that is the signal you are in the wrong lane.
+6. Implement the fix. Confirm the reproduction test now passes and no other test broke.
+7. Run `govkit validate --target .` and resolve anything it reports.
+
+## Output
+
+Write `fixes/<id>/fix.yaml` with:
+
+- `summary` — the defect in the language of the affected behavior, not the language of the code
+- `expectation.source` + `reference` — what established the behavior, and where in it
+- `failure.observed` — what actually happens, and `reported_in` if there is a report
+- `surface.paths` — the files the fix changes. Not the test; that is `reproduction.test`.
+- `reproduction.test` + `scenario` — the test and the case within it
+- `risk.*` — all six flags
+- `introduces_new_behavior: false`
+
+Two of these are declarations the tooling cannot verify: that the fix restores established behavior, and that it introduces none. `govkit validate` checks that the source path resolves, not that it says what you claim. State them precisely so a reviewer can check them quickly — that is what the record buys, and it is worth being straight about the limit rather than treating a green validate as proof.
+
+Write the test before the fix, and the record before the implementation. No implementation code in this step beyond the failing test.

--- a/ci/README.md
+++ b/ci/README.md
@@ -42,9 +42,7 @@ Copy the relevant templates for your project type:
 | `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
 | `ui-nextjs-quality-gate.yml` | — | — | Next.js L4/L5 | — |
 | `ui-nextjs-eval-gate.yml` | — | — | Next.js L4/L5 | — |
-| `l3-ui-nextjs-quality-gate.yml` | — | — | Next.js L3 | — |
-| `ui-nextjs-quality-gate.yml` | — | — | Next.js L4/L5 | — |
-| `ui-nextjs-eval-gate.yml` | — | — | Next.js L4/L5 | — |
+| `fix-lane-gate.yml` (L4+, configure first) | ✓ | ✓ | ✓ | ✓ |
 | `data-common-gate.yml` | — | — | — | ✓ |
 | `dbt-gate.yml` | — | — | — | `python-dbt` |
 | `databricks-gate.yml` | — | — | — | `databricks-lakehouse` |
@@ -212,6 +210,26 @@ A critical distinction in this governance framework: some checks enforce **actua
 | Architecture boundaries | boundary-gate-python | Runs `import-linter` to enforce hexagonal layering (`python-fastapi` only) |
 | Security vulnerabilities | l3-quality-gate | Snyk dependency scan |
 | Code quality metrics | l3-quality-gate | SonarQube duplication and complexity |
+| Governing artifact coverage | fix-lane-gate | Source changed in the PR is accounted for by a fix record or a feature |
+| Fix record correspondence | fix-lane-gate | A fix record's `surface.paths` matches what the diff actually changed, and the diff carries a test |
+
+#### The fix-lane gate needs configuring before it does anything
+
+Set `SOURCE_PATHS` in the workflow to your application source roots
+(comma-separated prefixes, e.g. `src/,lib/`). Until you do, the gate prints
+that it is inactive and passes — a fresh install stays green, and the false
+positives are your choice rather than govkit's. `.govkit/skill_context.yaml`
+records what govkit detected under `architecture.source_root` and
+`architecture.services[].root`; note `source_root: ""` means *no single root*
+and is not a value to paste in.
+
+This is the only gate that can catch a code change carrying no governance at
+all. `govkit validate` iterates artifacts that already exist, so a PR that
+changes source and creates none passes it untouched. The gate is also where a
+fix record's declarations meet reality: `validate` can prove a record is
+internally consistent, but `surface.paths` and the risk flags are both authored,
+so they can agree with each other while disagreeing with the diff. Only CI has
+the diff.
 
 ### Prediction-only (plan.md scores, not actuals)
 

--- a/ci/azure/fix-lane-gate.yml
+++ b/ci/azure/fix-lane-gate.yml
@@ -1,0 +1,122 @@
+# Azure DevOps mirror of ci/github/fix-lane-gate.yml.
+#
+# PURPOSE: Close the code-only escape hatch. `govkit validate` iterates artifacts
+#          that already exist, so a PR that changes source and creates no
+#          governing artifact passes every other gate untouched.
+#
+# validate is a working-tree tool: it can prove a fix record is internally
+# consistent, but not that its declarations match what the PR actually changed.
+# Only the diff can, and only CI has it.
+#
+# CONFIGURE THIS: set SOURCE_PATHS to your application source roots
+#   (comma-separated path prefixes, e.g. "src/,lib/"). The gate is INACTIVE
+#   until you do, so a fresh install stays green.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  SOURCE_PATHS: YOUR_SOURCE_PATHS
+
+stages:
+  - stage: FixLane
+    displayName: Fix lane
+    jobs:
+      - job: FixLaneCheck
+        displayName: Governing artifact for source changes
+        steps:
+          - checkout: self
+            fetchDepth: 0
+
+          - script: pip install pyyaml
+            displayName: Install pyyaml
+
+          - script: |
+              # Three-dot: what this branch changed relative to the merge base.
+              # Two-dot would also report changes main made since the branch point.
+              git diff --name-only origin/main...HEAD | python - <<'EOF'
+              import os
+              import sys
+
+              import yaml
+
+              raw = os.environ.get("SOURCE_PATHS", "")
+              prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+              if not prefixes or "YOUR_SOURCE_PATHS" in prefixes:
+                  print("SOURCE_PATHS is not configured — fix-lane gate inactive.")
+                  print("Set it in this workflow to your application source roots")
+                  print("(comma-separated, e.g. 'src/,lib/') to enable the gate.")
+                  sys.exit(0)
+
+              changed = [ln.strip() for ln in sys.stdin if ln.strip()]
+              touched_source = [
+                  p for p in changed if any(p.startswith(pre) for pre in prefixes)
+              ]
+              if not touched_source:
+                  print("No application source changed; nothing for this gate to check.")
+                  sys.exit(0)
+
+              fix_records = [
+                  p for p in changed
+                  if p.startswith("fixes/") and p.endswith("fix.yaml")
+              ]
+              feature_changes = [p for p in changed if p.startswith("features/")]
+
+              errors = []
+              if not fix_records and not feature_changes:
+                  errors.append(
+                      "source changed with no governing artifact: "
+                      + ", ".join(sorted(touched_source)[:10])
+                  )
+
+              tests = [p for p in changed if "test" in os.path.basename(p).lower()]
+
+              # Condition 2 — a fix without a regression test is not in the light lane.
+              # Checked against the diff, which is the only place it is provable.
+              if fix_records and not tests:
+                  errors.append(
+                      "a fix record is present but the diff adds or modifies no test"
+                  )
+
+              # Correspondence: surface.paths must account for what actually changed.
+              declared = set()
+              for record in fix_records:
+                  try:
+                      with open(record, encoding="utf-8") as fh:
+                          data = yaml.safe_load(fh) or {}
+                  except (OSError, yaml.YAMLError) as exc:
+                      errors.append(f"{record} could not be read: {exc}")
+                      continue
+                  declared.update((data.get("surface") or {}).get("paths") or [])
+
+              if fix_records:
+                  # The regression test lives under a source root too, but it is the
+                  # proof of the fix rather than part of it — surface.paths describes
+                  # what was repaired, so demanding the test appear there would be wrong.
+                  undeclared = sorted(set(touched_source) - declared - set(tests))
+                  if undeclared:
+                      errors.append(
+                          "changed source not declared in any fix record's surface.paths: "
+                          + ", ".join(undeclared[:10])
+                      )
+
+              if errors:
+                  for e in errors:
+                      print(f"FAIL: {e}")
+                  print("")
+                  print("A source change needs a governing artifact. Either:")
+                  print("  1. `govkit fix init <id>` and complete fixes/<id>/fix.yaml")
+                  print("     — for a defect that restores already-established behavior")
+                  print("  2. `govkit init <feature>` and complete the feature artifacts")
+                  print("     — for anything that introduces new behavior")
+                  sys.exit(1)
+
+              print("Source changes are covered by a governing artifact.")
+              EOF
+            displayName: Check governing artifact covers the source change

--- a/ci/github/fix-lane-gate.yml
+++ b/ci/github/fix-lane-gate.yml
@@ -1,0 +1,128 @@
+# fix-lane-gate.yml
+#
+# PURPOSE: Close the code-only escape hatch. `govkit validate` iterates artifacts
+#          that already exist, so a PR that changes source and creates no
+#          governing artifact passes every other gate untouched.
+#
+# JOBS:
+#   fix-lane-check — when a PR changes application source, require either a fix
+#                    record (fixes/<id>/fix.yaml) or a feature, and check the
+#                    record against the actual diff
+#
+# WHY THIS GATE AND NOT `govkit validate`:
+#   validate is a working-tree tool. It can prove a fix record is internally
+#   consistent — that its declared risk flags do not contradict its declared
+#   surface.paths — but it cannot prove those declarations match what the PR
+#   actually changed. Only the diff can. That correspondence is this gate's job.
+#
+# CONFIGURE THIS: set SOURCE_PATHS below to your application source roots.
+#   The gate is INACTIVE until you do, so a fresh install stays green.
+#   Comma-separated path prefixes, e.g. "src/,lib/".
+#   See .govkit/skill_context.yaml `architecture.source_root` and
+#   `architecture.services[].root` for what govkit detected.
+#
+# Copy this file to .github/workflows/fix-lane-gate.yml.
+
+name: Fix Lane Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  fix-lane-check:
+    name: Governing artifact for source changes
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_PATHS: YOUR_SOURCE_PATHS
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      - name: Check governing artifact covers the source change
+        run: |
+          # Three-dot: what this branch changed relative to the merge base.
+          # Two-dot would also report changes main made since the branch point.
+          git diff --name-only origin/main...HEAD | python - <<'EOF'
+          import os
+          import sys
+
+          import yaml
+
+          raw = os.environ.get("SOURCE_PATHS", "")
+          prefixes = [p.strip() for p in raw.split(",") if p.strip()]
+          if not prefixes or "YOUR_SOURCE_PATHS" in prefixes:
+              print("SOURCE_PATHS is not configured — fix-lane gate inactive.")
+              print("Set it in this workflow to your application source roots")
+              print("(comma-separated, e.g. 'src/,lib/') to enable the gate.")
+              sys.exit(0)
+
+          changed = [ln.strip() for ln in sys.stdin if ln.strip()]
+          touched_source = [
+              p for p in changed if any(p.startswith(pre) for pre in prefixes)
+          ]
+          if not touched_source:
+              print("No application source changed; nothing for this gate to check.")
+              sys.exit(0)
+
+          fix_records = [
+              p for p in changed
+              if p.startswith("fixes/") and p.endswith("fix.yaml")
+          ]
+          feature_changes = [p for p in changed if p.startswith("features/")]
+
+          errors = []
+          if not fix_records and not feature_changes:
+              errors.append(
+                  "source changed with no governing artifact: "
+                  + ", ".join(sorted(touched_source)[:10])
+              )
+
+          tests = [p for p in changed if "test" in os.path.basename(p).lower()]
+
+          # Condition 2 — a fix without a regression test is not in the light lane.
+          # Checked against the diff, which is the only place it is provable.
+          if fix_records and not tests:
+              errors.append(
+                  "a fix record is present but the diff adds or modifies no test"
+              )
+
+          # Correspondence: surface.paths must account for what actually changed.
+          declared = set()
+          for record in fix_records:
+              try:
+                  with open(record, encoding="utf-8") as fh:
+                      data = yaml.safe_load(fh) or {}
+              except (OSError, yaml.YAMLError) as exc:
+                  errors.append(f"{record} could not be read: {exc}")
+                  continue
+              declared.update((data.get("surface") or {}).get("paths") or [])
+
+          if fix_records:
+              # The regression test lives under a source root too, but it is the
+              # proof of the fix rather than part of it — surface.paths describes
+              # what was repaired, so demanding the test appear there would be wrong.
+              undeclared = sorted(set(touched_source) - declared - set(tests))
+              if undeclared:
+                  errors.append(
+                      "changed source not declared in any fix record's surface.paths: "
+                      + ", ".join(undeclared[:10])
+                  )
+
+          if errors:
+              for e in errors:
+                  print(f"FAIL: {e}")
+              print("")
+              print("A source change needs a governing artifact. Either:")
+              print("  1. `govkit fix init <id>` and complete fixes/<id>/fix.yaml")
+              print("     — for a defect that restores already-established behavior")
+              print("  2. `govkit init <feature>` and complete the feature artifacts")
+              print("     — for anything that introduces new behavior")
+              sys.exit(1)
+
+          print("Source changes are covered by a governing artifact.")
+          EOF

--- a/cli/cmd_fix.py
+++ b/cli/cmd_fix.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`govkit fix` — scaffold a defect-lane fix record.
+
+A defect that restores already-established behavior carries one schema-backed
+record instead of the five-artifact feature contract. This writes the skeleton;
+`govkit validate` then checks the eligibility conditions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from . import paths
+from .fixes import FIX_RECORD_FILE, FIX_RECORD_SKELETON, FIXES_DIR
+from .marker import read_govkit_marker
+
+# Mirrors the schema's `id` pattern. Checked here so a bad id fails at creation
+# rather than producing a record that can never validate.
+_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
+
+
+def cmd_fix_init(args: argparse.Namespace) -> None:
+    """Create `fixes/<id>/fix.yaml` from the skeleton."""
+    target = Path(args.target).resolve()
+    stored = read_govkit_marker(target) or {}
+
+    # Level gate first, before any other check — mirrors cmd_init.
+    level = args.level or stored.get("level") or "3"
+    if level == "3":
+        print(
+            "Error: 'govkit fix init' requires Level 4 (Spec-Driven Add-On) or higher.\n"
+            "  Level 3 (Foundations) ships agent rules and architecture contracts only;\n"
+            "  it has no per-change artifact model, so there is nothing for a fix\n"
+            "  record to sit alongside.\n"
+            "  Run 'govkit apply --level 4 --target <path>' first."
+        )
+        sys.exit(1)
+
+    fix_id = args.fix_id
+    if not _ID_PATTERN.match(fix_id):
+        print(
+            f"Error: '{fix_id}' is not a valid fix id.\n"
+            "  Use lowercase letters, digits, and . _ - (starting with a letter\n"
+            "  or digit) — e.g. 'task-filter-reset'. The id is also the directory\n"
+            "  name, and govkit validate requires the two to match."
+        )
+        sys.exit(1)
+
+    record_dir = target / FIXES_DIR / fix_id
+    record_path = record_dir / FIX_RECORD_FILE
+    if record_path.exists():
+        print(f"Error: fix record '{fix_id}' already exists at {record_path}")
+        sys.exit(1)
+
+    record_dir.mkdir(parents=True, exist_ok=True)
+    record_path.write_text(FIX_RECORD_SKELETON.format(id=fix_id), encoding="utf-8")
+
+    print(f"Created {record_path}\n")
+    print("Next steps:")
+    print(f"  1. Replace every TODO in {record_path}")
+    print("  2. `expectation.source` must point at the requirement, contract, or ADR")
+    print("     that established the behavior — a fix with no source is new behavior,")
+    print("     and belongs in the feature lane instead")
+    print("  3. `reproduction.test` must point at a test that fails before the fix")
+    print("  4. Run `govkit validate --target .` to check eligibility")
+
+
+def register(subparsers) -> None:
+    """Register the `fix` subcommand tree (`fix init`)."""
+    fix_parser = subparsers.add_parser(
+        "fix",
+        help="Scaffold a defect-lane fix record",
+    )
+    fix_sub = fix_parser.add_subparsers(dest="fix_command", required=True)
+
+    init_parser = fix_sub.add_parser(
+        "init", help="Create fixes/<id>/fix.yaml from the skeleton"
+    )
+    init_parser.add_argument(
+        "fix_id",
+        help="Fix id, also the directory name (e.g. task-filter-reset)",
+    )
+    init_parser.add_argument("--target", default=".", help=paths.TARGET_HELP)
+    init_parser.add_argument(
+        "--level", choices=["3", "4", "5"], default=None,
+        help="Maturity level (default: read from .govkit)",
+    )
+    init_parser.set_defaults(func=cmd_fix_init)

--- a/cli/cmd_fix.py
+++ b/cli/cmd_fix.py
@@ -38,9 +38,16 @@ _ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 def cmd_fix_init(args: argparse.Namespace) -> None:
     """Create `fixes/<id>/fix.yaml` from the skeleton."""
     target = Path(args.target).resolve()
+    # Before anything reads or writes: a missing target would otherwise read the
+    # marker from nowhere, resolve to L3, and report the wrong problem — and a
+    # typo'd path would grow a fixes/ tree somewhere surprising.
+    if not target.is_dir():
+        print(f"Error: target directory '{target}' does not exist.", file=sys.stderr)
+        sys.exit(1)
+
     stored = read_govkit_marker(target) or {}
 
-    # Level gate first, before any other check — mirrors cmd_init.
+    # Level gate next, before any other check — mirrors cmd_init.
     level = args.level or stored.get("level") or "3"
     if level == "3":
         print(

--- a/cli/fixes.py
+++ b/cli/fixes.py
@@ -34,7 +34,7 @@ green" contract as `check_eval_criteria`.
 import re
 import subprocess
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import yaml
 
@@ -167,6 +167,69 @@ def _check_required_keys(record: FixRecord) -> list[str]:
     return [f"{record.rel} missing required key(s): {', '.join(missing)}"]
 
 
+_RISK_FLAGS = (
+    "architecture",
+    "security_auth",
+    "data_handling",
+    "public_contract",
+    "nfr",
+    "cross_service",
+)
+
+_MAPPING_SECTIONS = ("expectation", "failure", "surface", "reproduction", "risk")
+
+
+def _nonempty_str(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _check_nested_structure(record: FixRecord) -> list[str]:
+    """Enforce the nested contract in-process, not only via check-jsonschema.
+
+    The record is the *whole* governance artifact for a defect-lane change, so a
+    structurally incomplete one cannot be allowed through on a warning when the
+    schema or the validator binary is unavailable. Reduced coverage is worth a
+    warning; a missing `expectation.source` is not.
+
+    Mirrors `governance/schemas/fix_record.schema.json`. Kept deliberately
+    narrow — required-and-typed only — so the schema stays the detailed
+    authority and this does not become a second, drifting copy of it.
+    """
+    data = record.data
+    wrong_type = [
+        f"{record.rel} {section} must be a mapping"
+        for section in _MAPPING_SECTIONS
+        if section in data and not isinstance(data[section], dict)
+    ]
+    if wrong_type:
+        # Everything below indexes into these sections.
+        return wrong_type
+
+    issues = []
+    if not _nonempty_str((data.get("expectation") or {}).get("source")):
+        issues.append(f"{record.rel} expectation.source must be a non-empty string")
+    if not _nonempty_str((data.get("failure") or {}).get("observed")):
+        issues.append(f"{record.rel} failure.observed must be a non-empty string")
+    if not _nonempty_str((data.get("reproduction") or {}).get("test")):
+        issues.append(f"{record.rel} reproduction.test must be a non-empty string")
+
+    paths = (data.get("surface") or {}).get("paths")
+    if not isinstance(paths, list) or not paths or not all(_nonempty_str(p) for p in paths):
+        issues.append(
+            f"{record.rel} surface.paths must be a non-empty list of strings"
+        )
+
+    risk = data.get("risk") or {}
+    issues += [
+        f"{record.rel} risk.{flag} must be present and boolean"
+        for flag in _RISK_FLAGS
+        if not isinstance(risk.get(flag), bool)
+    ]
+    if not isinstance(data.get("introduces_new_behavior"), bool):
+        issues.append(f"{record.rel} introduces_new_behavior must be boolean")
+    return issues
+
+
 def _check_id_matches_directory(record: FixRecord) -> list[str]:
     declared = record.data.get("id")
     if declared is None or declared == record.id:
@@ -195,32 +258,67 @@ _GOVERNED_AREA_PATTERNS = {
 
 
 def _posix(path: str) -> str:
-    return path.replace("\\", "/").lstrip("./")
+    """Normalise separators for pattern matching.
+
+    Only a leading `./` is stripped, and only once. The previous
+    `lstrip("./")` removed *every* leading `.` and `/`, which turned `../x`
+    into `x` — silently erasing an escape — and `.hidden/x` into `hidden/x`.
+    """
+    return path.replace("\\", "/").removeprefix("./")
+
+
+def _check_safe_path(
+    label: str, path: object, target: Path, hint: str, *, must_be_file: bool = True,
+) -> list[str]:
+    """Resolve `path` against `target` and require it to be relative, contained,
+    existing, and a file.
+
+    Mirrors `cli/extensions.py::_check_safe_file_path`. A fix record is authored
+    — often by an agent — so "does this path exist" is the wrong question on its
+    own; "is it inside the repository it claims to describe" is the one that
+    stops an absolute path or a `..` from reaching outside.
+    """
+    if not isinstance(path, str) or not path.strip():
+        return [f"{label} must be a non-empty string"]
+    # Path.is_absolute() is host-specific: "/etc/passwd" is not absolute on
+    # Windows (no drive), and "C:\\x" is not absolute on POSIX. Check both so
+    # neither flavour slips through on either platform.
+    if PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute():
+        return [f"{label}: {path!r} must be relative to the repository, not absolute"]
+    base = target.resolve()
+    candidate = (target / path).resolve(strict=False)
+    if not candidate.is_relative_to(base):
+        return [f"{label}: {path!r} resolves outside the repository"]
+    if not candidate.exists():
+        return [f"{label} '{path}' does not resolve — {hint}"]
+    if must_be_file and not candidate.is_file():
+        return [f"{label}: {path!r} is not a file"]
+    return []
 
 
 def _check_paths_resolve(record: FixRecord, target: Path) -> list[str]:
-    """Conditions 1 and 2 are assertions until their paths resolve."""
+    """Conditions 1 and 2 are assertions until their paths resolve — inside the
+    repository, and at a file rather than a directory."""
     issues = []
-    source = (record.data.get("expectation") or {}).get("source")
-    if isinstance(source, str) and not (target / source).exists():
-        issues.append(
-            f"{record.rel} expectation.source '{source}' does not resolve — a fix "
-            "that cannot cite what established the behavior is introducing it, "
-            "and belongs in the feature lane"
-        )
-    test = (record.data.get("reproduction") or {}).get("test")
-    if isinstance(test, str) and not (target / test).exists():
-        issues.append(
-            f"{record.rel} reproduction.test '{test}' does not resolve — the light "
-            "lane requires a test that fails before the fix"
-        )
-    missing = [
-        p for p in ((record.data.get("surface") or {}).get("paths") or [])
-        if isinstance(p, str) and not (target / p).exists()
-    ]
-    if missing:
-        issues.append(
-            f"{record.rel} surface.paths do not resolve: {', '.join(missing)}"
+    issues += _check_safe_path(
+        f"{record.rel} expectation.source",
+        (record.data.get("expectation") or {}).get("source"),
+        target,
+        "a fix that cannot cite what established the behavior is introducing it, "
+        "and belongs in the feature lane",
+    )
+    issues += _check_safe_path(
+        f"{record.rel} reproduction.test",
+        (record.data.get("reproduction") or {}).get("test"),
+        target,
+        "the light lane requires a test that fails before the fix",
+    )
+    for path in (record.data.get("surface") or {}).get("paths") or []:
+        issues += _check_safe_path(
+            f"{record.rel} surface.paths",
+            path,
+            target,
+            "surface.paths names the files the fix changes",
         )
     return issues
 
@@ -281,8 +379,8 @@ def _validate_against_schema(
     schema = target / SCHEMA_REL
     if not schema.is_file():
         return [], [
-            f"{record.rel} structure OK — no fix_record schema installed; "
-            "instance validation skipped"
+            f"{record.rel} instance validation skipped — "
+            "no fix_record schema installed"
         ]
     try:
         result = subprocess.run(
@@ -291,7 +389,8 @@ def _validate_against_schema(
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return [], [
-            f"{record.rel} structure OK — install check-jsonschema for full validation"
+            f"{record.rel} instance validation skipped — "
+            "install check-jsonschema for full validation"
         ]
     if result.returncode != 0:
         detail = (result.stdout or result.stderr or "").strip().splitlines()
@@ -319,9 +418,13 @@ def validate_fix_record(
     if issues:
         return issues, []
 
+    # In-process nested checks run regardless of tooling availability, and the
+    # schema check still runs so its warning is visible alongside them — a
+    # reader needs to know coverage was reduced *and* what was already wrong.
+    nested = _check_nested_structure(record)
     schema_issues, warnings = _validate_against_schema(record, target)
-    if schema_issues:
-        return schema_issues, warnings
+    if nested or schema_issues:
+        return nested + schema_issues, warnings
 
     # Eligibility runs only once the record is structurally sound — there is no
     # value in reasoning about conditions in a record missing half its fields.

--- a/cli/fixes.py
+++ b/cli/fixes.py
@@ -31,6 +31,7 @@ the type would create a cycle. Warnings carry the same "visible gaps, not silent
 green" contract as `check_eval_criteria`.
 """
 
+import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -176,6 +177,101 @@ def _check_id_matches_directory(record: FixRecord) -> list[str]:
     ]
 
 
+# Risk flags govkit can contradict from a path alone, because govkit *owns* the
+# namespace and its meaning is definitional rather than inferred.
+#
+# security_auth, data_handling and cross_service are deliberately absent. There
+# is no govkit-owned directory that definitionally means "security" or "data
+# handling", and services are declared in skill_context.yaml rather than implied
+# by a path. Inventing a glob for those would manufacture false contradictions;
+# those declarations stand alone here and are checked against the real diff in CI.
+_GOVERNED_AREA_PATTERNS = {
+    "architecture": re.compile(r"^docs/[^/]+/architecture/"),
+    "nfr": re.compile(r"^features/[^/]+/nfrs\.md$"),
+    # The area segment is optional: per-type schemas live at
+    # governance/<area>/schemas/, area-agnostic ones at governance/schemas/.
+    "public_contract": re.compile(r"^governance/([^/]+/)?schemas/"),
+}
+
+
+def _posix(path: str) -> str:
+    return path.replace("\\", "/").lstrip("./")
+
+
+def _check_paths_resolve(record: FixRecord, target: Path) -> list[str]:
+    """Conditions 1 and 2 are assertions until their paths resolve."""
+    issues = []
+    source = (record.data.get("expectation") or {}).get("source")
+    if isinstance(source, str) and not (target / source).exists():
+        issues.append(
+            f"{record.rel} expectation.source '{source}' does not resolve — a fix "
+            "that cannot cite what established the behavior is introducing it, "
+            "and belongs in the feature lane"
+        )
+    test = (record.data.get("reproduction") or {}).get("test")
+    if isinstance(test, str) and not (target / test).exists():
+        issues.append(
+            f"{record.rel} reproduction.test '{test}' does not resolve — the light "
+            "lane requires a test that fails before the fix"
+        )
+    missing = [
+        p for p in ((record.data.get("surface") or {}).get("paths") or [])
+        if isinstance(p, str) and not (target / p).exists()
+    ]
+    if missing:
+        issues.append(
+            f"{record.rel} surface.paths do not resolve: {', '.join(missing)}"
+        )
+    return issues
+
+
+def _check_lane_membership(record: FixRecord) -> list[str]:
+    """A declared risk is not a waiver. Any `true` means this change is outside
+    the light lane — it belongs in the feature lane, and where the contract
+    requires it, behind an ADR."""
+    issues = []
+    raised = sorted(
+        flag for flag, value in (record.data.get("risk") or {}).items() if value is True
+    )
+    if raised:
+        issues.append(
+            f"{record.rel} declares risk.{', risk.'.join(raised)} — this change "
+            "belongs in the feature lane, not the fix lane"
+        )
+    if record.data.get("introduces_new_behavior") is True:
+        issues.append(
+            f"{record.rel} declares introduces_new_behavior — restoring "
+            "established behavior is what this lane is for; new behavior "
+            "belongs in the feature lane"
+        )
+    return issues
+
+
+def _check_risk_matches_surface(record: FixRecord) -> list[str]:
+    """The other side of the two-sided check: a `false` beside a change in a
+    govkit-owned namespace is a contradiction.
+
+    Note this compares two *declared* fields — `surface.paths` is authored, not
+    derived from a diff — so it proves the record is internally consistent, not
+    that it matches what the PR changed. That correspondence is CI's job, where
+    the diff exists.
+    """
+    risk = record.data.get("risk") or {}
+    paths = [_posix(p) for p in ((record.data.get("surface") or {}).get("paths") or []) if isinstance(p, str)]
+    issues = []
+    for flag, pattern in _GOVERNED_AREA_PATTERNS.items():
+        if risk.get(flag) is not False:
+            continue
+        hits = [p for p in paths if pattern.search(p)]
+        if hits:
+            issues.append(
+                f"{record.rel} declares risk.{flag} false but changes "
+                f"{', '.join(hits)} — that is a {flag} change, so the record "
+                "contradicts itself"
+            )
+    return issues
+
+
 def _validate_against_schema(
     record: FixRecord, target: Path,
 ) -> tuple[list[str], list[str]]:
@@ -223,4 +319,15 @@ def validate_fix_record(
     if issues:
         return issues, []
 
-    return _validate_against_schema(record, target)
+    schema_issues, warnings = _validate_against_schema(record, target)
+    if schema_issues:
+        return schema_issues, warnings
+
+    # Eligibility runs only once the record is structurally sound — there is no
+    # value in reasoning about conditions in a record missing half its fields.
+    eligibility = [
+        *_check_paths_resolve(record, target),
+        *_check_lane_membership(record),
+        *_check_risk_matches_surface(record),
+    ]
+    return eligibility, warnings

--- a/cli/fixes.py
+++ b/cli/fixes.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defect lane — discovery and validation of `fixes/<id>/fix.yaml`.
+
+The L4 contract is feature-shaped: five prose artifacts for every governed
+change. A defect that restores already-established behavior carries one
+schema-backed record instead.
+
+Modelled on `cli/extensions.py`, the repo's existing second artifact family:
+a separate directory, a separate module, a distinct check ABI, and silent when
+absent. It deliberately does not reuse the feature protocol — `list_user_features`
+applies no content filter, so anything under `features/` is put through the
+five-artifact gauntlet, and `_run_feature_checks` hardcodes the `features/`
+prefix in its output.
+
+The ABI returns `(issues, warnings)` rather than the feature `(CheckStatus, str)`:
+`CheckStatus` lives in `cli/validate.py`, which imports this module, so sharing
+the type would create a cycle. Warnings carry the same "visible gaps, not silent
+green" contract as `check_eval_criteria`.
+"""
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+FIXES_DIR = "fixes"
+FIX_RECORD_FILE = "fix.yaml"
+SCHEMA_REL = Path("governance") / "schemas" / "fix_record.schema.json"
+
+# Mirrors the schema's top-level `required`. Checked in-process so a malformed
+# record fails even where check-jsonschema is unavailable.
+_REQUIRED_KEYS = (
+    "version",
+    "id",
+    "summary",
+    "expectation",
+    "failure",
+    "surface",
+    "reproduction",
+    "risk",
+    "introduces_new_behavior",
+)
+
+# Written by `govkit fix init`. There is no shipped template file: a third copy
+# of this shape would be a drift surface, so the generator is pinned directly to
+# the schema by test_skeleton_validates_against_the_shipped_schema.
+FIX_RECORD_SKELETON = """\
+version: 1
+id: {id}
+summary: TODO - one line stating the defect, in the language of the behavior
+
+# Condition 1 - what already established this behavior. A fix that cannot cite a
+# source is introducing behavior, not restoring it, and belongs in the feature
+# lane. This path must resolve.
+expectation:
+  source: TODO/path/to/spec-contract-or-adr
+  reference: TODO - the scenario, section, or clause
+
+failure:
+  observed: TODO - what actually happens
+  reported_in: TODO - issue or incident reference
+
+# Condition 4 input. Cross-checked against the risk flags below.
+surface:
+  paths:
+    - TODO/path/to/changed/file
+
+# Condition 2 - the test that fails before the fix and passes after. Must resolve.
+reproduction:
+  test: TODO/path/to/regression_test
+  scenario: TODO - the test case name
+
+# Condition 4. Every flag is required so an omission cannot read as false.
+# A `true` does not waive anything - it means the change belongs in the feature
+# lane, and govkit validate will say so.
+risk:
+  architecture: false
+  security_auth: false
+  data_handling: false
+  public_contract: false
+  nfr: false
+  cross_service: false
+
+# Condition 3. `true` promotes the change to the feature lane.
+introduces_new_behavior: false
+
+evidence: []
+"""
+
+
+@dataclass
+class FixRecord:
+    """One `fixes/<id>/fix.yaml`. `errors` carries discovery failures — a
+    missing or unparseable record — so discovery never raises."""
+
+    id: str
+    root: Path
+    path: Path
+    data: dict = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def rel(self) -> str:
+        return f"{FIXES_DIR}/{self.id}/{FIX_RECORD_FILE}"
+
+
+def discover_fix_records(target: Path) -> list[FixRecord]:
+    """Scan `<target>/fixes/*/fix.yaml`.
+
+    Returns [] when the directory is absent — repos without a defect lane see
+    no change. Dot-directories and loose files are skipped. Never raises: a
+    record that cannot be read carries the reason in `.errors`.
+    """
+    root = target / FIXES_DIR
+    try:
+        if not root.is_dir():
+            return []
+        entries = sorted(root.iterdir())
+    except OSError:
+        return []
+
+    records = []
+    for entry in entries:
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        records.append(_load_record(entry))
+    return records
+
+
+def _load_record(root: Path) -> FixRecord:
+    path = root / FIX_RECORD_FILE
+    record = FixRecord(id=root.name, root=root, path=path)
+    if not path.is_file():
+        record.errors.append(f"{record.rel} not found")
+        return record
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        record.errors.append(f"{record.rel} could not be parsed: {exc}")
+        return record
+    if not isinstance(data, dict):
+        record.errors.append(f"{record.rel} is not a YAML mapping")
+        return record
+    record.data = data
+    return record
+
+
+def _check_required_keys(record: FixRecord) -> list[str]:
+    missing = [k for k in _REQUIRED_KEYS if k not in record.data]
+    if not missing:
+        return []
+    return [f"{record.rel} missing required key(s): {', '.join(missing)}"]
+
+
+def _check_id_matches_directory(record: FixRecord) -> list[str]:
+    declared = record.data.get("id")
+    if declared is None or declared == record.id:
+        return []
+    return [
+        f"{record.rel} declares id '{declared}' but sits in directory "
+        f"'{record.id}' — they must match"
+    ]
+
+
+def _validate_against_schema(
+    record: FixRecord, target: Path,
+) -> tuple[list[str], list[str]]:
+    """Instance validation, with the three-tier degradation `check_eval_criteria`
+    established: a missing schema or absent tool is a visible warning, never a
+    silent pass."""
+    schema = target / SCHEMA_REL
+    if not schema.is_file():
+        return [], [
+            f"{record.rel} structure OK — no fix_record schema installed; "
+            "instance validation skipped"
+        ]
+    try:
+        result = subprocess.run(
+            ["check-jsonschema", "--schemafile", str(schema), str(record.path)],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return [], [
+            f"{record.rel} structure OK — install check-jsonschema for full validation"
+        ]
+    if result.returncode != 0:
+        detail = (result.stdout or result.stderr or "").strip().splitlines()
+        snippet = detail[-1] if detail else "schema validation failed"
+        return [f"{record.rel} fails {schema.name}: {snippet}"], []
+    return [], []
+
+
+def validate_fix_record(
+    record: FixRecord, target: Path,
+) -> tuple[list[str], list[str]]:
+    """Return (issues, warnings) for one fix record.
+
+    Issues fail the run; warnings surface a gap without failing it. Structural
+    checks run first and short-circuit — there is no value in schema output
+    about a record that is missing half its keys.
+    """
+    if record.errors:
+        return list(record.errors), []
+
+    issues = [
+        *_check_required_keys(record),
+        *_check_id_matches_directory(record),
+    ]
+    if issues:
+        return issues, []
+
+    return _validate_against_schema(record, target)

--- a/cli/govkit.py
+++ b/cli/govkit.py
@@ -32,6 +32,7 @@ import argparse
 from .calibrate import register as _register_calibrate
 from .cmd_apply import register as _register_apply
 from .cmd_extension import register as _register_extension
+from .cmd_fix import register as _register_fix
 from .cmd_init import register as _register_init
 from .cmd_list import register as _register_list
 from .cmd_stack import register as _register_stack
@@ -49,6 +50,7 @@ _REGISTRARS = (
     _register_stack,
     _register_extension,
     _register_init,
+    _register_fix,
     _register_doctor,
     _register_calibrate,
     _register_validate,

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -738,6 +738,38 @@ def _run_extension_checks(target: Path, strict: bool) -> int:
     return 1 if any_fail else 0
 
 
+def _run_fix_checks(target: Path) -> int:
+    """Validate all discovered fix records. Silent when the defect lane is
+    absent — repos that never adopt it see no change.
+
+    Unlike extensions, an invalid fix record is a hard failure rather than a
+    strict-mode warning: the record is the *whole* governance artifact for that
+    change, so a broken one means the change is ungoverned. Warnings (no schema
+    installed, check-jsonschema missing) stay visible without failing, matching
+    check_eval_criteria.
+    """
+    from .fixes import FIXES_DIR, discover_fix_records, validate_fix_record
+
+    records = discover_fix_records(target)
+    if not records:
+        return 0
+
+    print(f"\ngovkit validate — {FIXES_DIR}/\n")
+    any_fail = False
+    for record in records:
+        issues, warnings = validate_fix_record(record, target)
+        for msg in warnings:
+            print(f"  {WARN}  {msg}")
+        if issues:
+            for msg in issues:
+                print(f"  {FAIL}  {msg}")
+            any_fail = True
+        elif not warnings:
+            print(f"  {PASS}  {record.rel}")
+    print()
+    return 1 if any_fail else 0
+
+
 def run_validation(target: Path, level: str | None = None, strict: bool = False) -> int:
     """Run all governance checks on the target project. Returns exit code."""
     if not target.exists():
@@ -762,6 +794,11 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
         )
         return ext_exit
 
+    # The defect lane is L4+, like the feature contract it sits beside. Checked
+    # before the features/ guard so a repo mid-setup still hears about a broken
+    # fix record rather than only the missing directory.
+    fix_exit = _run_fix_checks(target)
+
     features_dir = target / "features"
     if not features_dir.exists():
         print(f"Error: no features/ directory found in '{target}'.")
@@ -773,7 +810,7 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
 
     if not feature_dirs:
         print("No feature directories found to validate.")
-        return ext_exit
+        return max(ext_exit, fix_exit)
 
     level_labels = {
         "3": "L3 Governed AI Delivery (Foundations)",
@@ -787,4 +824,4 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
     failed = len(feature_dirs) - passed
     print(f"{len(feature_dirs)} feature(s) checked, {passed} passed, {failed} failed")
     feature_exit = 0 if failed == 0 else 1
-    return max(feature_exit, ext_exit)
+    return max(feature_exit, ext_exit, fix_exit)

--- a/features/README.md
+++ b/features/README.md
@@ -10,6 +10,11 @@ Copy the appropriate starter when beginning a new feature. Backend/data
 starters contain the five common artifacts. UI starters add `design.md` and
 reference-image guidance as a sixth governed input.
 
+Not every change is a feature. A defect that *restores* behavior something
+already established uses the defect lane instead — one record at
+`fixes/<id>/fix.yaml` from `govkit fix init <id>`, not five artifacts here.
+See the defect lifecycle in the root README.
+
 | Starter | Use for | Copy from |
 |---|---|---|
 | `starter_backend/` | Python / Hexagonal Architecture API features | `features/starter_backend/` |

--- a/governance/schemas/fix_record.schema.json
+++ b/governance/schemas/fix_record.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:governed-ai-delivery:schemas:fix_record",
+  "title": "Fix Record Schema",
+  "description": "Schema for fixes/<id>/fix.yaml — the single artifact of the defect lane. A fix that restores already-established behavior carries this one record instead of the five-artifact feature contract. Area-agnostic: the shape is the same for api, cli, ui, and data projects, so this lives in governance/schemas/ rather than governance/<area>/schemas/.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "id",
+    "summary",
+    "expectation",
+    "failure",
+    "surface",
+    "reproduction",
+    "risk",
+    "introduces_new_behavior"
+  ],
+  "properties": {
+    "version": {
+      "description": "Fix record format version.",
+      "type": "integer",
+      "minimum": 1
+    },
+
+    "id": {
+      "description": "Slug identifying this fix; must match the fixes/<id>/ directory name.",
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+
+    "summary": {
+      "description": "One line stating the defect, in the language of the affected behavior.",
+      "type": "string",
+      "minLength": 1
+    },
+
+    "expectation": {
+      "description": "Eligibility condition 1 — what already established the behavior being restored. A fix that cannot cite a source is introducing behavior, not restoring it, and belongs in the feature lane.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source"],
+      "properties": {
+        "source": {
+          "description": "Repo-relative path to the requirement, contract, ADR, or spec that established the behavior. Must resolve — govkit validate checks it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "reference": {
+          "description": "The specific scenario, section, or clause within that source.",
+          "type": "string"
+        }
+      }
+    },
+
+    "failure": {
+      "description": "What was actually observed, and where it was reported.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed"],
+      "properties": {
+        "observed": { "type": "string", "minLength": 1 },
+        "reported_in": {
+          "description": "Issue, incident, or report reference.",
+          "type": "string"
+        }
+      }
+    },
+
+    "surface": {
+      "description": "What the fix touches. Cross-checked against the risk flags below.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paths"],
+      "properties": {
+        "paths": {
+          "description": "Repo-relative paths changed by this fix.",
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+
+    "reproduction": {
+      "description": "Eligibility condition 2 — the test that fails before the fix and passes after.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["test"],
+      "properties": {
+        "test": {
+          "description": "Repo-relative path to the reproduction or regression test. Must resolve — govkit validate checks it.",
+          "type": "string",
+          "minLength": 1
+        },
+        "scenario": {
+          "description": "The specific test case name within that file.",
+          "type": "string"
+        }
+      }
+    },
+
+    "risk": {
+      "description": "Eligibility condition 4. Every flag is required so an omission cannot be read as false. Each is cross-checked against surface.paths in both directions: a false beside a change in that area fails, and so does a true — a true means the change belongs in the feature lane, not this one.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "architecture",
+        "security_auth",
+        "data_handling",
+        "public_contract",
+        "nfr",
+        "cross_service"
+      ],
+      "properties": {
+        "architecture": { "type": "boolean" },
+        "security_auth": { "type": "boolean" },
+        "data_handling": { "type": "boolean" },
+        "public_contract": { "type": "boolean" },
+        "nfr": { "type": "boolean" },
+        "cross_service": { "type": "boolean" }
+      }
+    },
+
+    "introduces_new_behavior": {
+      "description": "Eligibility condition 3. Must be false to stay in this lane; true promotes the change to the feature lane.",
+      "type": "boolean"
+    },
+
+    "evidence": {
+      "description": "Optional references supporting the fix — CI run, before/after capture, profiling output.",
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -233,7 +233,11 @@ def test_ui_nextjs_skill_content_parity(skill: str):
 PLANNING_SKILL_PATHS = [
     REPO_ROOT / "agents" / agent / "skills" / "backend" / skill / "SKILL.md"
     for agent in ("claude-code", "codex", "copilot")
-    for skill in ("spec-planning", "implementation-plan")
+    # fix-record plans a defect the way spec-planning plans a feature: it scopes
+    # to one service, reads the recorded architecture rather than asserting one,
+    # and must not guess. Registering it here inherits those guarantees instead
+    # of restating them in a parallel test.
+    for skill in ("spec-planning", "implementation-plan", "fix-record")
 ]
 
 SERVICES_HEADING = "## Multi-service repos"
@@ -244,9 +248,9 @@ def _planning_id(p: Path) -> str:
 
 
 def test_the_planning_skill_set_is_what_we_think_it_is():
-    """Six files: two planning skills across three agents. If a path moved,
+    """Nine files: three planning skills across three agents. If a path moved,
     the parametrized tests below would silently cover fewer files."""
-    assert len(PLANNING_SKILL_PATHS) == 6
+    assert len(PLANNING_SKILL_PATHS) == 9
     missing = [p for p in PLANNING_SKILL_PATHS if not p.is_file()]
     assert not missing, f"planning skills not found: {missing}"
 

--- a/tests/test_agent_skills.py
+++ b/tests/test_agent_skills.py
@@ -492,3 +492,32 @@ def test_architecture_guidance_parity_across_agents():
             f"{skill}: agents disagree on where the architecture comes from: {refs}"
         )
         assert refs["claude-code"] == (True, False)
+
+
+def test_parity_doc_skill_count_matches_reality():
+    """PARITY_TEST.md states the skill inventory as a number, and it had already
+    drifted (11 skills / 33 files against an actual 12 / 36) before the defect
+    lane added one. A stated count nothing checks is a count that goes stale."""
+    import re
+
+    skill_files = sorted(REPO_ROOT.glob("agents/*/skills/*/*/SKILL.md"))
+    agents = {p.parents[3].name for p in skill_files}
+    assert agents == {"claude-code", "codex", "copilot"}, agents
+
+    per_agent = len(skill_files) // len(agents)
+    doc = (REPO_ROOT / "PARITY_TEST.md").read_text(encoding="utf-8")
+    match = re.search(
+        r"The (\d+) skills \((\d+) backend \+ (\d+) UI\) × 3 agents = (\d+) SKILL\.md files",
+        doc,
+    )
+    assert match, "PARITY_TEST.md no longer states the skill inventory in the pinned form"
+    stated_total, stated_backend, stated_ui, stated_files = (int(g) for g in match.groups())
+
+    backend = len({p.parent.name for p in skill_files if p.parents[1].name == "backend"})
+    ui = len({p.parent.name for p in skill_files if p.parents[1].name == "ui"})
+    assert (stated_backend, stated_ui) == (backend, ui), (
+        f"PARITY_TEST.md says {stated_backend} backend + {stated_ui} UI; "
+        f"the tree has {backend} + {ui}"
+    )
+    assert stated_total == per_agent == backend + ui
+    assert stated_files == len(skill_files)

--- a/tests/test_cmd_fix.py
+++ b/tests/test_cmd_fix.py
@@ -132,3 +132,30 @@ class TestWiring:
 
         modules = [r.__module__ for r in govkit._REGISTRARS]
         assert "cli.cmd_fix" in modules, modules
+
+
+class TestTargetValidation:
+    """Consistent with `govkit extension add`: a bad --target is an error, not a
+    directory tree conjured somewhere surprising."""
+
+    def test_missing_target_errors_before_creating_anything(self, tmp_path, capsys):
+        missing = tmp_path / "nope"
+        with pytest.raises(SystemExit) as exc:
+            cmd_fix_init(_args(missing))
+        assert exc.value.code == 1
+        assert not missing.exists(), "target was created despite being invalid"
+
+    def test_file_as_target_errors(self, tmp_path, capsys):
+        not_a_dir = tmp_path / "afile"
+        not_a_dir.write_text("x", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            cmd_fix_init(_args(not_a_dir))
+        assert exc.value.code == 1
+
+    def test_target_check_precedes_the_level_gate(self, tmp_path):
+        """A missing target reads the marker from nowhere and would otherwise
+        resolve to L3, reporting the wrong problem."""
+        missing = tmp_path / "nope"
+        with pytest.raises(SystemExit):
+            cmd_fix_init(_args(missing, level="4"))
+        assert not missing.exists()

--- a/tests/test_cmd_fix.py
+++ b/tests/test_cmd_fix.py
@@ -1,0 +1,134 @@
+"""`govkit fix init` — scaffolds one fix record for the defect lane.
+
+Mirrors `govkit init`'s level gate: the defect lane is L4+, because L3
+(Foundations) ships agent rules and architecture contracts only and has no
+artifact model at all.
+
+Unlike `govkit init`, it does not require an existing `features/` directory —
+`fixes/` is created on demand and is never shipped by apply.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+from cli.cmd_fix import cmd_fix_init, register
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_SRC = REPO_ROOT / "governance" / "schemas" / "fix_record.schema.json"
+
+
+def _marker(target: Path, level: str = "4") -> None:
+    (target / ".govkit").mkdir(parents=True, exist_ok=True)
+    (target / ".govkit" / "marker.json").write_text(
+        json.dumps({
+            "version": "0.18.0",
+            "level": level,
+            "agent": "claude-code",
+            "options": {"type": "api", "ci": "github"},
+            "applied_at": "2026-08-13T00:00:00Z",
+        }),
+        encoding="utf-8",
+    )
+
+
+def _args(target: Path, fix_id: str = "sample", level: str | None = None):
+    return argparse.Namespace(fix_id=fix_id, target=str(target), level=level)
+
+
+class TestLevelGate:
+    def test_errors_at_l3(self, tmp_path, capsys):
+        _marker(tmp_path, level="3")
+        with pytest.raises(SystemExit) as exc:
+            cmd_fix_init(_args(tmp_path))
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "Level 4" in out
+        assert not (tmp_path / "fixes").exists()
+
+    def test_errors_with_no_marker(self, tmp_path, capsys):
+        """No marker resolves to L3, matching govkit init."""
+        with pytest.raises(SystemExit) as exc:
+            cmd_fix_init(_args(tmp_path))
+        assert exc.value.code == 1
+
+    def test_explicit_level_flag_overrides_marker(self, tmp_path):
+        _marker(tmp_path, level="3")
+        cmd_fix_init(_args(tmp_path, level="4"))
+        assert (tmp_path / "fixes" / "sample" / "fix.yaml").is_file()
+
+    def test_works_at_l5(self, tmp_path):
+        _marker(tmp_path, level="5")
+        cmd_fix_init(_args(tmp_path))
+        assert (tmp_path / "fixes" / "sample" / "fix.yaml").is_file()
+
+
+class TestScaffold:
+    def test_creates_record_without_requiring_features_dir(self, tmp_path):
+        """fixes/ is created on demand; apply never ships it."""
+        _marker(tmp_path)
+        assert not (tmp_path / "features").exists()
+        cmd_fix_init(_args(tmp_path, "task-filter-reset"))
+        assert (tmp_path / "fixes" / "task-filter-reset" / "fix.yaml").is_file()
+
+    def test_record_carries_the_requested_id(self, tmp_path):
+        _marker(tmp_path)
+        cmd_fix_init(_args(tmp_path, "task-filter-reset"))
+        data = yaml.safe_load(
+            (tmp_path / "fixes" / "task-filter-reset" / "fix.yaml").read_text(encoding="utf-8")
+        )
+        assert data["id"] == "task-filter-reset"
+
+    def test_scaffolded_record_validates_against_the_schema(self, tmp_path):
+        """Structurally complete on creation — what fails is eligibility, which
+        is the point: the placeholders must be replaced with resolvable paths."""
+        _marker(tmp_path)
+        cmd_fix_init(_args(tmp_path))
+        data = yaml.safe_load(
+            (tmp_path / "fixes" / "sample" / "fix.yaml").read_text(encoding="utf-8")
+        )
+        schema = json.loads(SCHEMA_SRC.read_text(encoding="utf-8"))
+        errors = list(Draft202012Validator(schema).iter_errors(data))
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_refuses_to_overwrite_an_existing_record(self, tmp_path, capsys):
+        _marker(tmp_path)
+        cmd_fix_init(_args(tmp_path))
+        existing = tmp_path / "fixes" / "sample" / "fix.yaml"
+        existing.write_text("edited by hand\n", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            cmd_fix_init(_args(tmp_path))
+        assert exc.value.code == 1
+        assert existing.read_text(encoding="utf-8") == "edited by hand\n"
+
+    @pytest.mark.parametrize("bad_id", ["Has Spaces", "UPPER", "-leading", "with/slash"])
+    def test_rejects_ids_the_schema_would_reject(self, tmp_path, bad_id, capsys):
+        """Fail at creation rather than producing a record that cannot validate."""
+        _marker(tmp_path)
+        with pytest.raises(SystemExit) as exc:
+            cmd_fix_init(_args(tmp_path, bad_id))
+        assert exc.value.code == 1
+        assert not (tmp_path / "fixes").exists()
+
+
+class TestWiring:
+    def test_registers_the_fix_init_subcommand(self):
+        """A dropped registration is invisible to every other test here."""
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        register(subparsers)
+        args = parser.parse_args(["fix", "init", "my-defect", "--target", "."])
+        assert args.func is cmd_fix_init
+        assert args.fix_id == "my-defect"
+
+    def test_registered_in_the_main_dispatch_table(self):
+        """Every registrar is imported as a bare `register`, so identity is in
+        the defining module, not the function name."""
+        from cli import govkit
+
+        modules = [r.__module__ for r in govkit._REGISTRARS]
+        assert "cli.cmd_fix" in modules, modules

--- a/tests/test_fix_lane_gate_checks.py
+++ b/tests/test_fix_lane_gate_checks.py
@@ -1,0 +1,181 @@
+"""Behavior tests for the fix-lane gate's embedded checker.
+
+This gate exists because `govkit validate` structurally cannot do its job:
+validate is a working-tree tool, so it can prove a fix record is internally
+consistent but not that its declarations match what the PR actually changed.
+Only the diff can, and only CI has it.
+
+Following `tests/test_dbt_gate_checks.py` and `tests/test_eval_gate_checks.py`:
+extract the heredoc, execute it against fixtures, and pin the two platform
+embeddings identical so they cannot drift.
+
+The gate is deliberately self-contained — it never invokes govkit. Delegating
+would make a blocking gate depend on an unpinned PyPI release, and
+`run_validation` short-circuits to exit 0 when the marker is missing or stale,
+so a gate calling it could be disabled from inside the PR under review.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_PATHS = {
+    "github": REPO_ROOT / "ci" / "github" / "fix-lane-gate.yml",
+    "azure": REPO_ROOT / "ci" / "azure" / "fix-lane-gate.yml",
+}
+
+CONFIGURED = "src/"
+
+
+def _extract_checker(gate_path: Path) -> str:
+    raw = gate_path.read_text(encoding="utf-8")
+    marker = "python - <<'EOF'\n"
+    start = raw.index(marker) + len(marker)
+    body = []
+    for line in raw[start:].splitlines():
+        if line.strip() == "EOF":
+            break
+        body.append(line)
+    return textwrap.dedent("\n".join(body)) + "\n"
+
+
+def _run(
+    tmp_path: Path,
+    changed: list[str],
+    source_paths: str = CONFIGURED,
+    records: dict[str, dict] | None = None,
+) -> subprocess.CompletedProcess:
+    for rel, data in (records or {}).items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    script = tmp_path / "_gate.py"
+    script.write_text(_extract_checker(GATE_PATHS["github"]), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        input="\n".join(changed),
+        capture_output=True,
+        text=True,
+        env={"SOURCE_PATHS": source_paths, "PATH": "", "SYSTEMROOT": ""},
+    )
+
+
+def _record(paths: list[str]) -> dict:
+    return {"version": 1, "id": "alpha", "surface": {"paths": paths}}
+
+
+def test_checker_extraction_is_not_empty():
+    """Non-vacuous guard: a changed heredoc marker would make every test below
+    run an empty script and trivially pass."""
+    body = _extract_checker(GATE_PATHS["github"])
+    assert "SOURCE_PATHS" in body and "surface" in body, body[:300]
+
+
+class TestInactiveUntilConfigured:
+    def test_unconfigured_sentinel_passes(self, tmp_path):
+        """A fresh install must stay green — the opt-in posture."""
+        result = _run(tmp_path, ["src/app.py"], source_paths="YOUR_SOURCE_PATHS")
+        assert result.returncode == 0, result.stdout
+        assert "inactive" in result.stdout
+
+    def test_empty_source_paths_passes(self, tmp_path):
+        result = _run(tmp_path, ["src/app.py"], source_paths="")
+        assert result.returncode == 0, result.stdout
+
+
+class TestEscapeHatch:
+    def test_source_change_with_no_governing_artifact_fails(self, tmp_path):
+        """The whole point: this is what passed every other gate untouched."""
+        result = _run(tmp_path, ["src/app.py"])
+        assert result.returncode == 1, result.stdout
+        assert "no governing artifact" in result.stdout
+
+    def test_docs_only_change_is_not_this_gate_s_business(self, tmp_path):
+        result = _run(tmp_path, ["README.md", "docs/backend/architecture/X.md"])
+        assert result.returncode == 0, result.stdout
+
+    def test_feature_change_satisfies_the_gate(self, tmp_path):
+        """The feature lane is still a governing artifact."""
+        result = _run(
+            tmp_path, ["src/app.py", "features/billing/plan.md", "src/test_app.py"]
+        )
+        assert result.returncode == 0, result.stdout
+
+
+class TestCorrespondence:
+    def test_declared_surface_matching_the_diff_passes(self, tmp_path):
+        result = _run(
+            tmp_path,
+            ["src/app.py", "src/test_app.py", "fixes/alpha/fix.yaml"],
+            records={"fixes/alpha/fix.yaml": _record(["src/app.py"])},
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_source_changed_but_not_declared_fails(self, tmp_path):
+        """validate cannot catch this — surface.paths and risk are both declared,
+        so they agree with each other while disagreeing with reality."""
+        result = _run(
+            tmp_path,
+            ["src/app.py", "src/sneaky.py", "src/test_app.py", "fixes/alpha/fix.yaml"],
+            records={"fixes/alpha/fix.yaml": _record(["src/app.py"])},
+        )
+        assert result.returncode == 1, result.stdout
+        assert "sneaky.py" in result.stdout
+
+    def test_fix_record_without_a_test_in_the_diff_fails(self, tmp_path):
+        """Condition 2 is only provable against the diff."""
+        result = _run(
+            tmp_path,
+            ["src/app.py", "fixes/alpha/fix.yaml"],
+            records={"fixes/alpha/fix.yaml": _record(["src/app.py"])},
+        )
+        assert result.returncode == 1, result.stdout
+        assert "no test" in result.stdout
+
+    def test_unreadable_record_is_reported_not_crashed(self, tmp_path):
+        path = tmp_path / "fixes" / "alpha" / "fix.yaml"
+        path.parent.mkdir(parents=True)
+        path.write_text("key: [unclosed\n", encoding="utf-8")
+        result = _run(
+            tmp_path, ["src/app.py", "src/test_app.py", "fixes/alpha/fix.yaml"]
+        )
+        assert result.returncode == 1, result.stdout
+        assert "could not be read" in result.stdout
+
+    def test_multiple_source_roots_are_honoured(self, tmp_path):
+        result = _run(
+            tmp_path,
+            ["lib/util.py", "lib/test_util.py", "fixes/alpha/fix.yaml"],
+            source_paths="src/,lib/",
+            records={"fixes/alpha/fix.yaml": _record(["lib/util.py"])},
+        )
+        assert result.returncode == 0, result.stdout
+
+
+def test_platform_embeddings_are_identical():
+    github = _extract_checker(GATE_PATHS["github"])
+    azure = _extract_checker(GATE_PATHS["azure"])
+    assert github == azure, "github and azure fix-lane checkers have drifted"
+
+
+@pytest.mark.parametrize("platform", sorted(GATE_PATHS))
+def test_gate_does_not_invoke_govkit(platform):
+    """Self-contained by design: a blocking gate must not depend on an unpinned
+    PyPI release, and run_validation exits 0 on a missing marker — so a gate
+    delegating to it could be switched off from inside the PR it is reviewing."""
+    text = GATE_PATHS[platform].read_text(encoding="utf-8")
+    # Mentions in comments and remediation output are fine and wanted — what
+    # must not appear is an executed command.
+    invocations = [
+        ln for ln in text.splitlines()
+        if ln.strip().startswith(("run: govkit", "- script: govkit", "govkit "))
+    ]
+    assert not invocations, invocations

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -34,8 +34,10 @@ def _valid_record(record_id: str = "task-filter-reset") -> dict:
         "id": record_id,
         "summary": "Filter resets when navigating back",
         "expectation": {
-            "source": "features/sample/acceptance.feature",
-            "reference": "Scenario: Filter persists",
+            # Deliberately not under features/ — materializing a path there
+            # would create a directory list_user_features treats as a feature.
+            "source": "docs/backend/architecture/API_CONVENTIONS.md",
+            "reference": "Section 4: pagination state",
         },
         "failure": {"observed": "Filter discarded on back-navigation"},
         "surface": {"paths": ["src/hooks/useTaskFilter.ts"]},
@@ -61,6 +63,16 @@ def _write_record(target: Path, record_id: str, data) -> Path:
     else:
         path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
     return path
+
+
+def _materialize(target: Path, data: dict) -> None:
+    """Create the files a record references, so eligibility checks resolve.
+    Tests that assert on *non*-resolution deliberately skip this."""
+    rels = [data["expectation"]["source"], data["reproduction"]["test"], *data["surface"]["paths"]]
+    for rel in rels:
+        f = target / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("x", encoding="utf-8")
 
 
 def _install_schema(target: Path) -> None:
@@ -109,6 +121,7 @@ class TestDiscovery:
 class TestValidation:
     def test_valid_record_has_no_issues(self, tmp_path):
         _install_schema(tmp_path)
+        _materialize(tmp_path, _valid_record("alpha"))
         _write_record(tmp_path, "alpha", _valid_record("alpha"))
         record = discover_fix_records(tmp_path)[0]
         issues, _ = validate_fix_record(record, tmp_path)
@@ -142,6 +155,7 @@ class TestValidation:
 
     def test_missing_schema_warns_rather_than_passing_silently(self, tmp_path):
         """No schema installed is a visible gap, not silent green."""
+        _materialize(tmp_path, _valid_record("alpha"))
         _write_record(tmp_path, "alpha", _valid_record("alpha"))
         record = discover_fix_records(tmp_path)[0]
         issues, warnings = validate_fix_record(record, tmp_path)
@@ -204,6 +218,7 @@ class TestValidateIntegration:
 
         target = self._target(tmp_path)
         _install_schema(target)
+        _materialize(target, _valid_record("alpha"))
         _write_record(target, "alpha", _valid_record("alpha"))
         assert run_validation(target) == 0
         assert "alpha" in capsys.readouterr().out
@@ -241,6 +256,124 @@ class TestValidateIntegration:
         from cli.validate import run_validation
 
         target = self._target(tmp_path)
+        _materialize(target, _valid_record("alpha"))
         _write_record(target, "alpha", _valid_record("alpha"))
         assert run_validation(target) == 0
         assert "schema" in capsys.readouterr().out
+
+
+class TestEligibility:
+    """The four conditions, checked as far as a working-tree tool honestly can.
+
+    `surface.paths` is *declared*, not derived from a diff, so cross-checking
+    risk against it proves internal consistency — not correspondence with what
+    the PR actually changed. That correspondence is CI's job, where the diff
+    exists. Same split as declared-vs-computed averages in plan.md.
+    """
+
+    def _record_with(self, tmp_path: Path, **overrides) -> tuple:
+        _install_schema(tmp_path)
+        data = _valid_record("alpha")
+        for key, value in overrides.items():
+            data[key] = value
+        _write_record(tmp_path, "alpha", data)
+        return discover_fix_records(tmp_path)[0], tmp_path
+
+    def _touch(self, tmp_path: Path, rel: str) -> None:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+
+    def _fully_resolvable(self, tmp_path: Path) -> dict:
+        data = _valid_record("alpha")
+        _materialize(tmp_path, data)
+        return data
+
+    def test_fully_resolvable_record_passes(self, tmp_path):
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", self._fully_resolvable(tmp_path))
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert issues == [], issues
+
+    def test_unresolved_expectation_source_fails(self, tmp_path):
+        """Condition 1 is otherwise pure assertion."""
+        record, target = self._record_with(tmp_path)
+        issues, _ = validate_fix_record(record, target)
+        assert any("expectation.source" in i for i in issues), issues
+
+    def test_missing_reproduction_test_fails(self, tmp_path):
+        """Condition 2: no regression test, no light lane."""
+        self._touch(tmp_path, "docs/backend/architecture/API_CONVENTIONS.md")
+        self._touch(tmp_path, "src/hooks/useTaskFilter.ts")
+        record, target = self._record_with(tmp_path)
+        issues, _ = validate_fix_record(record, target)
+        assert any("reproduction.test" in i for i in issues), issues
+
+    def test_missing_surface_path_fails(self, tmp_path):
+        self._touch(tmp_path, "docs/backend/architecture/API_CONVENTIONS.md")
+        self._touch(tmp_path, "src/hooks/useTaskFilter.test.ts")
+        record, target = self._record_with(tmp_path)
+        issues, _ = validate_fix_record(record, target)
+        assert any("surface.paths" in i for i in issues), issues
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["architecture", "security_auth", "data_handling", "public_contract", "nfr", "cross_service"],
+    )
+    def test_any_risk_flag_true_promotes_to_the_feature_lane(self, tmp_path, flag):
+        """A `true` is not a waiver — it means this change is out of the lane."""
+        data = self._fully_resolvable(tmp_path)
+        data["risk"][flag] = True
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert any("feature lane" in i for i in issues), issues
+        assert any(flag in i for i in issues), issues
+
+    def test_new_behavior_promotes_to_the_feature_lane(self, tmp_path):
+        """Condition 3."""
+        data = self._fully_resolvable(tmp_path)
+        data["introduces_new_behavior"] = True
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert any("feature lane" in i for i in issues), issues
+
+    @pytest.mark.parametrize(
+        "path, flag",
+        [
+            ("docs/backend/architecture/ARCH_CONTRACT.md", "architecture"),
+            ("features/sample/nfrs.md", "nfr"),
+            ("governance/backend/schemas/eval_criteria.schema.json", "public_contract"),
+            # Area-agnostic schemas have no <area> segment; a pattern requiring
+            # one silently missed them, which a real-CLI run caught.
+            ("governance/schemas/fix_record.schema.json", "public_contract"),
+        ],
+    )
+    def test_touching_a_governed_area_contradicts_a_false_flag(self, tmp_path, path, flag):
+        """The other half of the two-sided check: a false beside a change in a
+        govkit-owned namespace is a contradiction the record must not carry."""
+        data = self._fully_resolvable(tmp_path)
+        data["surface"]["paths"] = [path]
+        self._touch(tmp_path, path)
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert any(flag in i for i in issues), issues
+
+    def test_undecidable_flags_are_not_guessed(self, tmp_path):
+        """govkit owns no namespace that definitionally means 'security' or
+        'data handling', so those declarations stand alone rather than being
+        cross-checked against an invented glob."""
+        data = self._fully_resolvable(tmp_path)
+        data["surface"]["paths"] = ["src/auth/session.ts"]
+        self._touch(tmp_path, "src/auth/session.ts")
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert issues == [], issues

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -1,0 +1,170 @@
+"""Discovery and validation for the defect lane's fix records.
+
+Modelled on `cli/extensions.py` — the repo's existing second artifact family.
+Like extensions, this is a separate directory, a separate module, a distinct
+check ABI, and silent when absent. It deliberately does **not** reuse the feature
+check protocol: `list_user_features` applies no content filter, so anything under
+`features/` gets the five-artifact gauntlet, and `_run_feature_checks` hardcodes
+the `features/` prefix in its output.
+
+The ABI returns `(issues, warnings)` rather than the feature `(CheckStatus, str)`
+because `CheckStatus` lives in `cli/validate.py`, which imports this module —
+sharing the type would make a cycle. Warnings carry the same
+"visible gaps, not silent green" contract `check_eval_criteria` uses.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cli.fixes import (
+    FIX_RECORD_SKELETON,
+    discover_fix_records,
+    validate_fix_record,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_SRC = REPO_ROOT / "governance" / "schemas" / "fix_record.schema.json"
+
+
+def _valid_record(record_id: str = "task-filter-reset") -> dict:
+    return {
+        "version": 1,
+        "id": record_id,
+        "summary": "Filter resets when navigating back",
+        "expectation": {
+            "source": "features/sample/acceptance.feature",
+            "reference": "Scenario: Filter persists",
+        },
+        "failure": {"observed": "Filter discarded on back-navigation"},
+        "surface": {"paths": ["src/hooks/useTaskFilter.ts"]},
+        "reproduction": {"test": "src/hooks/useTaskFilter.test.ts"},
+        "risk": {
+            "architecture": False,
+            "security_auth": False,
+            "data_handling": False,
+            "public_contract": False,
+            "nfr": False,
+            "cross_service": False,
+        },
+        "introduces_new_behavior": False,
+    }
+
+
+def _write_record(target: Path, record_id: str, data) -> Path:
+    d = target / "fixes" / record_id
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / "fix.yaml"
+    if isinstance(data, str):
+        path.write_text(data, encoding="utf-8")
+    else:
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _install_schema(target: Path) -> None:
+    """Mirror what `govkit apply` ships: the schema as a governed file."""
+    dest = target / "governance" / "schemas"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "fix_record.schema.json").write_text(
+        SCHEMA_SRC.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+class TestDiscovery:
+    def test_no_fixes_dir_is_silent(self, tmp_path):
+        """Existing repos must see no change — absence is not a finding."""
+        assert discover_fix_records(tmp_path) == []
+
+    def test_empty_fixes_dir(self, tmp_path):
+        (tmp_path / "fixes").mkdir()
+        assert discover_fix_records(tmp_path) == []
+
+    def test_finds_records(self, tmp_path):
+        _write_record(tmp_path, "alpha", _valid_record("alpha"))
+        _write_record(tmp_path, "beta", _valid_record("beta"))
+        found = discover_fix_records(tmp_path)
+        assert [r.id for r in found] == ["alpha", "beta"]
+
+    def test_ignores_dotdirs_and_loose_files(self, tmp_path):
+        _write_record(tmp_path, "alpha", _valid_record("alpha"))
+        (tmp_path / "fixes" / ".scratch").mkdir()
+        (tmp_path / "fixes" / "README.md").write_text("notes", encoding="utf-8")
+        assert [r.id for r in discover_fix_records(tmp_path)] == ["alpha"]
+
+    def test_missing_fix_yaml_is_an_error_not_a_crash(self, tmp_path):
+        (tmp_path / "fixes" / "alpha").mkdir(parents=True)
+        found = discover_fix_records(tmp_path)
+        assert len(found) == 1
+        assert found[0].errors
+
+    def test_unparseable_yaml_is_an_error_not_a_crash(self, tmp_path):
+        _write_record(tmp_path, "alpha", "key: [unclosed\n")
+        found = discover_fix_records(tmp_path)
+        assert len(found) == 1
+        assert found[0].errors
+
+
+class TestValidation:
+    def test_valid_record_has_no_issues(self, tmp_path):
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", _valid_record("alpha"))
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert issues == []
+
+    def test_id_must_match_directory_name(self, tmp_path):
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", _valid_record("something-else"))
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert any("directory" in i for i in issues), issues
+
+    @pytest.mark.parametrize(
+        "key", ["version", "summary", "expectation", "failure", "surface", "reproduction", "risk"],
+    )
+    def test_missing_required_key_is_an_issue(self, tmp_path, key):
+        """The structural pre-check runs in-process, so a malformed record fails
+        even where check-jsonschema is unavailable."""
+        data = _valid_record("alpha")
+        del data[key]
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert any(key in i for i in issues), issues
+
+    def test_discovery_error_passes_through(self, tmp_path):
+        (tmp_path / "fixes" / "alpha").mkdir(parents=True)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert issues
+
+    def test_missing_schema_warns_rather_than_passing_silently(self, tmp_path):
+        """No schema installed is a visible gap, not silent green."""
+        _write_record(tmp_path, "alpha", _valid_record("alpha"))
+        record = discover_fix_records(tmp_path)[0]
+        issues, warnings = validate_fix_record(record, tmp_path)
+        assert issues == []
+        assert any("schema" in w for w in warnings), warnings
+
+
+class TestSkeleton:
+    def test_skeleton_is_valid_yaml(self):
+        assert isinstance(yaml.safe_load(FIX_RECORD_SKELETON.format(id="sample")), dict)
+
+    def test_skeleton_validates_against_the_shipped_schema(self):
+        """Pins the generator to the schema. There is no template file, so this
+        is what stops `govkit fix init` output drifting from what validates."""
+        import json
+
+        from jsonschema import Draft202012Validator
+
+        schema = json.loads(SCHEMA_SRC.read_text(encoding="utf-8"))
+        instance = yaml.safe_load(FIX_RECORD_SKELETON.format(id="sample"))
+        errors = list(Draft202012Validator(schema).iter_errors(instance))
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_skeleton_carries_the_requested_id(self):
+        instance = yaml.safe_load(FIX_RECORD_SKELETON.format(id="my-defect"))
+        assert instance["id"] == "my-defect"

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -377,3 +377,149 @@ class TestEligibility:
         record = discover_fix_records(tmp_path)[0]
         issues, _ = validate_fix_record(record, tmp_path)
         assert issues == [], issues
+
+
+class TestPathSafety:
+    """Record-authored paths must be repo-relative and contained.
+
+    Mirrors `cli/extensions.py::_check_safe_file_path`. A record is authored by
+    an agent, so "the path exists" is not the question — "the path is inside the
+    repo it claims to describe" is.
+    """
+
+    def _record(self, tmp_path: Path, **overrides) -> tuple:
+        _install_schema(tmp_path)
+        data = _valid_record("alpha")
+        _materialize(tmp_path, data)
+        for dotted, value in overrides.items():
+            section, _, key = dotted.partition(".")
+            if key:
+                data[section][key] = value
+            else:
+                data[section] = value
+        _write_record(tmp_path, "alpha", data)
+        return discover_fix_records(tmp_path)[0], tmp_path
+
+    @pytest.mark.parametrize("abs_path", ["/etc/passwd", "C:\Windows\system.ini"])
+    @pytest.mark.parametrize("field", ["expectation.source", "reproduction.test"])
+    def test_absolute_paths_are_rejected(self, tmp_path, field, abs_path):
+        """Path.is_absolute() is host-specific, so both flavours must be caught."""
+        record, target = self._record(tmp_path, **{field: abs_path})
+        issues, _ = validate_fix_record(record, target)
+        assert any("absolute" in i for i in issues), issues
+
+    @pytest.mark.parametrize("field", ["expectation.source", "reproduction.test"])
+    def test_parent_escape_is_rejected(self, tmp_path, field):
+        outside = tmp_path.parent / "outside.md"
+        outside.write_text("x", encoding="utf-8")
+        record, target = self._record(tmp_path, **{field: f"../{outside.name}"})
+        issues, _ = validate_fix_record(record, target)
+        assert any("outside" in i for i in issues), issues
+
+    def test_surface_path_escape_is_rejected(self, tmp_path):
+        outside = tmp_path.parent / "outside.py"
+        outside.write_text("x", encoding="utf-8")
+        record, target = self._record(tmp_path, **{"surface.paths": [f"../{outside.name}"]})
+        issues, _ = validate_fix_record(record, target)
+        assert any("outside" in i for i in issues), issues
+
+    @pytest.mark.parametrize("field", ["expectation.source", "reproduction.test"])
+    def test_directory_is_not_a_valid_citation(self, tmp_path, field):
+        """A citation names a spec or a test, not a folder."""
+        (tmp_path / "docs" / "backend" / "architecture").mkdir(parents=True, exist_ok=True)
+        record, target = self._record(
+            tmp_path, **{field: "docs/backend/architecture"}
+        )
+        issues, _ = validate_fix_record(record, target)
+        assert any("not a file" in i for i in issues), issues
+
+    def test_dot_slash_prefix_is_tolerated(self, tmp_path):
+        """`./src/x.py` is the same path as `src/x.py` and must not be rejected,
+        nor mangled — the old lstrip('./') turned '../x' into 'x', silently
+        erasing an escape."""
+        data = _valid_record("alpha")
+        _materialize(tmp_path, data)
+        data["surface"]["paths"] = ["./" + data["surface"]["paths"][0]]
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert issues == [], issues
+
+    def test_governed_area_match_survives_a_dot_slash_prefix(self, tmp_path):
+        """Normalization must not be able to hide a governed-area path."""
+        data = _valid_record("alpha")
+        _materialize(tmp_path, data)
+        data["surface"]["paths"] = ["./features/sample/nfrs.md"]
+        (tmp_path / "features" / "sample").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "features" / "sample" / "nfrs.md").write_text("x", encoding="utf-8")
+        _install_schema(tmp_path)
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, _ = validate_fix_record(record, tmp_path)
+        assert any("nfr" in i for i in issues), issues
+
+
+class TestNestedStructureWithoutSchemaTooling:
+    """The record is the *whole* governance artifact for a defect-lane change.
+    When the schema or check-jsonschema is unavailable, a warning is the right
+    signal for reduced coverage — but an incomplete record must still fail.
+    """
+
+    def _issues(self, tmp_path: Path, data: dict) -> list[str]:
+        # Deliberately no _install_schema: this is the degraded path.
+        _write_record(tmp_path, "alpha", data)
+        record = discover_fix_records(tmp_path)[0]
+        issues, warnings = validate_fix_record(record, tmp_path)
+        assert any("schema" in w for w in warnings), warnings
+        return issues
+
+    def test_expectation_without_a_source_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["expectation"] = {"reference": "somewhere"}
+        assert any("expectation.source" in i for i in self._issues(tmp_path, data))
+
+    def test_empty_expectation_source_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["expectation"]["source"] = "   "
+        assert any("expectation.source" in i for i in self._issues(tmp_path, data))
+
+    def test_reproduction_without_a_test_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["reproduction"] = {}
+        assert any("reproduction.test" in i for i in self._issues(tmp_path, data))
+
+    def test_empty_surface_paths_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["surface"]["paths"] = []
+        assert any("surface.paths" in i for i in self._issues(tmp_path, data))
+
+    def test_non_string_surface_path_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["surface"]["paths"] = [123]
+        assert any("surface.paths" in i for i in self._issues(tmp_path, data))
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["architecture", "security_auth", "data_handling", "public_contract", "nfr", "cross_service"],
+    )
+    def test_missing_risk_flag_fails(self, tmp_path, flag):
+        data = _valid_record("alpha")
+        del data["risk"][flag]
+        assert any(flag in i for i in self._issues(tmp_path, data))
+
+    def test_non_boolean_risk_flag_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["risk"]["architecture"] = "no"
+        assert any("architecture" in i for i in self._issues(tmp_path, data))
+
+    def test_non_boolean_introduces_new_behavior_fails(self, tmp_path):
+        data = _valid_record("alpha")
+        data["introduces_new_behavior"] = "no"
+        assert any("introduces_new_behavior" in i for i in self._issues(tmp_path, data))
+
+    @pytest.mark.parametrize("section", ["expectation", "failure", "surface", "reproduction", "risk"])
+    def test_non_mapping_section_fails(self, tmp_path, section):
+        data = _valid_record("alpha")
+        data[section] = "not a mapping"
+        assert self._issues(tmp_path, data)

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -168,3 +168,79 @@ class TestSkeleton:
     def test_skeleton_carries_the_requested_id(self):
         instance = yaml.safe_load(FIX_RECORD_SKELETON.format(id="my-defect"))
         assert instance["id"] == "my-defect"
+
+
+class TestValidateIntegration:
+    """`run_validation` gains a second artifact family, exactly as extensions
+    did: silent when absent, its own exit code, combined via max()."""
+
+    def _target(self, tmp_path: Path, level: str = "4") -> Path:
+        import json
+
+        (tmp_path / ".govkit").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".govkit" / "marker.json").write_text(
+            json.dumps({
+                "version": "0.18.0", "level": level, "agent": "claude-code",
+                "options": {"type": "api", "ci": "github"},
+                "applied_at": "2026-08-13T00:00:00Z",
+            }),
+            encoding="utf-8",
+        )
+        # Empty features/ isolates the fix lane: list_user_features returns [],
+        # so the only thing that can move the exit code is the fix record.
+        (tmp_path / "features").mkdir(exist_ok=True)
+        return tmp_path
+
+    def test_absent_lane_is_silent(self, tmp_path, capsys):
+        """Repos without a defect lane must see no output change at all."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        assert run_validation(target) == 0
+        assert "fix" not in capsys.readouterr().out.lower()
+
+    def test_valid_record_passes_and_is_reported(self, tmp_path, capsys):
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        _install_schema(target)
+        _write_record(target, "alpha", _valid_record("alpha"))
+        assert run_validation(target) == 0
+        assert "alpha" in capsys.readouterr().out
+
+    def test_invalid_record_fails_the_run(self, tmp_path):
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        data = _valid_record("alpha")
+        del data["risk"]
+        _write_record(target, "alpha", data)
+        assert run_validation(target) == 1
+
+    def test_lane_is_not_checked_at_l3(self, tmp_path):
+        """L3 ships no artifact model; the defect lane starts at L4."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path, level="3")
+        data = _valid_record("alpha")
+        del data["risk"]
+        _write_record(target, "alpha", data)
+        assert run_validation(target) == 0
+
+    def test_lane_is_checked_at_l5(self, tmp_path):
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path, level="5")
+        data = _valid_record("alpha")
+        del data["risk"]
+        _write_record(target, "alpha", data)
+        assert run_validation(target) == 1
+
+    def test_warning_alone_does_not_fail(self, tmp_path, capsys):
+        """No schema installed is a visible gap, not a failure."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        _write_record(target, "alpha", _valid_record("alpha"))
+        assert run_validation(target) == 0
+        assert "schema" in capsys.readouterr().out

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -4291,7 +4291,10 @@ class TestDataCiContract:
         )
 
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
-        assert ci_governed == [repo_scope, data_common]
+        # The defect lane ships from L4, like the feature contract it sits
+        # beside; L3 has no per-change artifact model at all.
+        fix_lane = [f"ci/{platform}/fix-lane-gate.yml"] if level != "3" else []
+        assert ci_governed == [repo_scope, data_common, *fix_lane]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(
@@ -4313,7 +4316,10 @@ class TestDataCiContract:
         assert ci_block.get("governed", []) == []
         assert ci_block["by_type"]["data"]["governed"] == expected
         assert ci_block["level_4"].get("governed", []) == []
-        assert ci_block["level_4"]["by_type"]["data"]["governed"] == expected
+        # L4 adds the defect lane gate on top of the L3 common set.
+        assert ci_block["level_4"]["by_type"]["data"]["governed"] == [
+            *expected, f"ci/{platform}/fix-lane-gate.yml",
+        ]
 
 
 class TestDataCommonCiGate:
@@ -4429,7 +4435,10 @@ class TestPythonDbtCiGate:
         )
 
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
-        assert ci_governed == [repo_scope, data_common, dbt_gate]
+        # The defect lane ships from L4, like the feature contract it sits
+        # beside; L3 has no per-change artifact model at all.
+        fix_lane = [f"ci/{platform}/fix-lane-gate.yml"] if level != "3" else []
+        assert ci_governed == [repo_scope, data_common, dbt_gate, *fix_lane]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(
@@ -4589,7 +4598,10 @@ class TestDatabricksCiGate:
         )
 
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
-        assert ci_governed == [repo_scope, data_common, databricks_gate]
+        # The defect lane ships from L4, like the feature contract it sits
+        # beside; L3 has no per-change artifact model at all.
+        fix_lane = [f"ci/{platform}/fix-lane-gate.yml"] if level != "3" else []
+        assert ci_governed == [repo_scope, data_common, databricks_gate, *fix_lane]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -849,3 +849,114 @@ class TestDataEvalCriteriaSchema:
             manifest["variants"]["type"]["data"].get("level_4", {}).get("governed", [])
         )
         assert "governance/data/schemas/" in governed, agent
+
+
+# ---------------------------------------------------------------------------
+# Fix record schema (defect lane)
+# ---------------------------------------------------------------------------
+
+FIX_RECORD_SCHEMA_PATH = REPO_ROOT / "governance" / "schemas" / "fix_record.schema.json"
+
+
+class TestFixRecordSchema:
+    """The defect lane's single artifact. Area-agnostic, like
+    evaluation_prediction.schema.json — a fix record has the same shape whether
+    the repo is api, ui, or data, so it does not live under governance/<area>/."""
+
+    def _schema(self) -> dict:
+        return json.loads(FIX_RECORD_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def _valid_record(self) -> dict:
+        return {
+            "version": 1,
+            "id": "task-filter-reset",
+            "summary": "Task filter resets to All when navigating back from detail",
+            "expectation": {
+                "source": "features/ui_task_dashboard/acceptance.feature",
+                "reference": "Scenario: Filter persists across navigation",
+            },
+            "failure": {
+                "observed": "Filter state discarded on back-navigation",
+                "reported_in": "issue #482",
+            },
+            "surface": {"paths": ["src/features/tasks/hooks/useTaskFilter.ts"]},
+            "reproduction": {
+                "test": "src/features/tasks/hooks/useTaskFilter.test.ts",
+                "scenario": "restores persisted filter on remount",
+            },
+            "risk": {
+                "architecture": False,
+                "security_auth": False,
+                "data_handling": False,
+                "public_contract": False,
+                "nfr": False,
+                "cross_service": False,
+            },
+            "introduces_new_behavior": False,
+        }
+
+    def _errors(self, instance: dict) -> list:
+        return list(Draft202012Validator(self._schema()).iter_errors(instance))
+
+    def test_schema_is_valid_json_schema(self):
+        Draft202012Validator.check_schema(self._schema())
+
+    def test_valid_record_validates(self):
+        errors = self._errors(self._valid_record())
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_rejects_string_version(self):
+        """House convention: version is an integer, never a string."""
+        instance = self._valid_record() | {"version": "1"}
+        assert self._errors(instance)
+
+    def test_rejects_unknown_top_level_key(self):
+        instance = self._valid_record() | {"lane": "fix"}
+        assert self._errors(instance)
+
+    def test_rejects_evaluation_prediction(self):
+        """This lane deliberately carries no FIRST/Virtue prediction machinery —
+        its self-attestation problem is a separate decision."""
+        instance = self._valid_record() | {"evaluation_prediction": {"first": {}}}
+        assert self._errors(instance)
+
+    @pytest.mark.parametrize(
+        "section", ["expectation", "failure", "surface", "reproduction", "risk"],
+    )
+    def test_every_section_is_required(self, section):
+        instance = self._valid_record()
+        del instance[section]
+        assert self._errors(instance), f"{section} should be required"
+
+    def test_expectation_requires_a_source(self):
+        """Condition 1 is otherwise pure assertion — an unsourced claim that a
+        fix restores established behavior is not reviewable."""
+        instance = self._valid_record()
+        del instance["expectation"]["source"]
+        assert self._errors(instance)
+
+    def test_reproduction_requires_a_test(self):
+        """Condition 2: a fix without a regression test is not in this lane."""
+        instance = self._valid_record()
+        del instance["reproduction"]["test"]
+        assert self._errors(instance)
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["architecture", "security_auth", "data_handling", "public_contract", "nfr", "cross_service"],
+    )
+    def test_every_risk_flag_is_required(self, flag):
+        """Condition 4 is checked two ways against the diff, so a missing flag
+        cannot be read as 'false'."""
+        instance = self._valid_record()
+        del instance["risk"][flag]
+        assert self._errors(instance), f"risk.{flag} should be required"
+
+    def test_surface_requires_at_least_one_path(self):
+        instance = self._valid_record()
+        instance["surface"]["paths"] = []
+        assert self._errors(instance)
+
+    def test_introduces_new_behavior_must_be_boolean(self):
+        instance = self._valid_record() | {"introduces_new_behavior": "no"}
+        assert self._errors(instance)


### PR DESCRIPTION
## What

Adds a lane sized to a bug fix: one schema-backed record at `fixes/<id>/fix.yaml` instead of the five-artifact feature contract, with eligibility conditions that promote anything larger back to the feature lane.

> Stacked on #133. Targets `fix/governed-payload-consistency`, so this diff is the defect lane alone. Merge #133 first.

## Why

`run_validation` iterates artifacts that already exist, so a PR that changes source and creates no feature directory passes every govkit gate untouched. That is an accidental escape hatch, not a designed boundary — and it is the crack an autonomous bug-fix agent currently fits through (`plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §3).

Leaving it open has two failure modes. An agent that *obeys* the feature contract manufactures five documents of governance fiction for a three-line correction — and `validate` passes them, because every L4 gate is a shape check on agent-authored prose. An agent that *ignores* it ships ungoverned code. Both are worse than a lane sized to the change.

The distinction the lane draws is not size but **whether the behavior was already specified**. A three-line change introducing a capability is a feature; a hundred-line change making the code finally do what the contract said is a defect.

## Changes

**Installer**
- `governance/schemas/fix_record.schema.json` — area-agnostic, like `evaluation_prediction.schema.json`
- `cli/fixes.py` — discovery and validation, modelled on `cli/extensions.py`, the repo's existing second artifact family. Distinct ABI (`(issues, warnings)`), silent when absent, own exit code combined via `max()`
- `cli/cmd_fix.py` — `govkit fix init <id>`, L4+ gated
- `cli/validate.py` — eligibility checks: cited source and reproduction test must resolve; any `risk` flag `true` fails with a pointer to the feature lane; a `false` beside a change in a namespace govkit *owns* is a contradiction

**Payload**
- `ci/{github,azure}/fix-lane-gate.yml` — inactive until `SOURCE_PATHS` is set, mirroring `repo-scope-check`'s `REPO_OWNER`
- `agents/*/skills/backend/fix-record/SKILL.md` — three agents, byte-identical, registered in `PLANNING_SKILL_PATHS` to inherit its seven guarantees rather than restate them
- Manifest wiring by targeted insertion, not a JSON round-trip: these files are hand-formatted and a round-trip reformats 1449 lines, burying 44 real additions each
- README defect lifecycle, fix-lane rule in `spec-compliance.md` × 3, CHANGELOG

**Two deviations from the approved plan, both deliberate**
- **Dropped the planned doctor `D021`.** Increment 5 put those exact checks in `validate`. Building D021 would be one rule in two implementations, in a repo where both run inside the same gates — the defect class #133 exists to fix.
- **The gate never invokes govkit.** A blocking gate must not depend on an unpinned PyPI release, and `run_validation` exits 0 on a missing marker, so a gate delegating to it could be switched off from inside the PR under review. A test pins that.

## What this does not buy

Conditions 1 and 3 — "restores established behavior", "introduces no new behavior" — are declarations the tooling cannot verify. `validate` checks the cited source resolves, not that it says what you claim. And `surface.paths` is authored, not derived, so `validate` proves the record is internally consistent while CI proves it matches the diff. Both limits are stated in the README and the skill rather than left to be discovered.

## Testing

```bash
./run_tests   # 2510 passed
./full_test   # + 134 e2e passed (16 skips: no JDK/Maven locally)
```

Three new suites, each written failing-first: `test_fixes.py`, `test_cmd_fix.py`, `test_fix_lane_gate_checks.py` (extracts the gate heredoc and executes it), plus schema tests and a test deriving the PARITY_TEST skill count from the tree.

Verified against the real CLI on a fresh `govkit apply`, not just unit tests:

```
govkit apply --level 4 --type api   -> schema, skill, and gate all install
govkit fix init pager-offset        -> scaffolds the record
govkit validate                     -> skeleton FAILS: 3 unresolved paths
  (record completed)                -> PASS
  (risk.public_contract: true)      -> FAIL: belongs in the feature lane
  (version: "1")                    -> FAIL: schema, '1' is not of type 'integer'
```

That run also caught a real bug the unit tests missed: the `public_contract` pattern required an `<area>` segment and so never matched `governance/schemas/`. Fixed, with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)