### PR TITLE
feat: measured evidence over predicted scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
+- **Measured evidence.** `govkit evidence` reads what CI produced — the test
+  report, axe results — and gives a verdict per rubric dimension. Wired up by
+  `ci/{github,azure}/evidence-gate.yml`. Working and Accessibility are gated
+  today; Fast becomes gated once a team sets `--fast-max-seconds`. Everything
+  else reports `INCONCLUSIVE`, which is **not** a pass.
+- `docs/<area>/evaluation/EVIDENCE_CONTRACT.md` — the delivery-side evidence
+  vocabulary, promoted from the L5 extension that already governed the agent
+  systems govkit's users build.
+
+### Changed
+
+- **The FIRST/Virtue prediction is now an advisory forecast, not a merge gate.**
+  Those scores are written by the agent that did the work; the evidence contract
+  makes a producer self-check advisory by definition. A threshold breach now
+  WARNs. Internal contradiction and missing values still FAIL — the artifact
+  must be complete and honest about itself, it just no longer carries a verdict.
+  This applies to backend and UI the argument ADR-0001 accepted for data in July.
+- `eval-gate` and `ui-eval-gate` are marked advisory in their headers. Their
+  behavior is deliberately unchanged, so nothing breaks on `govkit upgrade`.
+- `docs/backend/evaluation/EVAL_STACK.md` described a "Home-Grown Evaluation
+  Framework" that enforced FIRST and Virtue scores at CI time and was "required
+  on all projects". **No such framework was ever built** — the only
+  implementation was a parser reading the agent's own numbers out of `plan.md`.
+  Replaced with `govkit evidence` and a note recording what happened.
+- The four scoring rubrics ended with "validate against actuals during review".
+  Nothing implemented it. They now say what the scores are for and where the
+  real gate is.
+- `tests/test_ci_govkit_dependency.py` enumerated `doctor|validate|apply|init`,
+  so `govkit evidence` could ship in a gate without a version pin and the suite
+  stayed green. It now matches any subcommand.
+- Removed two stale rows from `ci/README.md`'s "Not Enforced by CI" table; both
+  checks shipped some time ago.
+
 - **Defect lane.** A change that restores already-established behavior now
   carries one schema-backed record — `fixes/<id>/fix.yaml` — instead of the
   five-artifact feature contract. `govkit fix init <id>` scaffolds it,

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Backend installs ship no UI artifacts; UI installs ship no backend artifacts. Th
 | `govkit validate` | Level-aware compliance check over **features** (artifact existence, Gherkin structure, NFR coverage, eval-criteria schema, prediction thresholds) and **fix records** (schema, eligibility conditions). No-op at L3. |
 | `govkit init <feature>` | Scaffold a new feature folder from the appropriate starter (L4+). |
 | `govkit fix init <id>` | Scaffold a defect-lane fix record at `fixes/<id>/fix.yaml` (L4+) — one artifact instead of five, for a change that restores already-established behavior. |
+| `govkit evidence` | Report measured quality evidence from CI artifacts — a verdict per rubric dimension, with unmeasured ones reported as INCONCLUSIVE rather than green. |
 | `govkit stack` | `stack list` shows bundled tech-stack overlays; `stack apply <id>` swaps the stack on an existing install. |
 | `govkit extension` | `extension list` shows bundled extension packs; `extension add <id> --target <path>` copies one into your project's `extensions/<id>/`. |
 | `govkit upgrade` | Refresh the files govkit owns (contracts, CI gates, templates) to a new version without touching the files you own. |

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -454,18 +454,24 @@
           "governed": [],
           "by_type": {
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
-                "ci/github/fix-lane-gate.yml"],
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
@@ -488,7 +494,8 @@
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -507,7 +514,8 @@
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -525,7 +533,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
@@ -535,7 +544,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/github/ui-nextjs-quality-gate.yml",
@@ -544,7 +554,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] }
           }
         }
@@ -592,18 +603,24 @@
           "governed": [],
           "by_type": {
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
-                "ci/azure/fix-lane-gate.yml"],
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
@@ -626,7 +643,8 @@
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -645,7 +663,8 @@
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -663,7 +682,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
@@ -673,7 +693,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/azure/ui-nextjs-quality-gate.yml",
@@ -682,7 +703,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] }
           }
         }

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -476,18 +476,24 @@
           "governed": [],
           "by_type": {
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
-                "ci/github/fix-lane-gate.yml"],
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
@@ -510,7 +516,8 @@
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -529,7 +536,8 @@
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -547,7 +555,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
@@ -557,7 +566,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/github/ui-nextjs-quality-gate.yml",
@@ -566,7 +576,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] }
           }
         }
@@ -614,18 +625,24 @@
           "governed": [],
           "by_type": {
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
-                "ci/azure/fix-lane-gate.yml"],
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
@@ -648,7 +665,8 @@
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -667,7 +685,8 @@
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -685,7 +704,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
@@ -695,7 +715,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/azure/ui-nextjs-quality-gate.yml",
@@ -704,7 +725,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] }
           }
         }

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -458,18 +458,24 @@
           "governed": [],
           "by_type": {
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
-                "ci/github/fix-lane-gate.yml"] },
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
-                "ci/github/fix-lane-gate.yml"],
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/github/databricks-gate.yml"] }
@@ -492,7 +498,8 @@
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -511,7 +518,8 @@
                 "ci/github/guardrails-check.yml",
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/github/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -529,7 +537,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/github/l3-ui-quality-gate.yml",
@@ -539,7 +548,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/github/ui-nextjs-quality-gate.yml",
@@ -548,7 +558,8 @@
               "ci/github/guardrails-check.yml",
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
-                "ci/github/fix-lane-gate.yml"
+                "ci/github/fix-lane-gate.yml",
+                "ci/github/evidence-gate.yml"
             ] }
           }
         }
@@ -596,18 +607,24 @@
           "governed": [],
           "by_type": {
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
-                "ci/azure/fix-lane-gate.yml"] },
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
-                "ci/azure/fix-lane-gate.yml"],
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
                 "databricks-lakehouse": { "governed": ["ci/azure/databricks-gate.yml"] }
@@ -630,7 +647,8 @@
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -649,7 +667,8 @@
                 "ci/azure/guardrails-check.yml",
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
                 "python-fastapi": { "governed": ["ci/azure/boundary-gate-python.yml", "governance/backend/importlinter-reference.toml"] },
@@ -667,7 +686,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
               "ci/azure/l3-ui-quality-gate.yml",
@@ -677,7 +697,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
               "ci/azure/ui-nextjs-quality-gate.yml",
@@ -686,7 +707,8 @@
               "ci/azure/guardrails-check.yml",
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
-                "ci/azure/fix-lane-gate.yml"
+                "ci/azure/fix-lane-gate.yml",
+                "ci/azure/evidence-gate.yml"
             ] }
           }
         }

--- a/ci/README.md
+++ b/ci/README.md
@@ -212,6 +212,7 @@ A critical distinction in this governance framework: some checks enforce **actua
 | Code quality metrics | l3-quality-gate | SonarQube duplication and complexity |
 | Governing artifact coverage | fix-lane-gate | Source changed in the PR is accounted for by a fix record or a feature |
 | Fix record correspondence | fix-lane-gate | A fix record's `surface.paths` matches what the diff actually changed, and the diff carries a test |
+| Measured quality evidence | evidence-gate | `govkit evidence` reads the test report and axe results and gives a verdict per rubric dimension. Unmeasured dimensions report INCONCLUSIVE, which is **not** a pass |
 
 #### The fix-lane gate needs configuring before it does anything
 
@@ -235,8 +236,8 @@ the diff.
 
 | Check | Pipeline | What it does | How to close the gap |
 |---|---|---|---|
-| FIRST scores | eval-gate | Checks predicted averages >= 4.0 in `plan.md` | Add a post-test job that scores actual test suites against the [FIRST rubric](../docs/backend/evaluation/FIRST_SCORING_RUBRIC.md) |
-| Virtue scores | eval-gate | Checks predicted averages >= 4.0 in `plan.md` | Add static analysis metrics (complexity, duplication, coverage) and compare to thresholds |
+| FIRST scores | eval-gate | Reads a forecast the authoring agent wrote. **Advisory** — see `EVIDENCE_CONTRACT.md` | Largely closed: `evidence-gate` measures Working and Fast. Emit a test report from your test run |
+| Virtue scores | eval-gate | Reads a forecast the authoring agent wrote. **Advisory** | Partly closed: Working is measured. Duplication, complexity and coverage remain unmeasured and report INCONCLUSIVE |
 | Accessibility | ui-eval-gate | Checks predicted axe violations == 0 | Already partially enforced — Playwright axe scans run. Ensure `continue-on-error` is false. |
 
 ### Stubbed (require team configuration)
@@ -256,9 +257,7 @@ These governance rules are communicated to agents via CLAUDE.md / copilot-instru
 
 | Rule | Why no CI gate | Recommendation |
 |---|---|---|
-| Architecture preflight must exist before planning | No file existence check | Add a job that checks `features/*/architecture_preflight.md` exists for any feature with a `plan.md` |
 | ADR required when preflight flags it | No ADR validation | Add a job that checks for ADR files when preflight contains "ADR required" |
-| One increment per commit | No commit granularity check | Add commit message format validation (`feat(<scope>): increment N — ...`) |
 | Gherkin scenarios must map to tests | No test coverage gate | Add a job that cross-references `@nfr-*` tags with test files |
 
 ---

--- a/ci/azure/eval-gate.yml
+++ b/ci/azure/eval-gate.yml
@@ -1,4 +1,15 @@
 # Azure DevOps pipeline — Enforces evaluation score predictions and runs LLM eval suites on every PR.
+#
+# ADVISORY AS OF THE EVIDENCE CONTRACT. The scores this gate reads are written
+# into plan.md by the agent that did the work. docs/<area>/evaluation/
+# EVIDENCE_CONTRACT.md names that a producer self-check and makes it advisory:
+# "the task owner never commits its own final gate." Treat a failure here as a
+# forecast under the bar, not as a quality verdict.
+#
+# The merge gate for quality is ci/<platform>/evidence-gate.yml, which reports
+# what an executed tool observed. This gate's behavior is unchanged so nothing
+# breaks for existing adopters; prefer the evidence gate as the required check.
+#
 # Validate with your Azure DevOps admin before use.
 #
 # JOBS:

--- a/ci/azure/evidence-gate.yml
+++ b/ci/azure/evidence-gate.yml
@@ -1,0 +1,62 @@
+# Azure DevOps mirror of ci/github/evidence-gate.yml.
+#
+# PURPOSE: Gate merge on measured quality evidence rather than on scores the
+#          authoring agent predicted for itself.
+#
+# A FIRST or Virtue score in plan.md is written by the agent that did the work.
+# docs/<area>/evaluation/EVIDENCE_CONTRACT.md names that a producer self-check
+# and makes it advisory: "the task owner never commits its own final gate."
+#
+# THIS GATE FAILS UNTIL YOU CONFIGURE IT — deliberately, and unlike every other
+#   opt-in gate govkit ships. A gate that measured nothing has not passed.
+#
+# CONFIGURE THIS: replace the "Run tests and produce evidence" step with your
+#   own test command, emitting JUnit XML (and, for UI, axe JSON). Anything you
+#   do not emit reports INCONCLUSIVE, which is not a pass.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  - stage: Evidence
+    displayName: Measured quality evidence
+    jobs:
+      - job: EvidenceCheck
+        displayName: Measured quality evidence
+        steps:
+          - checkout: self
+
+          - task: UsePythonVersion@0
+            inputs:
+              versionSpec: '3.11'
+            displayName: Set up Python
+
+          - script: pip install govkit~=0.18.0
+            displayName: Install GovKit
+
+          # CONFIGURE THIS — replace with your own test command.
+          # It must leave JUnit XML (and, for UI, axe JSON) in the workspace.
+          - script: |
+              echo "Not configured: this gate has no test command yet."
+              echo ""
+              echo "Replace this step with your test run, emitting JUnit XML, e.g.:"
+              echo "  pytest --junitxml=junit.xml"
+              echo "  npx vitest run --reporter=junit --outputFile=junit.xml"
+              echo ""
+              echo "govkit evidence will now report every dimension as INCONCLUSIVE"
+              echo "and fail, because a gate that measured nothing has not passed."
+            displayName: Run tests and produce evidence
+
+          - script: govkit evidence --target .
+            displayName: Report measured evidence
+
+          - publish: $(System.DefaultWorkingDirectory)
+            artifact: quality-evidence
+            condition: always()
+            displayName: Upload evidence artifacts

--- a/ci/azure/ui-eval-gate.yml
+++ b/ci/azure/ui-eval-gate.yml
@@ -1,4 +1,15 @@
 # Azure DevOps pipeline — Enforces evaluation thresholds and E2E accessibility compliance on every UI PR.
+#
+# ADVISORY AS OF THE EVIDENCE CONTRACT. The scores this gate reads are written
+# into plan.md by the agent that did the work. docs/<area>/evaluation/
+# EVIDENCE_CONTRACT.md names that a producer self-check and makes it advisory:
+# "the task owner never commits its own final gate." Treat a failure here as a
+# forecast under the bar, not as a quality verdict.
+#
+# The merge gate for quality is ci/<platform>/evidence-gate.yml, which reports
+# what an executed tool observed. This gate's behavior is unchanged so nothing
+# breaks for existing adopters; prefer the evidence gate as the required check.
+#
 # Validate with your Azure DevOps admin before use.
 #
 # JOBS:

--- a/ci/github/eval-gate.yml
+++ b/ci/github/eval-gate.yml
@@ -1,5 +1,16 @@
 # eval-gate-example.yml
 #
+# ADVISORY AS OF THE EVIDENCE CONTRACT. The scores this gate reads are written
+# into plan.md by the agent that did the work. docs/<area>/evaluation/
+# EVIDENCE_CONTRACT.md names that a producer self-check and makes it advisory:
+# "the task owner never commits its own final gate." Treat a failure here as a
+# forecast under the bar, not as a quality verdict.
+#
+# The merge gate for quality is ci/<platform>/evidence-gate.yml, which reports
+# what an executed tool observed. This gate's behavior is unchanged so nothing
+# breaks for existing adopters; prefer the evidence gate as the required check.
+#
+#
 # PURPOSE: Enforces evaluation score predictions and runs LLM eval suites on every PR.
 # Copy this file to .github/workflows/eval-gate.yml and configure the
 # steps marked "Configure your..." before enabling in CI.

--- a/ci/github/evidence-gate.yml
+++ b/ci/github/evidence-gate.yml
@@ -1,0 +1,77 @@
+# evidence-gate.yml
+#
+# PURPOSE: Gate merge on measured quality evidence rather than on scores the
+#          authoring agent predicted for itself.
+#
+# JOBS:
+#   evidence-check — runs your tests, then `govkit evidence` over the artifacts
+#
+# WHY THIS EXISTS:
+#   A FIRST or Virtue score in plan.md is written by the agent that did the
+#   work. docs/<area>/evaluation/EVIDENCE_CONTRACT.md names that a producer
+#   self-check and makes it advisory: "the task owner never commits its own
+#   final gate." eval-gate still checks those numbers, but they are a forecast.
+#   This gate reports what an executed tool observed.
+#
+# THIS GATE FAILS UNTIL YOU CONFIGURE IT. That is deliberate and is the
+#   opposite of every other opt-in gate govkit ships. ci/README.md warns that
+#   tools "report success on an empty analysis, so a misconfigured contract
+#   looks exactly like a clean repo" — a gate that measured nothing has not
+#   passed. Copying this file is an explicit act; wire the step below before
+#   you make it a required check.
+#
+# CONFIGURE THIS: replace the "Run tests and produce evidence" step with your
+#   own test command, emitting:
+#     - JUnit XML  (pytest --junitxml=junit.xml | vitest --reporter=junit | jest --reporters=jest-junit)
+#     - axe JSON   (UI only — write your axe results to axe.json)
+#   Anything you do not emit reports INCONCLUSIVE, which is not a pass.
+#
+# Copy this file to .github/workflows/evidence-gate.yml.
+
+name: Evidence Gate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  evidence-check:
+    name: Measured quality evidence
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install GovKit
+        run: pip install govkit~=0.18.0
+
+      # CONFIGURE THIS — replace with your own test command.
+      # It must leave JUnit XML (and, for UI, axe JSON) in the workspace.
+      - name: Run tests and produce evidence
+        run: |
+          echo "Not configured: this gate has no test command yet."
+          echo ""
+          echo "Replace this step with your test run, emitting JUnit XML, e.g.:"
+          echo "  pytest --junitxml=junit.xml"
+          echo "  npx vitest run --reporter=junit --outputFile=junit.xml"
+          echo ""
+          echo "govkit evidence will now report every dimension as INCONCLUSIVE"
+          echo "and fail, because a gate that measured nothing has not passed."
+
+      - name: Report measured evidence
+        run: govkit evidence --target .
+
+      - name: Upload evidence artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quality-evidence
+          path: |
+            junit*.xml
+            axe*.json
+          if-no-files-found: ignore

--- a/ci/github/ui-eval-gate.yml
+++ b/ci/github/ui-eval-gate.yml
@@ -1,5 +1,16 @@
 # ui-eval-gate-example.yml
 #
+# ADVISORY AS OF THE EVIDENCE CONTRACT. The scores this gate reads are written
+# into plan.md by the agent that did the work. docs/<area>/evaluation/
+# EVIDENCE_CONTRACT.md names that a producer self-check and makes it advisory:
+# "the task owner never commits its own final gate." Treat a failure here as a
+# forecast under the bar, not as a quality verdict.
+#
+# The merge gate for quality is ci/<platform>/evidence-gate.yml, which reports
+# what an executed tool observed. This gate's behavior is unchanged so nothing
+# breaks for existing adopters; prefer the evidence gate as the required check.
+#
+#
 # PURPOSE: Enforces evaluation thresholds and E2E accessibility compliance on every UI PR.
 # Copy this file to .github/workflows/ui-eval-gate.yml and configure the
 # steps marked "Configure your..." before enabling in CI.

--- a/cli/cmd_evidence.py
+++ b/cli/cmd_evidence.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`govkit evidence` — report measured quality evidence per dimension.
+
+Separate from `govkit validate` on purpose. `validate` checks that governed
+*artifacts* are well-formed; this reports what an executed tool *observed*.
+Collapsing them would put a forecast and an observation behind one verdict,
+which is the confusion this work exists to remove.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import paths
+from .evidence import Outcome, collect_evidence, summarize
+
+_LABEL = {
+    Outcome.PASS: "\033[32mPASS\033[0m",
+    Outcome.FAIL: "\033[31mFAIL\033[0m",
+    Outcome.INCONCLUSIVE: "\033[33mINCONCLUSIVE\033[0m",
+    Outcome.ERROR: "\033[31mERROR\033[0m",
+}
+
+
+def cmd_evidence(args: argparse.Namespace) -> None:
+    target = Path(args.target).resolve()
+    if not target.is_dir():
+        print(f"Error: target directory '{target}' does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    verdicts = collect_evidence(target)
+    print("\ngovkit evidence — measured quality evidence\n")
+    width = max(len(v.dimension) for v in verdicts)
+    for verdict in verdicts:
+        print(f"  {verdict.dimension.ljust(width)}  {_LABEL[verdict.outcome]}  {verdict.detail}")
+
+    exit_code, summary = summarize(verdicts)
+    print(f"\n{summary}\n")
+    sys.exit(exit_code)
+
+
+def register(subparsers) -> None:
+    """Register the `evidence` subcommand."""
+    p = subparsers.add_parser(
+        "evidence",
+        help="Report measured quality evidence from CI artifacts",
+    )
+    p.add_argument("--target", default=".", help=paths.TARGET_HELP)
+    p.set_defaults(func=cmd_evidence)

--- a/cli/cmd_evidence.py
+++ b/cli/cmd_evidence.py
@@ -43,7 +43,7 @@ def cmd_evidence(args: argparse.Namespace) -> None:
         print(f"Error: target directory '{target}' does not exist.", file=sys.stderr)
         sys.exit(1)
 
-    verdicts = collect_evidence(target)
+    verdicts = collect_evidence(target, fast_max_seconds=args.fast_max_seconds)
     print("\ngovkit evidence — measured quality evidence\n")
     width = max(len(v.dimension) for v in verdicts)
     for verdict in verdicts:
@@ -61,4 +61,12 @@ def register(subparsers) -> None:
         help="Report measured quality evidence from CI artifacts",
     )
     p.add_argument("--target", default=".", help=paths.TARGET_HELP)
+    p.add_argument(
+        "--fast-max-seconds", type=float, default=None,
+        help=(
+            "Per-test duration ceiling. Without it, Fast reports its observed "
+            "durations but stays INCONCLUSIVE — govkit will not invent a "
+            "threshold your team has not calibrated."
+        ),
+    )
     p.set_defaults(func=cmd_evidence)

--- a/cli/evidence.py
+++ b/cli/evidence.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Measured evidence — read what CI produced, and report what it did not.
+
+See `docs/<area>/evaluation/EVIDENCE_CONTRACT.md`. The rule this implements:
+
+    A producer self-check is advisory. The task owner never commits its own
+    final gate.
+
+A FIRST/Virtue score in `plan.md` is written by the agent that did the work, so
+it is a forecast. This module reports only what an executed tool observed.
+
+`INCONCLUSIVE` is the load-bearing outcome. An unmeasured dimension that reports
+green is indistinguishable from a verified one, which is how a fabricated score
+survives review — so every dimension is reported every run, and the ones without
+evidence say so.
+"""
+
+import json
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+# The rubrics' own dimensions — 5 FIRST + 7 Virtues. A test pins these against
+# docs/backend/evaluation/*_SCORING_RUBRIC.md so this cannot measure something
+# govkit never asked for. Accessibility is not a rubric dimension but is gated
+# for UI, so it is reported alongside.
+FIRST_DIMENSIONS = ("Fast", "Isolated", "Repeatable", "Self-Verifying", "Timely")
+VIRTUE_DIMENSIONS = ("Working", "Unique", "Simple", "Clear", "Easy", "Developed", "Brief")
+DIMENSIONS = (*FIRST_DIMENSIONS, *VIRTUE_DIMENSIONS, "Accessibility")
+
+# axe impacts that block. The UI rubric bands minor violations at 3 and a single
+# critical/serious at 2, so only the latter two are merge blockers.
+_BLOCKING_IMPACTS = ("critical", "serious")
+
+_JUNIT_GLOBS = ("junit*.xml", "**/junit*.xml", "**/*junit*.xml", "**/test-results*.xml")
+_AXE_GLOBS = ("axe*.json", "**/axe*.json", "**/*axe-results*.json")
+
+# Dimensions with no instrument today. The reason is carried into the report so
+# a reader learns what to wire up rather than just seeing a blank.
+_NOT_INSTRUMENTED = {
+    "Isolated": "no randomised-order or run-alone execution recorded",
+    "Repeatable": "no repeated-run flake rate recorded",
+    "Self-Verifying": "no assertion-shape analysis recorded",
+    "Timely": "no test-versus-source commit ordering recorded",
+    "Unique": "no duplication report recorded",
+    "Simple": "no complexity or nesting-depth report recorded",
+    "Easy": "no boundary-gate result recorded",
+    "Developed": "no coverage report recorded",
+    "Brief": "no unused-import or dead-code report recorded",
+}
+
+# Not an instrumentation gap — a category error. Its measurable proxies
+# (identifier length, comment density) reward verbosity over clarity, so it must
+# never report PASS. See EVIDENCE_CONTRACT.md.
+_JUDGEMENT_ONLY = {
+    "Clear": (
+        "a matter of judgement, not measurement — scoreable only by an "
+        "independent identified evaluator, never by a metric or by the "
+        "agent that produced the work"
+    ),
+}
+
+
+class Outcome(Enum):
+    """From EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md. INCONCLUSIVE is not
+    a pass: no evidence, insufficient evidence, or evidence out of scope."""
+
+    PASS = "PASS"
+    FAIL = "FAIL"
+    INCONCLUSIVE = "INCONCLUSIVE"
+    ERROR = "ERROR"
+
+
+@dataclass
+class Verdict:
+    dimension: str
+    outcome: Outcome
+    detail: str
+
+
+def _find(target: Path, globs) -> list[Path]:
+    seen, found = set(), []
+    for pattern in globs:
+        for path in sorted(target.glob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                found.append(path)
+    return found
+
+
+def _read_junit(paths: list[Path]) -> tuple[dict | None, str | None]:
+    """Aggregate JUnit XML. Returns (totals, error). Never raises."""
+    totals = {"tests": 0, "failures": 0, "errors": 0, "durations": []}
+    for path in paths:
+        try:
+            root = ET.parse(path).getroot()
+        except (ET.ParseError, OSError) as exc:
+            return None, f"{path.name} could not be parsed: {exc}"
+        suites = [root] if root.tag == "testsuite" else root.iter("testsuite")
+        for suite in suites:
+            totals["tests"] += int(suite.get("tests") or 0)
+            totals["failures"] += int(suite.get("failures") or 0)
+            totals["errors"] += int(suite.get("errors") or 0)
+        for case in root.iter("testcase"):
+            try:
+                totals["durations"].append(float(case.get("time") or 0.0))
+            except ValueError:
+                continue
+    return totals, None
+
+
+def _assess_working(totals: dict | None, error: str | None, found: bool) -> Verdict:
+    if error:
+        return Verdict("Working", Outcome.ERROR, error)
+    if not found:
+        return Verdict("Working", Outcome.INCONCLUSIVE, "no test-run report found")
+    if not totals or totals["tests"] == 0:
+        return Verdict(
+            "Working", Outcome.INCONCLUSIVE,
+            "test-run report contains no tests — an empty analysis, not a clean one",
+        )
+    broken = totals["failures"] + totals["errors"]
+    if broken:
+        return Verdict(
+            "Working", Outcome.FAIL,
+            f"{broken} of {totals['tests']} tests failed or errored",
+        )
+    return Verdict("Working", Outcome.PASS, f"{totals['tests']} tests passed")
+
+
+def _assess_fast(totals: dict | None, found: bool) -> Verdict:
+    """Observed, deliberately not judged.
+
+    JUnit carries per-test durations, so the measurement is free. Turning the
+    rubric's 1-5 bands into a pass/fail threshold is a calibration decision,
+    and ADR-0001 warns that inventing a rubric nobody has calibrated recreates
+    the ceremony this work removes. Report the number; leave the policy.
+    """
+    if not found or not totals or not totals["durations"]:
+        return Verdict("Fast", Outcome.INCONCLUSIVE, "no per-test durations recorded")
+    durations = sorted(totals["durations"])
+    slowest = durations[-1]
+    over_200ms = sum(1 for d in durations if d > 0.2)
+    return Verdict(
+        "Fast", Outcome.INCONCLUSIVE,
+        f"observed: slowest test {slowest:g}s, {over_200ms} of {len(durations)} over 200ms "
+        "— set a threshold to make this blocking",
+    )
+
+
+def _read_axe(paths: list[Path]) -> tuple[list[dict] | None, str | None]:
+    violations = []
+    for path in paths:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            return None, f"{path.name} could not be parsed: {exc}"
+        for result in data if isinstance(data, list) else [data]:
+            if isinstance(result, dict):
+                violations.extend(v for v in (result.get("violations") or []) if isinstance(v, dict))
+    return violations, None
+
+
+def _assess_accessibility(violations: list[dict] | None, error: str | None, found: bool) -> Verdict:
+    if error:
+        return Verdict("Accessibility", Outcome.ERROR, error)
+    if not found:
+        return Verdict("Accessibility", Outcome.INCONCLUSIVE, "no axe report found")
+    counts: dict[str, int] = {}
+    for violation in violations or []:
+        impact = str(violation.get("impact") or "unknown")
+        counts[impact] = counts.get(impact, 0) + 1
+    blocking = {k: v for k, v in counts.items() if k in _BLOCKING_IMPACTS}
+    seen = ", ".join(f"{n} {impact}" for impact, n in sorted(counts.items())) or "none"
+    if blocking:
+        return Verdict("Accessibility", Outcome.FAIL, f"axe violations: {seen}")
+    return Verdict("Accessibility", Outcome.PASS, f"no critical or serious axe violations ({seen})")
+
+
+def collect_evidence(target: Path) -> list[Verdict]:
+    """Report a verdict for every dimension, every run.
+
+    Reporting all of them is the point: a dimension left out of the output is
+    indistinguishable from one that passed.
+    """
+    junit_paths = _find(target, _JUNIT_GLOBS)
+    totals, junit_error = _read_junit(junit_paths)
+    axe_paths = _find(target, _AXE_GLOBS)
+    violations, axe_error = _read_axe(axe_paths)
+
+    measured = {
+        "Working": _assess_working(totals, junit_error, bool(junit_paths)),
+        "Fast": _assess_fast(totals, bool(junit_paths)),
+        "Accessibility": _assess_accessibility(violations, axe_error, bool(axe_paths)),
+    }
+    verdicts = []
+    for dimension in DIMENSIONS:
+        if dimension in measured:
+            verdicts.append(measured[dimension])
+        elif dimension in _JUDGEMENT_ONLY:
+            verdicts.append(Verdict(dimension, Outcome.INCONCLUSIVE, _JUDGEMENT_ONLY[dimension]))
+        else:
+            verdicts.append(
+                Verdict(dimension, Outcome.INCONCLUSIVE, _NOT_INSTRUMENTED[dimension])
+            )
+    return verdicts
+
+
+def summarize(verdicts: list[Verdict]) -> tuple[int, str]:
+    """Return (exit_code, summary).
+
+    Fails on a real failure, and on an empty analysis. The second half matters
+    as much as the first: `ci/README.md` warns that every boundary tool "reports
+    success on an empty analysis, so a misconfigured contract looks exactly like
+    a clean repo". A gate that measured nothing has not passed.
+
+    Partial coverage is not a blocker — it reports how much went unmeasured, so
+    adoption is possible without pretending the gaps are closed.
+    """
+    blocking = [v for v in verdicts if v.outcome in (Outcome.FAIL, Outcome.ERROR)]
+    measured = [v for v in verdicts if v.outcome in (Outcome.PASS, Outcome.FAIL)]
+    unmeasured = [v for v in verdicts if v.outcome is Outcome.INCONCLUSIVE]
+
+    if not measured and not blocking:
+        return 1, (
+            "The evidence gate analysed nothing — 0 of "
+            f"{len(verdicts)} dimensions have evidence.\n"
+            "This is a failure, not a pass: an unmeasured dimension is "
+            "indistinguishable from a verified one."
+        )
+    if blocking:
+        return 1, (
+            f"{len(blocking)} dimension(s) failed; "
+            f"{len(measured)} measured, {len(unmeasured)} unmeasured."
+        )
+    return 0, (
+        f"{len(measured)} measured, {len(unmeasured)} unmeasured. "
+        "Unmeasured dimensions have not passed — they were not assessed."
+    )

--- a/cli/evidence.py
+++ b/cli/evidence.py
@@ -186,15 +186,37 @@ def _assess_fast(
 
 
 def _read_axe(paths: list[Path]) -> tuple[list[dict] | None, str | None]:
+    """Aggregate axe JSON. Returns (violations, error). Never raises.
+
+    A file that parses as JSON is not automatically an axe report. `{}`,
+    `[]` and `{"violations": "oops"}` all carry no evidence, and treating any
+    of them as "scanned, found nothing" would give an artifact with no
+    information the same verdict as a clean scan — the failure the evidence
+    contract exists to prevent. Every result must be a mapping whose
+    `violations` is genuinely a list; anything else is a shape error.
+    """
     violations = []
     for path in paths:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             return None, f"{path.name} could not be parsed: {exc}"
-        for result in data if isinstance(data, list) else [data]:
-            if isinstance(result, dict):
-                violations.extend(v for v in (result.get("violations") or []) if isinstance(v, dict))
+
+        results = data if isinstance(data, list) else [data]
+        recognised = 0
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            found = result.get("violations")
+            if not isinstance(found, list):
+                continue
+            recognised += 1
+            violations.extend(v for v in found if isinstance(v, dict))
+        if recognised == 0:
+            return None, (
+                f"{path.name} has unsupported axe JSON shape — expected a result "
+                'object with a "violations" list, or an array of them'
+            )
     return violations, None
 
 
@@ -203,6 +225,15 @@ def _assess_accessibility(violations: list[dict] | None, error: str | None, foun
         return Verdict("Accessibility", Outcome.ERROR, error)
     if not found:
         return Verdict("Accessibility", Outcome.INCONCLUSIVE, "no axe report found")
+    if violations is None:
+        # A report was present but could not be read. ERROR rather than
+        # INCONCLUSIVE: the distinction is "we did not evaluate" versus "we
+        # tried and could not", and a broken artifact someone thinks is working
+        # deserves the louder of the two.
+        return Verdict(
+            "Accessibility", Outcome.ERROR,
+            "an axe report was found but could not be interpreted",
+        )
     counts: dict[str, int] = {}
     for violation in violations or []:
         impact = str(violation.get("impact") or "unknown")

--- a/cli/evidence.py
+++ b/cli/evidence.py
@@ -104,7 +104,8 @@ def _find(target: Path, globs) -> list[Path]:
 
 def _read_junit(paths: list[Path]) -> tuple[dict | None, str | None]:
     """Aggregate JUnit XML. Returns (totals, error). Never raises."""
-    totals = {"tests": 0, "failures": 0, "errors": 0, "durations": []}
+    totals = {"tests": 0, "failures": 0, "errors": 0, "durations": [], "slowest_name": None}
+    slowest = -1.0
     for path in paths:
         try:
             root = ET.parse(path).getroot()
@@ -117,9 +118,13 @@ def _read_junit(paths: list[Path]) -> tuple[dict | None, str | None]:
             totals["errors"] += int(suite.get("errors") or 0)
         for case in root.iter("testcase"):
             try:
-                totals["durations"].append(float(case.get("time") or 0.0))
+                seconds = float(case.get("time") or 0.0)
             except ValueError:
                 continue
+            totals["durations"].append(seconds)
+            if seconds > slowest:
+                slowest = seconds
+                totals["slowest_name"] = case.get("name")
     return totals, None
 
 
@@ -142,23 +147,41 @@ def _assess_working(totals: dict | None, error: str | None, found: bool) -> Verd
     return Verdict("Working", Outcome.PASS, f"{totals['tests']} tests passed")
 
 
-def _assess_fast(totals: dict | None, found: bool) -> Verdict:
-    """Observed, deliberately not judged.
+def _assess_fast(
+    totals: dict | None, found: bool, max_seconds: float | None,
+    slowest_name: str | None,
+) -> Verdict:
+    """Observed always; judged only against a threshold the team declared.
 
     JUnit carries per-test durations, so the measurement is free. Turning the
     rubric's 1-5 bands into a pass/fail threshold is a calibration decision,
     and ADR-0001 warns that inventing a rubric nobody has calibrated recreates
-    the ceremony this work removes. Report the number; leave the policy.
+    the ceremony this work removes. So govkit reports the number and leaves the
+    policy — until a team sets `--fast-max-seconds`, at which point their
+    calibration, not govkit's guess, makes it blocking.
     """
     if not found or not totals or not totals["durations"]:
         return Verdict("Fast", Outcome.INCONCLUSIVE, "no per-test durations recorded")
     durations = sorted(totals["durations"])
     slowest = durations[-1]
-    over_200ms = sum(1 for d in durations if d > 0.2)
+    if max_seconds is None:
+        over_200ms = sum(1 for d in durations if d > 0.2)
+        return Verdict(
+            "Fast", Outcome.INCONCLUSIVE,
+            f"observed: slowest test {slowest:g}s, {over_200ms} of {len(durations)} over 200ms "
+            "— set --fast-max-seconds to make this blocking",
+        )
+    over = [d for d in durations if d > max_seconds]
+    if over:
+        name = f" (slowest: {slowest_name})" if slowest_name else ""
+        return Verdict(
+            "Fast", Outcome.FAIL,
+            f"{len(over)} of {len(durations)} tests exceed {max_seconds:g}s; "
+            f"slowest {slowest:g}s{name}",
+        )
     return Verdict(
-        "Fast", Outcome.INCONCLUSIVE,
-        f"observed: slowest test {slowest:g}s, {over_200ms} of {len(durations)} over 200ms "
-        "— set a threshold to make this blocking",
+        "Fast", Outcome.PASS,
+        f"all {len(durations)} tests under {max_seconds:g}s (slowest {slowest:g}s)",
     )
 
 
@@ -191,7 +214,7 @@ def _assess_accessibility(violations: list[dict] | None, error: str | None, foun
     return Verdict("Accessibility", Outcome.PASS, f"no critical or serious axe violations ({seen})")
 
 
-def collect_evidence(target: Path) -> list[Verdict]:
+def collect_evidence(target: Path, fast_max_seconds: float | None = None) -> list[Verdict]:
     """Report a verdict for every dimension, every run.
 
     Reporting all of them is the point: a dimension left out of the output is
@@ -204,7 +227,10 @@ def collect_evidence(target: Path) -> list[Verdict]:
 
     measured = {
         "Working": _assess_working(totals, junit_error, bool(junit_paths)),
-        "Fast": _assess_fast(totals, bool(junit_paths)),
+        "Fast": _assess_fast(
+            totals, bool(junit_paths), fast_max_seconds,
+            (totals or {}).get("slowest_name"),
+        ),
         "Accessibility": _assess_accessibility(violations, axe_error, bool(axe_paths)),
     }
     verdicts = []

--- a/cli/govkit.py
+++ b/cli/govkit.py
@@ -31,6 +31,7 @@ import argparse
 
 from .calibrate import register as _register_calibrate
 from .cmd_apply import register as _register_apply
+from .cmd_evidence import register as _register_evidence
 from .cmd_extension import register as _register_extension
 from .cmd_fix import register as _register_fix
 from .cmd_init import register as _register_init
@@ -51,6 +52,7 @@ _REGISTRARS = (
     _register_extension,
     _register_init,
     _register_fix,
+    _register_evidence,
     _register_doctor,
     _register_calibrate,
     _register_validate,

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -414,27 +414,35 @@ def check_plan_eval_prediction(feature_dir: Path) -> tuple[CheckStatus, str]:
     if not averages:
         return CheckStatus.FAIL, f"{_PLAN_MD} evaluation_prediction missing average values"
 
-    below_threshold = []
-    for avg_str in averages:
-        avg = float(avg_str)
-        if avg < 4.0:
-            below_threshold.append(avg_str)
-
-    if below_threshold:
-        return CheckStatus.FAIL, f"{_PLAN_MD} evaluation_prediction average(s) below 4.0: {', '.join(below_threshold)}"
-
+    # Internal contradiction stays blocking: a block whose declared average
+    # disagrees with the scores beneath it is a defective artifact, independent
+    # of whether the numbers are believable.
     inconsistent, low_scores = _prediction_score_problems(block)
     if inconsistent:
         return CheckStatus.FAIL, (
             f"{_PLAN_MD} evaluation_prediction is internally inconsistent — "
             + "; ".join(inconsistent)
         )
+
+    # Threshold judgements are advisory. A FIRST/Virtue score is written by the
+    # agent that did the work — a producer self-check, which
+    # docs/<area>/evaluation/EVIDENCE_CONTRACT.md makes advisory by definition:
+    # "the task owner never commits its own final gate". Blocking merge on it
+    # dressed an unverified claim as a verdict. The forecast is still required
+    # and still reported; `govkit evidence` is what gates on measurement.
+    advisory = []
+    below_threshold = [a for a in averages if float(a) < 4.0]
+    if below_threshold:
+        advisory.append(f"average(s) below 4.0: {', '.join(below_threshold)}")
     if low_scores:
-        return CheckStatus.FAIL, (
-            f"{_PLAN_MD} evaluation_prediction has individual score(s) below 3: "
-            + ", ".join(low_scores)
+        advisory.append(f"individual score(s) below 3: {', '.join(low_scores)}")
+    if advisory:
+        return CheckStatus.WARN, (
+            f"{_PLAN_MD} evaluation_prediction forecast is under the bar "
+            f"({'; '.join(advisory)}) — revise the plan, or record why it is "
+            "acceptable. Merge is gated by `govkit evidence`, not by this forecast."
         )
-    return CheckStatus.PASS, f"{_PLAN_MD} evaluation_prediction averages OK ({', '.join(averages)})"
+    return CheckStatus.PASS, f"{_PLAN_MD} evaluation_prediction forecast OK ({', '.join(averages)})"
 
 
 # A markdown table's delimiter row (`|---|:---:|`). Rows before it are the

--- a/docs/backend/evaluation/EVAL_STACK.md
+++ b/docs/backend/evaluation/EVAL_STACK.md
@@ -8,7 +8,7 @@ The *what* is defined in `eval_criteria.md`. This document defines the *how*.
 
 # 1. Evaluation Architecture
 
-Evaluation is modelled as a hexagonal concern. The home-grown evaluation framework defines the **evaluation port** — the contract that all features must satisfy. Other tools are **outbound adapters** that implement observation, evaluation, and reporting against that contract.
+Evaluation is modelled as a hexagonal concern. `govkit evidence` defines the **evaluation port** — the contract that all features must satisfy. Other tools are **outbound adapters** that implement observation, evaluation, and reporting against that contract.
 
 ```
 ┌──────────────────────────────────────────────┐
@@ -18,8 +18,9 @@ Evaluation is modelled as a hexagonal concern. The home-grown evaluation framewo
                │
        ┌───────┼──────────┬──────────┬──────────┐
        ▼       ▼          ▼          ▼          ▼
-  Home-grown  DeepEval  Promptfoo  RAGAS    Langfuse
-  (CI gates)  (quality) (safety)  (retrieval) (visibility)
+  govkit      DeepEval  Promptfoo  RAGAS    Langfuse
+  evidence    (quality) (safety)  (retrieval) (visibility)
+  (CI gate)
 ```
 
 No single tool owns all roles. Projects activate the adapters appropriate to their stage and feature type.
@@ -28,20 +29,44 @@ No single tool owns all roles. Projects activate the adapters appropriate to the
 
 # 2. Tool Roles
 
-## Home-Grown Evaluation Framework
+## govkit evidence
 
-**Role:** CI gate enforcement for FIRST and 7 Virtues
+**Role:** CI gate on measured quality evidence
 
-**When:** Every build, all levels
+**When:** Every build, L4+
 
-Used to enforce the project's code and test quality contract at CI time:
+`govkit evidence` reads the reports your test run produced and gives a verdict
+per rubric dimension: `PASS`, `FAIL`, `INCONCLUSIVE`, or `ERROR`. It is wired up
+by `ci/<platform>/evidence-gate.yml`.
 
-- FIRST score enforcement
-- 7 Code Virtue score enforcement
-- Feature-level `eval_criteria.yaml` thresholds
-- Fail-fast on regression
+It reads the standard XML test report every mainstream runner can emit, and — for
+UI projects — accessibility results as JSON:
 
-This adapter is **required** on all projects. It is the only evaluation tool that blocks merges for code quality.
+```bash
+pytest --junitxml=junit.xml                       # python
+npx vitest run --reporter=junit --outputFile=junit.xml   # node
+# any runner that writes the same report format works; nothing is stack-specific
+```
+
+- Working — the test run had no failures
+- Accessibility — no critical or serious axe violations
+- Fast — blocking once the team sets `--fast-max-seconds`
+- Everything else — `INCONCLUSIVE`, and **INCONCLUSIVE is not a pass**
+
+This is the tool that blocks merges for code quality.
+
+### What replaced what
+
+Earlier versions of this document described a "Home-Grown Evaluation Framework"
+that enforced FIRST and Virtue scores at CI time and was "required on all
+projects". **No such framework was ever built.** The only implementation was a
+parser that read the FIRST/Virtue numbers out of `plan.md` — numbers written by
+the agent that did the work.
+
+`docs/backend/evaluation/EVIDENCE_CONTRACT.md` names that a producer self-check
+and makes it advisory: *"the task owner never commits its own final gate."* The
+prediction gates still run and still report, but as a **planning forecast**, not
+a quality verdict. Merge is gated on evidence.
 
 ---
 
@@ -137,7 +162,7 @@ Rules:
 
 # 3. Pipeline by Environment
 
-| Environment | Home-Grown | DeepEval | Promptfoo | RAGAS | Langfuse |
+| Environment | govkit evidence | DeepEval | Promptfoo | RAGAS | Langfuse |
 |-------------|-----------|----------|-----------|-------|----------|
 | Local dev | optional | enabled | optional | optional | optional |
 | CI | **required** | **required** (if mode: llm) | **required** (if preflight says so) | **required** (if RAG) | disabled |
@@ -151,8 +176,8 @@ Rules:
 Each project configures active adapters via environment variables:
 
 ```bash
-# Home-grown (always on in CI)
-GOVKIT_EVAL_ENABLED=true
+# govkit evidence reads CI artifacts; no env var. Emit JUnit XML (and axe
+# JSON for UI) from your test run and the evidence gate picks them up.
 
 # DeepEval
 DEEPEVAL_API_KEY=...            # Optional — for DeepEval cloud features
@@ -183,7 +208,7 @@ When applying govkit to a new project, review:
 - Whether Promptfoo is needed (required for user-facing LLM features)
 - Whether RAGAS is needed (required for RAG features)
 - Whether Langfuse is configured (required for production LLM features)
-- The home-grown framework is always required — thresholds may be tuned in `eval_criteria.yaml`
+- `govkit evidence` is always required. Which dimensions it can judge depends on what your test run emits; set `--fast-max-seconds` to make per-test duration blocking
 
 ---
 
@@ -191,7 +216,7 @@ When applying govkit to a new project, review:
 
 An ADR must be created if:
 
-- Replacing or removing the home-grown CI gate adapter
+- Replacing or removing the `govkit evidence` CI gate
 - Replacing DeepEval, Promptfoo, RAGAS, or Langfuse with a different tool
 - Introducing a new evaluation tool not listed here
 - Changing evaluation thresholds below the minimums defined in `eval_criteria.md`

--- a/docs/backend/evaluation/EVIDENCE_CONTRACT.md
+++ b/docs/backend/evaluation/EVIDENCE_CONTRACT.md
@@ -1,0 +1,119 @@
+# Evidence Contract
+
+govkit requires a **planning forecast before implementation** and **measured
+quality evidence before merge**. This contract defines what counts as evidence,
+what a gate may conclude from it, and — honestly — which dimensions govkit can
+measure today and which it cannot.
+
+## Source
+
+The vocabulary here is lifted from
+`extensions/skill-oriented-agent-architecture/docs/backend/architecture/EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md`,
+which govkit ships to govern the agent systems its users *build*. Promoting it
+rather than inventing a parallel set of words is deliberate: two vocabularies
+for the same concepts drift into meaning different things, and a framework that
+holds its users to a standard its own delivery layer does not meet is not
+defensible.
+
+## Separate concepts
+
+| Concept | Meaning |
+|---|---|
+| Evaluation | Measurement of a target against explicit criteria |
+| Evidence | A source-linked observation record, scoped to exact versions |
+| Gate decision | Deterministic application of policy to evaluated claims |
+| Forecast | A prediction made before the work exists |
+
+A forecast is not evidence. It is a planning artifact, useful for deciding
+whether a plan is worth executing, and it says nothing about what was built.
+
+## The rule this contract exists to enforce
+
+> A **producer self-check** is advisory. The task owner **never commits its own final gate**.
+
+A FIRST or 7-Virtue score written into `plan.md` by the agent doing the work is a
+producer self-check. It is a legitimate forecast and an illegitimate gate. Any
+number the producer both authors and is judged by carries no assurance, however
+carefully it is cross-checked against other numbers the same producer authored.
+
+## Gate outcomes
+
+| Outcome | Meaning |
+|---|---|
+| `PASS` | Evidence exists and satisfies the criterion |
+| `FAIL` | Evidence exists and does not satisfy the criterion |
+| `INCONCLUSIVE` | No evidence, insufficient evidence, or evidence out of scope |
+| `ERROR` | The evaluation could not be executed |
+
+**INCONCLUSIVE is not a pass.** This is the single most important line in this
+contract. An unmeasured dimension that reports green is indistinguishable from a
+verified one, which is exactly how a fabricated score survives review. A gate
+must report what it did not measure as loudly as what it did.
+
+One blocking failure fails the gate. `ERROR`, missing execution, and stale
+evidence never become a pass through aggregation. Weighted or averaged scoring
+applies only to non-blocking criteria — which is why an *average* of twelve
+dimensions cannot itself be the blocking gate.
+
+## Evidence rules
+
+Evidence must be:
+
+- Produced by executing something, not by asserting something
+- Source-linked — the artifact, the tool, and the run are identifiable
+- Scoped to the exact commit and configuration it describes
+- Independent of the producer's own claims about the work
+
+Evidence from a different commit, configuration, or environment requires
+explicit justification before it counts. Stale evidence is `INCONCLUSIVE`, not
+`PASS`.
+
+## What govkit measures today
+
+Honest status. Most dimensions are `INCONCLUSIVE` on a fresh install, and saying
+so is the point of this contract.
+
+| Dimension | Evidence source | Status |
+|---|---|---|
+| Working | Test run outcome | UI only — no backend gate runs the project's tests |
+| Accessibility | axe critical/serious counts | UI component tests only; the E2E axe job is a stub |
+| Easy | Boundary gate (import-linter, dependency-cruiser, go-arch-lint, ArchUnit) | Where the team has adopted a boundary contract |
+| Unique, Simple | SonarQube duplication and complexity | Weak — thresholds live on the Sonar server, so govkit asserts nothing about the numbers |
+| Developed | Coverage | Not measured. UI uploads a `coverage/` artifact that nothing reads |
+| Fast | Per-test duration | Not measured |
+| Repeatable | Flake rate over repeated runs | Not measured |
+| Isolated | Randomised-order and run-alone outcomes | Not measured |
+| Timely | Commit ordering of test versus source | Not measured |
+| Self-Verifying | Assertion shape | Not measured |
+| Brief | Unused imports, commented-out code | Not measured |
+| Clear | — | **Not mechanically scorable.** See below |
+
+Every row marked "not measured" reports `INCONCLUSIVE`. None of them reports
+`PASS`.
+
+## What must never be scored mechanically
+
+**Clear** — "identifiers are descriptive and domain-aligned", "functions do one
+thing", "the code reads as prose" — is irreducibly a matter of judgement. Its
+only measurable proxies (identifier length, comment density) are weak enough to
+be actively misleading, rewarding verbosity over clarity.
+
+Dimensions of this kind stay advisory. They may be scored by an **independent,
+identified evaluator with evidence** — never by the agent that produced the work,
+and never by a metric standing in for a judgement it cannot make.
+
+## Forecast versus evidence
+
+Both are required, and they answer different questions.
+
+| | Forecast | Evidence |
+|---|---|---|
+| When | Before implementation | Before merge |
+| Author | The planning agent | An executed tool |
+| Lives in | `plan.md` `evaluation_prediction` | CI artifacts |
+| Purpose | Is this plan worth executing? | Is what was built acceptable? |
+| Blocking | No | Yes, where the dimension is measured |
+
+A forecast that turns out wrong is not a governance failure — it is information.
+A forecast treated as evidence is a governance failure, because it converts an
+unverified claim into a green check.

--- a/docs/backend/evaluation/EVIDENCE_CONTRACT.md
+++ b/docs/backend/evaluation/EVIDENCE_CONTRACT.md
@@ -50,6 +50,23 @@ contract. An unmeasured dimension that reports green is indistinguishable from a
 verified one, which is exactly how a fabricated score survives review. A gate
 must report what it did not measure as loudly as what it did.
 
+**A present-but-unreadable artifact is `ERROR`, never `PASS`.** A file that
+parses is not automatically an evidence file. An empty document, a document
+missing the field the tool writes, or a field of the wrong type all carry *no
+information* — and reading "no violations found" out of them would give an
+artifact that says nothing the same verdict as a clean scan. That is the same
+failure as a fabricated score, arriving by a different route.
+
+The distinction between the two non-verdicts is worth keeping sharp:
+
+- `INCONCLUSIVE` — we did not evaluate this. Nothing was produced, or what was
+  produced does not cover this dimension.
+- `ERROR` — we tried to evaluate and could not. An artifact exists and someone
+  probably believes it is working.
+
+`ERROR` is the louder of the two on purpose. A broken report that a team thinks
+is protecting them is worse than a report they know is missing.
+
 One blocking failure fails the gate. `ERROR`, missing execution, and stale
 evidence never become a pass through aggregation. Weighted or averaged scoring
 applies only to non-blocking criteria — which is why an *average* of twelve

--- a/docs/backend/evaluation/FIRST_SCORING_RUBRIC.md
+++ b/docs/backend/evaluation/FIRST_SCORING_RUBRIC.md
@@ -78,9 +78,18 @@ Each FIRST principle is scored 1–5 per test file or test suite. The minimum ac
 
 1. Score each principle 1–5 for the test suite under review
 2. Calculate the average across all five principles
-3. **Pass:** average >= 4.0 AND no individual score below 3
-4. **Fail:** average < 4.0 OR any individual score below 3
-5. Record scores in the feature's `plan.md` evaluation_prediction block during planning, and validate against actuals during review
+3. **Meets the bar:** average >= 4.0 AND no individual score below 3
+4. **Below the bar:** average < 4.0 OR any individual score below 3
+5. Record scores in the feature's `plan.md` evaluation_prediction block during planning
+
+These scores are a **forecast**, not a verdict. You are scoring work you are
+about to do, or have just done, against your own rubric — a producer
+self-check, which `EVIDENCE_CONTRACT.md` makes advisory: *"the task owner never
+commits its own final gate."*
+
+Merge is gated by `govkit evidence`, on what the test run actually produced. A
+forecast under the bar means revise the plan; it does not by itself block a
+merge, and a forecast above the bar proves nothing.
 
 ---
 

--- a/docs/backend/evaluation/VIRTUE_SCORING_RUBRIC.md
+++ b/docs/backend/evaluation/VIRTUE_SCORING_RUBRIC.md
@@ -106,9 +106,18 @@ Each virtue is scored 1–5 per implementation increment. The minimum acceptable
 
 1. Score each virtue 1–5 for the implementation increment under review
 2. Calculate the average across all seven virtues
-3. **Pass:** average >= 4.0 AND no individual score below 3
-4. **Fail:** average < 4.0 OR any individual score below 3
-5. Record scores in the feature's `plan.md` evaluation_prediction block during planning, and validate against actuals during review
+3. **Meets the bar:** average >= 4.0 AND no individual score below 3
+4. **Below the bar:** average < 4.0 OR any individual score below 3
+5. Record scores in the feature's `plan.md` evaluation_prediction block during planning
+
+These scores are a **forecast**, not a verdict. You are scoring work you are
+about to do, or have just done, against your own rubric — a producer
+self-check, which `EVIDENCE_CONTRACT.md` makes advisory: *"the task owner never
+commits its own final gate."*
+
+Merge is gated by `govkit evidence`, on what the test run actually produced. A
+forecast under the bar means revise the plan; it does not by itself block a
+merge, and a forecast above the bar proves nothing.
 
 ---
 

--- a/docs/ui/evaluation/EVIDENCE_CONTRACT.md
+++ b/docs/ui/evaluation/EVIDENCE_CONTRACT.md
@@ -1,0 +1,119 @@
+# Evidence Contract
+
+govkit requires a **planning forecast before implementation** and **measured
+quality evidence before merge**. This contract defines what counts as evidence,
+what a gate may conclude from it, and — honestly — which dimensions govkit can
+measure today and which it cannot.
+
+## Source
+
+The vocabulary here is lifted from
+`extensions/skill-oriented-agent-architecture/docs/backend/architecture/EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md`,
+which govkit ships to govern the agent systems its users *build*. Promoting it
+rather than inventing a parallel set of words is deliberate: two vocabularies
+for the same concepts drift into meaning different things, and a framework that
+holds its users to a standard its own delivery layer does not meet is not
+defensible.
+
+## Separate concepts
+
+| Concept | Meaning |
+|---|---|
+| Evaluation | Measurement of a target against explicit criteria |
+| Evidence | A source-linked observation record, scoped to exact versions |
+| Gate decision | Deterministic application of policy to evaluated claims |
+| Forecast | A prediction made before the work exists |
+
+A forecast is not evidence. It is a planning artifact, useful for deciding
+whether a plan is worth executing, and it says nothing about what was built.
+
+## The rule this contract exists to enforce
+
+> A **producer self-check** is advisory. The task owner **never commits its own final gate**.
+
+A FIRST or 7-Virtue score written into `plan.md` by the agent doing the work is a
+producer self-check. It is a legitimate forecast and an illegitimate gate. Any
+number the producer both authors and is judged by carries no assurance, however
+carefully it is cross-checked against other numbers the same producer authored.
+
+## Gate outcomes
+
+| Outcome | Meaning |
+|---|---|
+| `PASS` | Evidence exists and satisfies the criterion |
+| `FAIL` | Evidence exists and does not satisfy the criterion |
+| `INCONCLUSIVE` | No evidence, insufficient evidence, or evidence out of scope |
+| `ERROR` | The evaluation could not be executed |
+
+**INCONCLUSIVE is not a pass.** This is the single most important line in this
+contract. An unmeasured dimension that reports green is indistinguishable from a
+verified one, which is exactly how a fabricated score survives review. A gate
+must report what it did not measure as loudly as what it did.
+
+One blocking failure fails the gate. `ERROR`, missing execution, and stale
+evidence never become a pass through aggregation. Weighted or averaged scoring
+applies only to non-blocking criteria — which is why an *average* of twelve
+dimensions cannot itself be the blocking gate.
+
+## Evidence rules
+
+Evidence must be:
+
+- Produced by executing something, not by asserting something
+- Source-linked — the artifact, the tool, and the run are identifiable
+- Scoped to the exact commit and configuration it describes
+- Independent of the producer's own claims about the work
+
+Evidence from a different commit, configuration, or environment requires
+explicit justification before it counts. Stale evidence is `INCONCLUSIVE`, not
+`PASS`.
+
+## What govkit measures today
+
+Honest status. Most dimensions are `INCONCLUSIVE` on a fresh install, and saying
+so is the point of this contract.
+
+| Dimension | Evidence source | Status |
+|---|---|---|
+| Working | Test run outcome | UI only — no backend gate runs the project's tests |
+| Accessibility | axe critical/serious counts | UI component tests only; the E2E axe job is a stub |
+| Easy | Boundary gate (import-linter, dependency-cruiser, go-arch-lint, ArchUnit) | Where the team has adopted a boundary contract |
+| Unique, Simple | SonarQube duplication and complexity | Weak — thresholds live on the Sonar server, so govkit asserts nothing about the numbers |
+| Developed | Coverage | Not measured. UI uploads a `coverage/` artifact that nothing reads |
+| Fast | Per-test duration | Not measured |
+| Repeatable | Flake rate over repeated runs | Not measured |
+| Isolated | Randomised-order and run-alone outcomes | Not measured |
+| Timely | Commit ordering of test versus source | Not measured |
+| Self-Verifying | Assertion shape | Not measured |
+| Brief | Unused imports, commented-out code | Not measured |
+| Clear | — | **Not mechanically scorable.** See below |
+
+Every row marked "not measured" reports `INCONCLUSIVE`. None of them reports
+`PASS`.
+
+## What must never be scored mechanically
+
+**Clear** — "identifiers are descriptive and domain-aligned", "functions do one
+thing", "the code reads as prose" — is irreducibly a matter of judgement. Its
+only measurable proxies (identifier length, comment density) are weak enough to
+be actively misleading, rewarding verbosity over clarity.
+
+Dimensions of this kind stay advisory. They may be scored by an **independent,
+identified evaluator with evidence** — never by the agent that produced the work,
+and never by a metric standing in for a judgement it cannot make.
+
+## Forecast versus evidence
+
+Both are required, and they answer different questions.
+
+| | Forecast | Evidence |
+|---|---|---|
+| When | Before implementation | Before merge |
+| Author | The planning agent | An executed tool |
+| Lives in | `plan.md` `evaluation_prediction` | CI artifacts |
+| Purpose | Is this plan worth executing? | Is what was built acceptable? |
+| Blocking | No | Yes, where the dimension is measured |
+
+A forecast that turns out wrong is not a governance failure — it is information.
+A forecast treated as evidence is a governance failure, because it converts an
+unverified claim into a green check.

--- a/docs/ui/evaluation/EVIDENCE_CONTRACT.md
+++ b/docs/ui/evaluation/EVIDENCE_CONTRACT.md
@@ -50,6 +50,23 @@ contract. An unmeasured dimension that reports green is indistinguishable from a
 verified one, which is exactly how a fabricated score survives review. A gate
 must report what it did not measure as loudly as what it did.
 
+**A present-but-unreadable artifact is `ERROR`, never `PASS`.** A file that
+parses is not automatically an evidence file. An empty document, a document
+missing the field the tool writes, or a field of the wrong type all carry *no
+information* — and reading "no violations found" out of them would give an
+artifact that says nothing the same verdict as a clean scan. That is the same
+failure as a fabricated score, arriving by a different route.
+
+The distinction between the two non-verdicts is worth keeping sharp:
+
+- `INCONCLUSIVE` — we did not evaluate this. Nothing was produced, or what was
+  produced does not cover this dimension.
+- `ERROR` — we tried to evaluate and could not. An artifact exists and someone
+  probably believes it is working.
+
+`ERROR` is the louder of the two on purpose. A broken report that a team thinks
+is protecting them is worse than a report they know is missing.
+
 One blocking failure fails the gate. `ERROR`, missing execution, and stale
 evidence never become a pass through aggregation. Weighted or averaged scoring
 applies only to non-blocking criteria — which is why an *average* of twelve

--- a/docs/ui/evaluation/FIRST_SCORING_RUBRIC.md
+++ b/docs/ui/evaluation/FIRST_SCORING_RUBRIC.md
@@ -80,9 +80,18 @@ This rubric adapts backend FIRST principles for the UI context: component render
 
 1. Score each principle 1–5 for the test suite under review
 2. Calculate the average across all five principles
-3. **Pass:** average >= 4.0 AND no individual score below 3
-4. **Fail:** average < 4.0 OR any individual score below 3
-5. Record scores in the feature's `plan.md` evaluation_prediction block during planning, and validate against actuals during review
+3. **Meets the bar:** average >= 4.0 AND no individual score below 3
+4. **Below the bar:** average < 4.0 OR any individual score below 3
+5. Record scores in the feature's `plan.md` evaluation_prediction block during planning
+
+These scores are a **forecast**, not a verdict. You are scoring work you are
+about to do, or have just done, against your own rubric — a producer
+self-check, which `EVIDENCE_CONTRACT.md` makes advisory: *"the task owner never
+commits its own final gate."*
+
+Merge is gated by `govkit evidence`, on what the test run actually produced. A
+forecast under the bar means revise the plan; it does not by itself block a
+merge, and a forecast above the bar proves nothing.
 
 ---
 

--- a/docs/ui/evaluation/VIRTUE_SCORING_RUBRIC.md
+++ b/docs/ui/evaluation/VIRTUE_SCORING_RUBRIC.md
@@ -108,9 +108,18 @@ This rubric adapts the 7 Code Virtues for the UI context: MVVM separation, compo
 
 1. Score each virtue 1–5 for the implementation increment under review
 2. Calculate the average across all seven virtues
-3. **Pass:** average >= 4.0 AND no individual score below 3
-4. **Fail:** average < 4.0 OR any individual score below 3
-5. Record scores in the feature's `plan.md` evaluation_prediction block during planning, and validate against actuals during review
+3. **Meets the bar:** average >= 4.0 AND no individual score below 3
+4. **Below the bar:** average < 4.0 OR any individual score below 3
+5. Record scores in the feature's `plan.md` evaluation_prediction block during planning
+
+These scores are a **forecast**, not a verdict. You are scoring work you are
+about to do, or have just done, against your own rubric — a producer
+self-check, which `EVIDENCE_CONTRACT.md` makes advisory: *"the task owner never
+commits its own final gate."*
+
+Merge is gated by `govkit evidence`, on what the test run actually produced. A
+forecast under the bar means revise the plan; it does not by itself block a
+merge, and a forecast above the bar proves nothing.
 
 ---
 

--- a/plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md
+++ b/plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md
@@ -101,11 +101,73 @@ Until an approval can be *represented*, "autonomous but governed" has nowhere to
 
 ---
 
-## Open decisions
+## Decisions — all three answered
 
-1. Does a defect lane belong in govkit — a `fix`-shaped artifact set lighter than the five-artifact feature contract — or does the bug-fix agent stay outside the governance model by design?
-2. Should govkit gain a machine-readable approval representation (signed marker, CI-verified provenance) so `Accepted` is something other than a human typing a name into a template?
-3. Should any prediction-only gate become measured? The 4.0 floor is the most-cited element of govkit's value proposition and is currently unfalsifiable.
+### 1. Defect lane — **DECIDED and DELIVERED** (2026-08-13)
+
+govkit owns a lightweight, risk-tiered fix contract. The bug-fix agent may stay
+an external harness, but its workflow does not sit outside governance.
+
+Shipped: `fixes/<id>/fix.yaml` against `governance/schemas/fix_record.schema.json`,
+`govkit fix init`, eligibility checks in `cli/fixes.py`, the diff-aware
+`ci/*/fix-lane-gate.yml`, and `/govkit-fix-record` across all three agents.
+L4+; L3 keeps no artifact model.
+
+The four eligibility conditions and what verifies each are in the README's
+defect lifecycle. Two of them — "restores established behavior" and "introduces
+no new behavior" — remain **declared**, which is decision 2's territory.
+
+### 2. Machine-verifiable approval — **DECIDED, NOT BUILT**
+
+Yes, but as an **approval attestation**, not a name typed into an ADR or a field
+in `.govkit/marker.json`. The marker represents installation and calibration
+state, is repo-global, and has no approval semantics; overloading it would be
+wrong.
+
+The representation must carry: subject identity and exact artifact digest or
+commit SHA; decision and scope; approver identity and authorised role; policy
+version and issuer; timestamp, expiry, conditions, evidence references; and
+verifiable provider provenance or a signature. CI verifies issuer, role, subject
+digest, and freshness. Any relevant change invalidates the approval, so
+`Accepted` becomes a **derived state**, not editable source text.
+
+MVP: an authenticated GitHub/Azure review by an authorised team against the
+current head SHA is sufficient provenance. A signed offline attestation is a
+later profile.
+
+This is what govkit's own `AUTHORITY_AND_APPROVAL_CONTRACT.md` already demands
+of the systems its users build — scoped, evidence-linked, identity-bound,
+revocable — and explicitly forbids satisfying with prompt or chat text.
+
+### 3. Measured evidence over predicted scores — **DECIDED, NOT BUILT**
+
+Keep predictions as **planning forecasts**. Stop calling them quality gates and
+stop using the 4.0 floor as the headline value proposition until it is measured.
+
+Measure what has credible observable evidence: Working (acceptance and
+regression tests pass), Fast (recorded test-duration thresholds), Repeatable
+(reruns and flake detection), Isolated (independent or randomised-order
+execution), Unique/Simple/Brief (duplication, complexity, coupling, scoped-size
+thresholds), Accessibility (actual axe results, not `predicted_axe_violations`),
+and architecture/security from existing boundary and scanner results.
+
+Clear, Easy, Developed and Timely stay advisory unless scored by an independent,
+identified evaluator with evidence — never by the authoring agent.
+
+The precedent already exists in-repo: `docs/data/architecture/ADR/0001-data-features-skip-prediction-gate.md`
+(Accepted) calls the self-predicted 4.0 average "ceremony" and replaces it with
+deterministic CI outcomes. Backend and UI should follow it.
+
+Partially landed already: `check_plan_eval_prediction` now cross-checks the
+declared average against the scores beneath it and enforces the rubric's
+"no individual score below 3", which was never checked. That closes a
+sloppiness gap, **not** the self-attestation one — reconciling two numbers the
+same agent authored is not measurement.
+
+Target position: *govkit requires a planning forecast before implementation and
+measured quality evidence before merge.* Restore "4.0 quality floor" as a
+headline only once evaluations are commit-bound, independently produced,
+calibrated, and enforce both the average and the individual-score floors.
 
 ---
 

--- a/tests/test_ci_govkit_dependency.py
+++ b/tests/test_ci_govkit_dependency.py
@@ -22,7 +22,13 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 CI_DIRS = [REPO_ROOT / "ci" / "github", REPO_ROOT / "ci" / "azure"]
 
 # `govkit <subcommand>` as an executed command, not a prose mention.
-INVOKES_RE = re.compile(r"^\s*(?:-\s*script:\s*|run:\s*)?govkit\s+(doctor|validate|apply|init)\b", re.MULTILINE)
+# Deliberately matches ANY subcommand rather than an enumerated list: the first
+# version named doctor|validate|apply|init, so `govkit evidence` shipped in a
+# gate without a pin and this suite stayed green. A new subcommand must not be
+# able to escape the pin requirement by not being on a list.
+INVOKES_RE = re.compile(
+    r"^\s*(?:-\s*script:\s*|run:\s*)?govkit\s+[a-z][a-z-]*\b", re.MULTILINE
+)
 # A pinned install: govkit~=X.Y.Z (compatible-release, patch-only within the minor)
 PINNED_RE = re.compile(r"pip install\s+['\"]?govkit~=(\d+\.\d+\.\d+)['\"]?")
 # Any install at all, pinned or not.

--- a/tests/test_cmd_evidence.py
+++ b/tests/test_cmd_evidence.py
@@ -14,8 +14,8 @@ import pytest
 from cli.cmd_evidence import cmd_evidence, register
 
 
-def _args(target: Path):
-    return argparse.Namespace(target=str(target))
+def _args(target: Path, fast_max_seconds: float | None = None):
+    return argparse.Namespace(target=str(target), fast_max_seconds=fast_max_seconds)
 
 
 def _passing_junit(target: Path) -> None:

--- a/tests/test_cmd_evidence.py
+++ b/tests/test_cmd_evidence.py
@@ -1,0 +1,101 @@
+"""`govkit evidence` — report measured evidence per dimension.
+
+Deliberately a separate command from `validate`. `validate` checks that governed
+*artifacts* are well-formed; this reports what an executed tool *observed*. They
+answer different questions and fail for different reasons, and collapsing them
+would put a forecast and an observation behind the same verdict.
+"""
+
+import argparse
+from pathlib import Path
+
+import pytest
+
+from cli.cmd_evidence import cmd_evidence, register
+
+
+def _args(target: Path):
+    return argparse.Namespace(target=str(target))
+
+
+def _passing_junit(target: Path) -> None:
+    (target / "junit.xml").write_text(
+        '<?xml version="1.0"?><testsuites><testsuite name="s" tests="2" '
+        'failures="0" errors="0"><testcase classname="s" name="a" time="0.01"/>'
+        '<testcase classname="s" name="b" time="0.02"/></testsuite></testsuites>',
+        encoding="utf-8",
+    )
+
+
+class TestTargetValidation:
+    def test_missing_target_errors(self, tmp_path):
+        with pytest.raises(SystemExit) as exc:
+            cmd_evidence(_args(tmp_path / "nope"))
+        assert exc.value.code == 1
+
+    def test_file_as_target_errors(self, tmp_path):
+        f = tmp_path / "afile"
+        f.write_text("x", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            cmd_evidence(_args(f))
+        assert exc.value.code == 1
+
+
+class TestReporting:
+    def test_empty_analysis_exits_non_zero(self, tmp_path, capsys):
+        with pytest.raises(SystemExit) as exc:
+            cmd_evidence(_args(tmp_path))
+        assert exc.value.code == 1
+        assert "analysed nothing" in capsys.readouterr().out.lower()
+
+    def test_every_dimension_is_printed(self, tmp_path, capsys):
+        """A dimension missing from the output is indistinguishable from one
+        that passed."""
+        from cli.evidence import DIMENSIONS
+
+        _passing_junit(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_evidence(_args(tmp_path))
+        out = capsys.readouterr().out
+        missing = [d for d in DIMENSIONS if d not in out]
+        assert not missing, missing
+
+    def test_measured_pass_exits_zero(self, tmp_path, capsys):
+        import json
+
+        _passing_junit(tmp_path)
+        (tmp_path / "axe.json").write_text(json.dumps({"violations": []}), encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            cmd_evidence(_args(tmp_path))
+        assert exc.value.code == 0, capsys.readouterr().out
+
+    def test_failure_exits_non_zero(self, tmp_path):
+        (tmp_path / "junit.xml").write_text(
+            '<?xml version="1.0"?><testsuites><testsuite name="s" tests="1" '
+            'failures="1" errors="0"><testcase classname="s" name="a" time="0.01">'
+            '<failure message="x"/></testcase></testsuite></testsuites>',
+            encoding="utf-8",
+        )
+        with pytest.raises(SystemExit) as exc:
+            cmd_evidence(_args(tmp_path))
+        assert exc.value.code == 1
+
+    def test_unmeasured_dimensions_are_labelled_inconclusive(self, tmp_path, capsys):
+        _passing_junit(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_evidence(_args(tmp_path))
+        assert "INCONCLUSIVE" in capsys.readouterr().out
+
+
+class TestWiring:
+    def test_registers_the_subcommand(self):
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        register(sub)
+        args = parser.parse_args(["evidence", "--target", "."])
+        assert args.func is cmd_evidence
+
+    def test_registered_in_the_main_dispatch_table(self):
+        from cli import govkit
+
+        assert "cli.cmd_evidence" in [r.__module__ for r in govkit._REGISTRARS]

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,205 @@
+"""Measured evidence: read what CI actually produced, and say what it did not.
+
+Two dimensions have unambiguous criteria today and are gated: Working (the test
+run had no failures) and Accessibility (axe reported no critical or serious
+violations). Everything else reports INCONCLUSIVE.
+
+That is deliberate, not a shortfall to be papered over. Turning a 1-5 rubric
+band into a pass/fail threshold is a calibration decision, and
+`docs/data/architecture/ADR/0001-...` already warns that inventing a rubric
+nobody has calibrated "recreates the ceremony this ADR removes". Fast therefore
+reports its *observed* durations while staying INCONCLUSIVE until a team sets a
+threshold — the measurement is real, the policy is theirs.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from cli.evidence import (
+    DIMENSIONS,
+    Outcome,
+    collect_evidence,
+    summarize,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _junit(tmp_path: Path, cases: list[tuple[str, float, bool]], name: str = "junit.xml") -> Path:
+    """cases = [(test name, seconds, passed)]"""
+    failures = sum(1 for _, _, ok in cases if not ok)
+    body = "".join(
+        f'<testcase classname="suite" name="{n}" time="{t}">'
+        + ("" if ok else '<failure message="boom">trace</failure>')
+        + "</testcase>"
+        for n, t, ok in cases
+    )
+    path = tmp_path / name
+    path.write_text(
+        f'<?xml version="1.0"?><testsuites><testsuite name="suite" '
+        f'tests="{len(cases)}" failures="{failures}" errors="0">{body}</testsuite></testsuites>',
+        encoding="utf-8",
+    )
+    return path
+
+
+def _axe(tmp_path: Path, impacts: list[str], name: str = "axe.json") -> Path:
+    import json
+
+    path = tmp_path / name
+    path.write_text(
+        json.dumps({"violations": [{"id": f"r{i}", "impact": imp, "nodes": [{}]}
+                                   for i, imp in enumerate(impacts)]}),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _by_dimension(verdicts) -> dict:
+    return {v.dimension: v for v in verdicts}
+
+
+class TestNoEvidence:
+    def test_every_dimension_reported(self, tmp_path):
+        """Silence about a dimension is how an unmeasured one reads as green."""
+        verdicts = collect_evidence(tmp_path)
+        assert {v.dimension for v in verdicts} == set(DIMENSIONS)
+
+    def test_all_inconclusive_when_nothing_produced(self, tmp_path):
+        verdicts = collect_evidence(tmp_path)
+        assert all(v.outcome is Outcome.INCONCLUSIVE for v in verdicts), [
+            (v.dimension, v.outcome) for v in verdicts if v.outcome is not Outcome.INCONCLUSIVE
+        ]
+
+    def test_empty_analysis_fails(self, tmp_path):
+        """ci/README: every tool reports success on an empty analysis, so a
+        misconfigured contract looks exactly like a clean repo."""
+        exit_code, summary = summarize(collect_evidence(tmp_path))
+        assert exit_code == 1
+        assert "analysed nothing" in summary.lower()
+
+
+class TestWorking:
+    def test_passing_suite(self, tmp_path):
+        _junit(tmp_path, [("t1", 0.01, True), ("t2", 0.02, True)])
+        v = _by_dimension(collect_evidence(tmp_path))["Working"]
+        assert v.outcome is Outcome.PASS, v.detail
+
+    def test_failing_suite(self, tmp_path):
+        _junit(tmp_path, [("t1", 0.01, True), ("t2", 0.02, False)])
+        v = _by_dimension(collect_evidence(tmp_path))["Working"]
+        assert v.outcome is Outcome.FAIL
+        assert "1" in v.detail
+
+    def test_failure_makes_the_run_fail(self, tmp_path):
+        _junit(tmp_path, [("t1", 0.01, False)])
+        exit_code, _ = summarize(collect_evidence(tmp_path))
+        assert exit_code == 1
+
+    def test_zero_test_suite_is_inconclusive_not_pass(self, tmp_path):
+        """A JUnit file reporting no tests is an empty analysis, not a clean one."""
+        _junit(tmp_path, [])
+        v = _by_dimension(collect_evidence(tmp_path))["Working"]
+        assert v.outcome is Outcome.INCONCLUSIVE, v.detail
+
+    def test_unreadable_artifact_is_error_not_pass(self, tmp_path):
+        (tmp_path / "junit.xml").write_text("<not-xml", encoding="utf-8")
+        v = _by_dimension(collect_evidence(tmp_path))["Working"]
+        assert v.outcome is Outcome.ERROR, v.detail
+
+    def test_error_makes_the_run_fail(self, tmp_path):
+        (tmp_path / "junit.xml").write_text("<not-xml", encoding="utf-8")
+        exit_code, _ = summarize(collect_evidence(tmp_path))
+        assert exit_code == 1
+
+
+class TestAccessibility:
+    def test_no_violations(self, tmp_path):
+        _axe(tmp_path, [])
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.PASS, v.detail
+
+    @pytest.mark.parametrize("impact", ["critical", "serious"])
+    def test_blocking_impacts_fail(self, tmp_path, impact):
+        _axe(tmp_path, [impact])
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.FAIL
+        assert impact in v.detail
+
+    @pytest.mark.parametrize("impact", ["moderate", "minor"])
+    def test_non_blocking_impacts_pass_but_are_reported(self, tmp_path, impact):
+        """The UI rubric bands minor violations at 3, not 1 — they are not a
+        merge blocker, but they must not vanish either."""
+        _axe(tmp_path, [impact])
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.PASS
+        assert impact in v.detail
+
+    def test_playwright_array_shape_is_read(self, tmp_path):
+        """Playwright axe runs commonly write an array of results."""
+        import json
+
+        (tmp_path / "axe.json").write_text(
+            json.dumps([{"violations": [{"id": "x", "impact": "critical", "nodes": [{}]}]}]),
+            encoding="utf-8",
+        )
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.FAIL
+
+
+class TestFastReportsWithoutJudging:
+    def test_durations_observed_but_outcome_stays_inconclusive(self, tmp_path):
+        """The measurement is real; the threshold is the team's calibration to
+        make. Inventing one here would recreate the ceremony being removed."""
+        _junit(tmp_path, [("t1", 0.001, True), ("t2", 1.5, True)])
+        v = _by_dimension(collect_evidence(tmp_path))["Fast"]
+        assert v.outcome is Outcome.INCONCLUSIVE
+        assert "1.5" in v.detail or "1500" in v.detail
+
+    def test_no_junit_means_no_observation(self, tmp_path):
+        v = _by_dimension(collect_evidence(tmp_path))["Fast"]
+        assert v.outcome is Outcome.INCONCLUSIVE
+        assert "no" in v.detail.lower()
+
+
+class TestSummary:
+    def test_partial_coverage_passes_but_names_the_gap(self, tmp_path):
+        """Some measured, none failing: not a blocker, but the summary must say
+        how much went unmeasured rather than printing a bare green."""
+        _junit(tmp_path, [("t1", 0.01, True)])
+        _axe(tmp_path, [])
+        exit_code, summary = summarize(collect_evidence(tmp_path))
+        assert exit_code == 0
+        assert "2 measured" in summary
+        assert "unmeasured" in summary.lower()
+
+    def test_summary_never_claims_a_dimension_it_did_not_measure(self, tmp_path):
+        _junit(tmp_path, [("t1", 0.01, True)])
+        _, summary = summarize(collect_evidence(tmp_path))
+        assert "Clear" not in summary.split("unmeasured")[0]
+
+
+def test_clear_is_never_measurable(tmp_path):
+    """Its only proxies reward verbosity over clarity. The contract says it must
+    stay advisory; this pins that it can never report PASS."""
+    _junit(tmp_path, [("t1", 0.01, True)])
+    _axe(tmp_path, [])
+    v = _by_dimension(collect_evidence(tmp_path))["Clear"]
+    assert v.outcome is Outcome.INCONCLUSIVE
+    assert "judgement" in v.detail.lower()
+
+
+def test_dimensions_match_the_shipped_rubrics():
+    """Non-vacuous guard: the dimension list must be the rubrics' own, or this
+    module is measuring something govkit never asked for."""
+    first = (REPO_ROOT / "docs" / "backend" / "evaluation" / "FIRST_SCORING_RUBRIC.md").read_text(
+        encoding="utf-8"
+    )
+    virtues = (REPO_ROOT / "docs" / "backend" / "evaluation" / "VIRTUE_SCORING_RUBRIC.md").read_text(
+        encoding="utf-8"
+    )
+    for dim in ("Fast", "Isolated", "Repeatable", "Self-Verifying", "Timely"):
+        assert dim in first, dim
+    for dim in ("Working", "Unique", "Simple", "Clear", "Easy", "Developed", "Brief"):
+        assert dim in virtues, dim

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -203,3 +203,34 @@ def test_dimensions_match_the_shipped_rubrics():
         assert dim in first, dim
     for dim in ("Working", "Unique", "Simple", "Clear", "Easy", "Developed", "Brief"):
         assert dim in virtues, dim
+
+
+class TestFastThreshold:
+    """A team can make Fast blocking by declaring the threshold they calibrated.
+
+    The threshold is a flag rather than an eval_criteria.yaml field on purpose:
+    it is repo-wide policy, and eval_criteria.yaml is per-feature. Putting it
+    there would have meant one feature's file silently deciding the gate for the
+    whole repo, and a closed-schema edit for a field nothing else reads.
+    """
+
+    def test_under_threshold_passes(self, tmp_path):
+        _junit(tmp_path, [("t1", 0.01, True), ("t2", 0.05, True)])
+        v = _by_dimension(collect_evidence(tmp_path, fast_max_seconds=0.2))["Fast"]
+        assert v.outcome is Outcome.PASS, v.detail
+
+    def test_over_threshold_fails_and_names_the_test(self, tmp_path):
+        _junit(tmp_path, [("quick", 0.01, True), ("crawler", 1.4, True)])
+        v = _by_dimension(collect_evidence(tmp_path, fast_max_seconds=0.2))["Fast"]
+        assert v.outcome is Outcome.FAIL
+        assert "crawler" in v.detail, v.detail
+
+    def test_threshold_without_durations_is_still_inconclusive(self, tmp_path):
+        """A declared threshold does not conjure evidence."""
+        v = _by_dimension(collect_evidence(tmp_path, fast_max_seconds=0.2))["Fast"]
+        assert v.outcome is Outcome.INCONCLUSIVE
+
+    def test_no_threshold_keeps_the_observation_advisory(self, tmp_path):
+        _junit(tmp_path, [("t1", 5.0, True)])
+        v = _by_dimension(collect_evidence(tmp_path))["Fast"]
+        assert v.outcome is Outcome.INCONCLUSIVE

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -234,3 +234,68 @@ class TestFastThreshold:
         _junit(tmp_path, [("t1", 5.0, True)])
         v = _by_dimension(collect_evidence(tmp_path))["Fast"]
         assert v.outcome is Outcome.INCONCLUSIVE
+
+
+class TestMalformedAxeIsNotAPass:
+    """A parseable file is not the same as an evidence file.
+
+    `{}`, `[]` and `{"violations": "oops"}` all previously read as "no
+    violations found" and reported PASS — an artifact carrying no evidence
+    producing the same verdict as a clean scan. The contract calls that out
+    directly: insufficient or out-of-scope evidence is never a pass.
+    """
+
+    def _write(self, tmp_path: Path, payload) -> None:
+        import json
+
+        (tmp_path / "axe.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    @pytest.mark.parametrize(
+        "payload, why",
+        [
+            ({}, "no violations key at all"),
+            ([], "empty array carries no result objects"),
+            ({"violations": "oops"}, "violations is not a list"),
+            ({"violations": {"a": 1}}, "violations is a mapping, not a list"),
+            ([{}], "result object has no violations key"),
+            (["not-a-result"], "array of non-objects"),
+            (None, "null document"),
+            (42, "scalar document"),
+        ],
+    )
+    def test_unsupported_shapes_do_not_pass(self, tmp_path, payload, why):
+        self._write(tmp_path, payload)
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is not Outcome.PASS, f"{why}: {v.detail}"
+        assert v.outcome is Outcome.ERROR, f"{why}: got {v.outcome}"
+        assert "shape" in v.detail.lower(), v.detail
+
+    def test_only_a_real_empty_result_passes(self, tmp_path):
+        """The one shape that legitimately means 'scanned, found nothing'."""
+        self._write(tmp_path, {"violations": []})
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.PASS, v.detail
+
+    def test_array_of_valid_results_passes(self, tmp_path):
+        self._write(tmp_path, [{"violations": []}, {"violations": []}])
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.PASS, v.detail
+
+    def test_one_malformed_file_among_valid_ones_is_not_masked(self, tmp_path):
+        import json
+
+        (tmp_path / "axe.json").write_text(json.dumps({"violations": []}), encoding="utf-8")
+        (tmp_path / "axe-2.json").write_text(json.dumps({"nope": 1}), encoding="utf-8")
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert v.outcome is Outcome.ERROR, v.detail
+
+    def test_malformed_axe_fails_the_run(self, tmp_path):
+        self._write(tmp_path, {})
+        exit_code, _ = summarize(collect_evidence(tmp_path))
+        assert exit_code == 1
+
+    def test_the_file_name_is_named(self, tmp_path):
+        """A reader has to know which artifact to go and look at."""
+        self._write(tmp_path, {})
+        v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
+        assert "axe.json" in v.detail, v.detail

--- a/tests/test_evidence_contract.py
+++ b/tests/test_evidence_contract.py
@@ -1,0 +1,115 @@
+"""The delivery-side evidence contract.
+
+govkit already ships a rigorous evidence contract — but as an opt-in L5
+extension governing the *customer's* runtime agents, so it never applies to
+govkit's own delivery layer. Its decisive line:
+
+    A producer self-check is advisory. The task owner never commits its own
+    final gate.
+
+The FIRST/Virtue prediction *is* a producer self-check used as a final gate.
+This contract promotes that vocabulary to the delivery side rather than
+inventing a parallel one, so the two cannot drift into different meanings for
+the same words.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CONTRACT_PATHS = [
+    REPO_ROOT / "docs" / area / "evaluation" / "EVIDENCE_CONTRACT.md"
+    for area in ("backend", "ui")
+]
+
+SOURCE_CONTRACT = (
+    REPO_ROOT / "extensions" / "skill-oriented-agent-architecture" / "docs" / "backend"
+    / "architecture" / "EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md"
+)
+
+REQUIRED_SECTIONS = [
+    "## Separate concepts",
+    "## Gate outcomes",
+    "## What govkit measures today",
+    "## Forecast versus evidence",
+]
+
+# The four outcomes, lifted verbatim from the source contract.
+GATE_OUTCOMES = ["PASS", "FAIL", "INCONCLUSIVE", "ERROR"]
+
+
+def _rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def test_source_contract_still_says_what_we_are_lifting():
+    """Guard the premise. If the extension contract changes its vocabulary, the
+    delivery-side copy is no longer a promotion of it and must be revisited."""
+    text = SOURCE_CONTRACT.read_text(encoding="utf-8")
+    assert "A producer self-check is advisory" in text
+    assert "never commits its own final gate" in text
+    for outcome in GATE_OUTCOMES:
+        assert f"`{outcome}`" in text, outcome
+
+
+@pytest.mark.parametrize("path", CONTRACT_PATHS, ids=_rel)
+def test_contract_exists_and_has_required_sections(path: Path):
+    text = path.read_text(encoding="utf-8")
+    missing = [s for s in REQUIRED_SECTIONS if s not in text]
+    assert not missing, f"{_rel(path)} missing: {missing}"
+
+
+@pytest.mark.parametrize("path", CONTRACT_PATHS, ids=_rel)
+def test_contract_defines_all_four_gate_outcomes(path: Path):
+    """INCONCLUSIVE is the one that matters: today an unmeasured dimension reads
+    as green, which is why a fabricated score is indistinguishable from a
+    verified one."""
+    text = path.read_text(encoding="utf-8")
+    missing = [o for o in GATE_OUTCOMES if o not in text]
+    assert not missing, f"{_rel(path)} missing outcome(s): {missing}"
+
+
+@pytest.mark.parametrize("path", CONTRACT_PATHS, ids=_rel)
+def test_contract_states_inconclusive_is_not_a_pass(path: Path):
+    text = path.read_text(encoding="utf-8").lower()
+    assert "inconclusive is not a pass" in text, (
+        f"{_rel(path)} must state plainly that an unmeasured dimension does not pass"
+    )
+
+
+@pytest.mark.parametrize("path", CONTRACT_PATHS, ids=_rel)
+def test_contract_carries_the_producer_self_check_rule(path: Path):
+    """The whole argument rests on this sentence; it must be quoted, not paraphrased."""
+    text = path.read_text(encoding="utf-8")
+    assert "producer self-check" in text, _rel(path)
+    assert "never commits its own final gate" in text, _rel(path)
+
+
+@pytest.mark.parametrize("path", CONTRACT_PATHS, ids=_rel)
+def test_contract_cites_its_source(path: Path):
+    """A promoted vocabulary must say where it came from, or the two copies drift
+    into different meanings for the same words."""
+    text = path.read_text(encoding="utf-8")
+    assert "EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md" in text, _rel(path)
+
+
+@pytest.mark.parametrize("path", CONTRACT_PATHS, ids=_rel)
+def test_contract_is_honest_about_what_is_unmeasured(path: Path):
+    """The point of this pass is visible gaps, not a claim of full coverage.
+    'Clear' is irreducibly judgemental and must be named as such."""
+    text = path.read_text(encoding="utf-8")
+    assert "Clear" in text, _rel(path)
+    assert re.search(r"judgement|judgemental|not mechanically", text, re.I), _rel(path)
+
+
+def test_contract_body_is_identical_across_areas():
+    """[[feedback_agent_parity]] applied to a governed doc: the vocabulary must
+    mean the same thing in a backend repo and a UI one."""
+    bodies = {p: p.read_text(encoding="utf-8") for p in CONTRACT_PATHS}
+    assert len(set(bodies.values())) == 1, (
+        "EVIDENCE_CONTRACT.md differs between areas: "
+        f"{[_rel(p) for p in bodies]}"
+    )

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -4293,8 +4293,13 @@ class TestDataCiContract:
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
         # The defect lane ships from L4, like the feature contract it sits
         # beside; L3 has no per-change artifact model at all.
-        fix_lane = [f"ci/{platform}/fix-lane-gate.yml"] if level != "3" else []
-        assert ci_governed == [repo_scope, data_common, *fix_lane]
+        # Gates that ship from L4 alongside the common set. L3 has no
+        # per-change artifact model, so neither applies there.
+        l4_gates = [] if level == "3" else [
+            f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/evidence-gate.yml",
+        ]
+        assert ci_governed == [repo_scope, data_common, *l4_gates]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(
@@ -4318,7 +4323,9 @@ class TestDataCiContract:
         assert ci_block["level_4"].get("governed", []) == []
         # L4 adds the defect lane gate on top of the L3 common set.
         assert ci_block["level_4"]["by_type"]["data"]["governed"] == [
-            *expected, f"ci/{platform}/fix-lane-gate.yml",
+            *expected,
+            f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/evidence-gate.yml",
         ]
 
 
@@ -4437,8 +4444,13 @@ class TestPythonDbtCiGate:
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
         # The defect lane ships from L4, like the feature contract it sits
         # beside; L3 has no per-change artifact model at all.
-        fix_lane = [f"ci/{platform}/fix-lane-gate.yml"] if level != "3" else []
-        assert ci_governed == [repo_scope, data_common, dbt_gate, *fix_lane]
+        # Gates that ship from L4 alongside the common set. L3 has no
+        # per-change artifact model, so neither applies there.
+        l4_gates = [] if level == "3" else [
+            f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/evidence-gate.yml",
+        ]
+        assert ci_governed == [repo_scope, data_common, dbt_gate, *l4_gates]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(
@@ -4600,8 +4612,13 @@ class TestDatabricksCiGate:
         ci_governed = [path for path in governed if path.startswith(f"ci/{platform}/")]
         # The defect lane ships from L4, like the feature contract it sits
         # beside; L3 has no per-change artifact model at all.
-        fix_lane = [f"ci/{platform}/fix-lane-gate.yml"] if level != "3" else []
-        assert ci_governed == [repo_scope, data_common, databricks_gate, *fix_lane]
+        # Gates that ship from L4 alongside the common set. L3 has no
+        # per-change artifact model, so neither applies there.
+        l4_gates = [] if level == "3" else [
+            f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/evidence-gate.yml",
+        ]
+        assert ci_governed == [repo_scope, data_common, databricks_gate, *l4_gates]
 
     @pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
     @pytest.mark.parametrize(

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -653,7 +653,9 @@ class TestCheckPlanEvalPrediction:
         assert ok is CheckStatus.FAIL
         assert "null" in msg
 
-    def test_below_threshold(self, tmp_path):
+    def test_below_threshold_warns_rather_than_blocks(self, tmp_path):
+        """A self-predicted average is a forecast, not evidence. It is reported
+        and it does not block — `govkit evidence` gates on measurement."""
         write(tmp_path / "plan.md", """\
             # Plan
 
@@ -666,8 +668,9 @@ class TestCheckPlanEvalPrediction:
             ```
         """)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is CheckStatus.FAIL
+        assert ok is CheckStatus.WARN
         assert "3.5" in msg
+        assert "forecast" in msg.lower()
 
     def test_unrelated_earlier_yaml_block_is_not_absorbed(self, tmp_path):
         """The block pattern anchored on the *first* ```yaml fence and let `.*?`
@@ -774,7 +777,7 @@ class TestPredictionInternalConsistency:
             ```
         """)
         ok, msg = check_plan_eval_prediction(tmp_path)
-        assert ok is CheckStatus.FAIL
+        assert ok is CheckStatus.WARN, "a forecast below the floor is information, not a blocker"
         assert "below 3" in msg
 
     def test_ui_shape_is_cross_checked(self, tmp_path):


### PR DESCRIPTION
## What

Stops gating merge on quality scores the authoring agent wrote about its own work, and starts gating on what an executed tool observed.

## Why

govkit's headline claim is a 4.0 floor on FIRST and 7-Virtue scores. Those scores are written into `plan.md` by the agent that did the work, and the gate reads them back.

This is not a new observation — govkit has documented the gap three times and never closed it:

- `ci/README.md` listed them under *"Prediction-only (plan.md scores, not actuals)"* and said *"teams should work toward closing this gap by wiring up actual test results"*, then prescribed exactly this solution.
- All four rubrics ended with *"validate against actuals during review"*. Grep returned those four lines and nothing else — nothing consumed actuals.
- `docs/data/architecture/ADR/0001` accepted the argument for data features in July: *"a self-predicted ≥ 4.0 average is ceremony either way: the prediction is authored by the same agent that authors the plan."* Backend and UI never followed.

## Changes

**The vocabulary already existed in-repo.** `EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md` ships as an L5 extension governing the agent systems govkit's *users* build, and states the decisive rule: *"A producer self-check is advisory. The task owner never commits its own final gate."* This promotes it to the delivery side rather than inventing a parallel one.

- `docs/<area>/evaluation/EVIDENCE_CONTRACT.md` — concepts, gate outcomes, and an honest table of what govkit can and cannot measure
- `cli/evidence.py` + `govkit evidence` — reads the test report and axe results, gives a verdict per dimension
- `ci/{github,azure}/evidence-gate.yml`
- `check_plan_eval_prediction` — threshold breaches now WARN; contradictions and missing values still FAIL
- `eval-gate` / `ui-eval-gate` marked advisory, behavior unchanged

## The load-bearing design choice

**`INCONCLUSIVE` is not a pass.** Every dimension is reported every run. Today most are unmeasured — and an unmeasured dimension that reports green is indistinguishable from a verified one, which is exactly how a fabricated score survives review.

An empty analysis **fails**, inverting the usual opt-in-gate posture, because `ci/README.md` already warns that tools "report success on an empty analysis, so a misconfigured contract looks exactly like a clean repo".

Two dimensions have unambiguous criteria and are gated: **Working** and **Accessibility**. **Fast** is measured but *not judged* — JUnit carries durations for free, but turning a 1-5 band into a threshold is a calibration decision, and ADR-0001 warns that inventing a rubric nobody calibrated recreates the ceremony being removed. It reports the numbers and becomes blocking when a team sets `--fast-max-seconds`. **Clear** can never report PASS: its measurable proxies reward verbosity over clarity, so it is a category error rather than an instrumentation gap.

## Two deviations from the approved plan

- **Dropped the `eval_criteria.yaml` measured block.** It is a per-feature file, but this is repo-wide policy — one feature's file would have decided the gate for the whole repo. A `--fast-max-seconds` flag does the job without editing a closed schema to add a field nothing reads.
- **Corrected a false claim.** `EVAL_STACK.md` described a "Home-Grown Evaluation Framework" that was "required on all projects" and "the only evaluation tool that blocks merges for code quality". No such framework was ever built. Shipping that while demoting the prediction would have been indefensible.

## Testing

```bash
./run_tests   # 2595 passed
./full_test   # + 134 e2e passed (16 skips: no JDK/Maven locally)
```

Verified against the real CLI on a fresh `govkit apply`:

```
govkit evidence                     -> 13 dimensions INCONCLUSIVE, exit 1, "analysed nothing"
  + passing test report + axe       -> Working PASS, Accessibility PASS, "2 measured, 11 unmeasured"
  + a failing test                  -> Working FAIL, exit 1
  + --fast-max-seconds 0.2          -> Fast FAIL naming the slowest test
govkit validate, forecast under bar -> WARN, exit unaffected
```

Also fixes a hole in `tests/test_ci_govkit_dependency.py` from #133: it enumerated `doctor|validate|apply|init`, so `govkit evidence` shipped in a gate without a version pin and the suite stayed green. It now matches any subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)