### PR TITLE
fix: report only the evidence dimensions that describe the project

### DIFF
--- a/cli/cmd_evidence.py
+++ b/cli/cmd_evidence.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 from . import paths
 from .evidence import Outcome, collect_evidence, summarize
+from .marker import read_govkit_marker
 
 _LABEL = {
     Outcome.PASS: "\033[32mPASS\033[0m",
@@ -43,7 +44,16 @@ def cmd_evidence(args: argparse.Namespace) -> None:
         print(f"Error: target directory '{target}' does not exist.", file=sys.stderr)
         sys.exit(1)
 
-    verdicts = collect_evidence(target, fast_max_seconds=args.fast_max_seconds)
+    # Report the dimensions that describe this project. An unreadable marker
+    # reports everything — narrowing on uncertainty would hide a dimension,
+    # and silence reads as a pass.
+    marker = read_govkit_marker(target) or {}
+    project_type = (marker.get("options") or {}).get("type")
+    verdicts = collect_evidence(
+        target,
+        fast_max_seconds=args.fast_max_seconds,
+        project_type=project_type,
+    )
     print("\ngovkit evidence — measured quality evidence\n")
     width = max(len(v.dimension) for v in verdicts)
     for verdict in verdicts:

--- a/cli/evidence.py
+++ b/cli/evidence.py
@@ -75,6 +75,41 @@ _JUDGEMENT_ONLY = {
 }
 
 
+# Which dimensions describe a given project type.
+#
+# Reporting a dimension as INCONCLUSIVE asserts it *should* be measured. For a
+# dimension that does not apply to the project at all, that is a false claim in
+# the quieter direction — it manufactures a gap and tells a team to instrument
+# something the framework already decided is out of scope.
+#
+# `cli/validate.py` already routes by marker.options.type; this keeps the two
+# consistent rather than leaving one type-aware and the other blind.
+_UI_TYPES = frozenset({"ui-react", "ui-angular", "ui-nextjs"})
+
+
+def applicable_dimensions(project_type: str | None) -> tuple[str, ...]:
+    """The dimensions worth reporting for `project_type`.
+
+    An unknown or absent type reports everything. Hiding a dimension because
+    the marker could not be read would be the wrong direction to fail: silence
+    reads as a pass, which is the failure this whole module exists to prevent.
+    """
+    if project_type is None:
+        return DIMENSIONS
+    if project_type == "data":
+        # ADR-0001 (Accepted): the 7 Virtues rubric "was written for
+        # application code", and FIRST "scores unit-test design; data features
+        # are verified by schema tests, singular tests, and query predicates —
+        # a different surface with its own contract". Working survives because
+        # the ADR's replacement *is* deterministic CI outcomes, and whether
+        # those passed is what Working reports.
+        return ("Working",)
+    dims = [*FIRST_DIMENSIONS, *VIRTUE_DIMENSIONS]
+    if project_type in _UI_TYPES:
+        dims.append("Accessibility")
+    return tuple(dims)
+
+
 class Outcome(Enum):
     """From EVALUATION_EVIDENCE_AND_COMPLETION_CONTRACT.md. INCONCLUSIVE is not
     a pass: no evidence, insufficient evidence, or evidence out of scope."""
@@ -245,7 +280,11 @@ def _assess_accessibility(violations: list[dict] | None, error: str | None, foun
     return Verdict("Accessibility", Outcome.PASS, f"no critical or serious axe violations ({seen})")
 
 
-def collect_evidence(target: Path, fast_max_seconds: float | None = None) -> list[Verdict]:
+def collect_evidence(
+    target: Path,
+    fast_max_seconds: float | None = None,
+    project_type: str | None = None,
+) -> list[Verdict]:
     """Report a verdict for every dimension, every run.
 
     Reporting all of them is the point: a dimension left out of the output is
@@ -265,7 +304,7 @@ def collect_evidence(target: Path, fast_max_seconds: float | None = None) -> lis
         "Accessibility": _assess_accessibility(violations, axe_error, bool(axe_paths)),
     }
     verdicts = []
-    for dimension in DIMENSIONS:
+    for dimension in applicable_dimensions(project_type):
         if dimension in measured:
             verdicts.append(measured[dimension])
         elif dimension in _JUDGEMENT_ONLY:

--- a/docs/backend/evaluation/EVIDENCE_CONTRACT.md
+++ b/docs/backend/evaluation/EVIDENCE_CONTRACT.md
@@ -108,6 +108,30 @@ so is the point of this contract.
 Every row marked "not measured" reports `INCONCLUSIVE`. None of them reports
 `PASS`.
 
+### Only the dimensions that describe this project are reported
+
+Reporting a dimension as `INCONCLUSIVE` asserts it *should* be measured. For a
+dimension that does not apply to the project at all, that is a false claim in
+the quieter direction — it manufactures a gap and tells a team to instrument
+something already ruled out of scope.
+
+| Project type | Reported |
+|---|---|
+| `api`, `cli` | FIRST and the 7 Virtues |
+| `ui-react`, `ui-angular`, `ui-nextjs` | the above plus Accessibility |
+| `data` | Working only |
+| unknown / no marker | everything |
+
+`data` follows ADR-0001, which removed the FIRST and Virtue rubrics for data
+features: the Virtues rubric *"was written for application code"*, and FIRST
+*"scores unit-test design; data features are verified by schema tests, singular
+tests, and query predicates — a different surface with its own contract"*.
+Working survives because the ADR's replacement is deterministic CI outcomes, and
+whether those passed is exactly what Working reports.
+
+An unknown type reports everything. Narrowing on uncertainty would hide a
+dimension, and silence reads as a pass.
+
 ## What must never be scored mechanically
 
 **Clear** — "identifiers are descriptive and domain-aligned", "functions do one

--- a/docs/ui/evaluation/EVIDENCE_CONTRACT.md
+++ b/docs/ui/evaluation/EVIDENCE_CONTRACT.md
@@ -108,6 +108,30 @@ so is the point of this contract.
 Every row marked "not measured" reports `INCONCLUSIVE`. None of them reports
 `PASS`.
 
+### Only the dimensions that describe this project are reported
+
+Reporting a dimension as `INCONCLUSIVE` asserts it *should* be measured. For a
+dimension that does not apply to the project at all, that is a false claim in
+the quieter direction — it manufactures a gap and tells a team to instrument
+something already ruled out of scope.
+
+| Project type | Reported |
+|---|---|
+| `api`, `cli` | FIRST and the 7 Virtues |
+| `ui-react`, `ui-angular`, `ui-nextjs` | the above plus Accessibility |
+| `data` | Working only |
+| unknown / no marker | everything |
+
+`data` follows ADR-0001, which removed the FIRST and Virtue rubrics for data
+features: the Virtues rubric *"was written for application code"*, and FIRST
+*"scores unit-test design; data features are verified by schema tests, singular
+tests, and query predicates — a different surface with its own contract"*.
+Working survives because the ADR's replacement is deterministic CI outcomes, and
+whether those passed is exactly what Working reports.
+
+An unknown type reports everything. Narrowing on uncertainty would hide a
+dimension, and silence reads as a pass.
+
 ## What must never be scored mechanically
 
 **Clear** — "identifiers are descriptive and domain-aligned", "functions do one

--- a/tests/test_cmd_evidence.py
+++ b/tests/test_cmd_evidence.py
@@ -99,3 +99,55 @@ class TestWiring:
         from cli import govkit
 
         assert "cli.cmd_evidence" in [r.__module__ for r in govkit._REGISTRARS]
+
+
+class TestProjectTypeFromMarker:
+    """The command reads the type govkit already recorded, rather than asking
+    the user to repeat it — and degrades to reporting everything when it cannot."""
+
+    def _marker(self, target: Path, project_type: str) -> None:
+        import json
+
+        (target / ".govkit").mkdir(parents=True, exist_ok=True)
+        (target / ".govkit" / "marker.json").write_text(
+            json.dumps({
+                "version": "0.18.0", "level": "4", "agent": "claude-code",
+                "options": {"type": project_type, "ci": "github"},
+                "applied_at": "2026-08-13T00:00:00Z",
+            }),
+            encoding="utf-8",
+        )
+
+    def test_data_project_is_not_told_about_virtues(self, tmp_path, capsys):
+        self._marker(tmp_path, "data")
+        _passing_junit(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_evidence(_args(tmp_path))
+        out = capsys.readouterr().out
+        assert "Working" in out
+        for absent in ("Unique", "Simple", "Clear", "Isolated"):
+            assert absent not in out, f"{absent} reported for a data project"
+
+    def test_backend_project_is_not_told_about_accessibility(self, tmp_path, capsys):
+        self._marker(tmp_path, "api")
+        _passing_junit(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_evidence(_args(tmp_path))
+        assert "Accessibility" not in capsys.readouterr().out
+
+    def test_ui_project_keeps_accessibility(self, tmp_path, capsys):
+        self._marker(tmp_path, "ui-react")
+        _passing_junit(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_evidence(_args(tmp_path))
+        assert "Accessibility" in capsys.readouterr().out
+
+    def test_missing_marker_reports_everything(self, tmp_path, capsys):
+        """No marker is not a licence to report less."""
+        from cli.evidence import DIMENSIONS
+
+        _passing_junit(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_evidence(_args(tmp_path))
+        out = capsys.readouterr().out
+        assert not [d for d in DIMENSIONS if d not in out]

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -18,6 +18,8 @@ import pytest
 
 from cli.evidence import (
     DIMENSIONS,
+    FIRST_DIMENSIONS,
+    VIRTUE_DIMENSIONS,
     Outcome,
     collect_evidence,
     summarize,
@@ -299,3 +301,75 @@ class TestMalformedAxeIsNotAPass:
         self._write(tmp_path, {})
         v = _by_dimension(collect_evidence(tmp_path))["Accessibility"]
         assert "axe.json" in v.detail, v.detail
+
+
+class TestDimensionsApplyByProjectType:
+    """Report the dimensions that apply to this project, and no others.
+
+    `cli/validate.py` already routes by `marker.options.type` — data features
+    skip the prediction check entirely per ADR-0001, which says the 7 Virtues
+    rubric "was written for application code" and the FIRST rubric "scores
+    unit-test design; data features are verified by schema tests, singular
+    tests, and query predicates — a different surface with its own contract".
+
+    Evidence shipped type-blind, so a dbt project was told it had eleven
+    unmeasured gaps that an accepted ADR says are not gaps. Reporting a
+    dimension as INCONCLUSIVE asserts it *should* be measured; for a dimension
+    that does not apply, that is a false claim in the quieter direction.
+    """
+
+    def _dims(self, tmp_path: Path, project_type=None) -> set:
+        _junit(tmp_path, [("t1", 0.01, True)])
+        return {v.dimension for v in collect_evidence(tmp_path, project_type=project_type)}
+
+    def test_unknown_type_reports_everything(self, tmp_path):
+        """Hiding a dimension because the type is unreadable would be the wrong
+        direction to fail: silence reads as a pass."""
+        assert self._dims(tmp_path) == set(DIMENSIONS)
+
+    @pytest.mark.parametrize("project_type", ["api", "cli"])
+    def test_backend_has_no_accessibility_dimension(self, tmp_path, project_type):
+        """A backend project has no axe report and never will; reporting it as
+        an unmeasured gap is noise, not honesty."""
+        assert "Accessibility" not in self._dims(tmp_path, project_type)
+
+    @pytest.mark.parametrize("project_type", ["ui-react", "ui-angular", "ui-nextjs"])
+    def test_ui_keeps_accessibility(self, tmp_path, project_type):
+        assert "Accessibility" in self._dims(tmp_path, project_type)
+
+    @pytest.mark.parametrize("project_type", ["api", "cli", "ui-react"])
+    def test_non_data_keeps_the_full_rubric(self, tmp_path, project_type):
+        dims = self._dims(tmp_path, project_type)
+        for d in (*FIRST_DIMENSIONS, *VIRTUE_DIMENSIONS):
+            assert d in dims, d
+
+    def test_data_drops_first_and_the_other_virtues(self, tmp_path):
+        """ADR-0001: those rubrics do not describe a data feature's surface."""
+        dims = self._dims(tmp_path, "data")
+        for d in ("Fast", "Isolated", "Repeatable", "Self-Verifying", "Timely",
+                  "Unique", "Simple", "Clear", "Easy", "Developed", "Brief"):
+            assert d not in dims, f"{d} should not be reported for a data project"
+
+    def test_data_keeps_working(self, tmp_path):
+        """ADR-0001 replaced the prediction with deterministic CI outcomes —
+        schema tests, singular tests, query predicates. Whether those passed is
+        exactly what Working reports."""
+        assert "Working" in self._dims(tmp_path, "data")
+
+    def test_data_still_fails_on_a_failing_test_run(self, tmp_path):
+        _junit(tmp_path, [("t1", 0.01, False)])
+        verdicts = collect_evidence(tmp_path, project_type="data")
+        exit_code, _ = summarize(verdicts)
+        assert exit_code == 1
+
+    def test_data_with_no_evidence_still_fails_empty_analysis(self, tmp_path):
+        exit_code, summary = summarize(collect_evidence(tmp_path, project_type="data"))
+        assert exit_code == 1
+        assert "analysed nothing" in summary.lower()
+
+    def test_narrowing_cannot_manufacture_a_pass(self, tmp_path):
+        """The filter removes dimensions that do not apply — it must never turn
+        a FAIL or an unmeasured run into a green one."""
+        _axe(tmp_path, ["critical"])
+        verdicts = collect_evidence(tmp_path, project_type="ui-react")
+        assert summarize(verdicts)[0] == 1


### PR DESCRIPTION
## What

`govkit evidence` now reports the dimensions that apply to the project type, instead of all thirteen regardless.

## Why

Found while reviewing whether #135 was merged too early. It was safe — every change there was loosening, so no adopter's green build could break — but it left this gap.

`cli/validate.py` has always routed by `marker.options.type`; `cli/evidence.py` shipped type-blind. The asymmetry showed up immediately in a data project:

```
Isolated        INCONCLUSIVE  no randomised-order or run-alone execution recorded
Unique          INCONCLUSIVE  no duplication report recorded
Simple          INCONCLUSIVE  no complexity or nesting-depth report recorded
```

Eleven unmeasured "gaps" for a type where **ADR-0001 (Accepted, July) removed those rubrics entirely** — the Virtues rubric *"was written for application code"*, and FIRST *"scores unit-test design; data features are verified by schema tests, singular tests, and query predicates — a different surface with its own contract"*.

Reporting a dimension as `INCONCLUSIVE` asserts it *should* be measured. For one that does not apply, that is a false claim in the quieter direction: it manufactures a gap and tells a team to instrument something already ruled out of scope. It is the same failure mode as an unmeasured dimension reading green, pointing the other way — and it left the framework contradicting its own accepted ADR, which is precisely what this line of work exists to stop.

## Changes

| Project type | Reported |
|---|---|
| `api`, `cli` | FIRST and the 7 Virtues |
| `ui-react`, `ui-angular`, `ui-nextjs` | the above plus Accessibility |
| `data` | Working only |
| unknown / no marker | everything |

**Working survives for data** because ADR-0001's replacement *is* deterministic CI outcomes — schema tests, singular tests, query predicates — and whether those passed is exactly what Working reports.

**Backend and cli also lose Accessibility**, which was the same noise in a form nobody had complained about yet: an api project has no axe report and never will.

**An unknown or unreadable marker reports everything.** Narrowing on uncertainty would hide a dimension, and silence reads as a pass — the failure this module exists to prevent, so the degradation has to go the other way.

## Testing

```bash
./run_tests   # 2626 passed
```

18 new tests, written failing-first. The one I'd point at in review is `test_narrowing_cannot_manufacture_a_pass`: the filter removes dimensions that do not apply, and must never turn a FAIL or an empty analysis into a green run. A failing test run and a no-evidence run both still fail after narrowing.

Verified against the real CLI:

```
data     -> 1 dimension reported
api      -> 12
ui-react -> 13
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)