### PR TITLE
feat: approval attestation — Accepted becomes a derived state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
+- **ADR approval attestation.** An ADR's `Accepted` status is now a derived
+  state rather than typed text. The governance rules gate implementation on it
+  — *"ADRs … must be Accepted before implementation proceeds"* — and nothing in
+  `cli/` or `ci/` had ever read it.
+  - `governance/approval_policy.yaml` (+ its schema) names which platform
+    logins hold the Approver role. `AUTHORITY_AND_APPROVAL_CONTRACT.md`, which
+    govkit ships to govern *its users'* agent systems, states that "a reviewer
+    does not gain approval authority" and lists "approval by an unauthorized
+    identity" among prohibited patterns — so a review becomes an approval only
+    once a policy says that identity may give one. Ships inert, with a
+    `YOUR_APPROVER_LOGIN` sentinel.
+  - `ci/{github,azure}/adr-approval-gate.yml` requires, for every ADR changed
+    in a PR that claims `Accepted`, an approving review from an approver in the
+    policy, bound to the head commit. It **fails closed** when the policy names
+    nobody. The GitHub half carries the payload's first `permissions:` block.
+  - `govkit validate` gains the working-tree half: the policy is well-formed
+    and names a real approver, and ADRs claiming `Accepted` with no approval
+    record are reported. No new command.
 - **Measured evidence.** `govkit evidence` reads what CI produced — the test
   report, axe results — and gives a verdict per rubric dimension. Wired up by
   `ci/{github,azure}/evidence-gate.yml`. Working and Accessibility are gated
@@ -21,6 +39,15 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Changed
 
+- **The `adr-author` skill writes `Proposed` and stops.** The backend skill
+  handed the agent the full status vocabulary, so nothing stopped it writing
+  the one status it cannot earn. Both skills now name where approval authority
+  lives and what proves it. All three agents in lockstep.
+- **The ADR templates' Approval section requests a decision rather than
+  recording one.** `## Status` and `## Approval` sat ~140 lines apart, unlinked,
+  and Approval was three empty colon-terminated labels bound to no identity, no
+  date and no commit. `ci/README.md` loses its *"ADR required when preflight
+  flags it | No ADR validation"* gap row, which this closes.
 - **The FIRST/Virtue prediction is now an advisory forecast, not a merge gate.**
   Those scores are written by the agent that did the work; the evidence contract
   makes a producer self-check advisory by definition. A threshold breach now

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Backend installs ship no UI artifacts; UI installs ship no backend artifacts. Th
 | `govkit apply` | Install / scaffold governance into your project. Detects your stack, writes the `.govkit` marker. |
 | `govkit calibrate` | Guided, type-aware review to make installed defaults match your repo. UI reviews include brand readiness; `--non-interactive` writes a checklist file and `--only <step>` revisits one decision. |
 | `govkit doctor` | Read-only **governance-fit** checks (rule globs, CI/stack/language/framework fit, stale baselines, extensions, and the Next.js database boundary). Run once you have source code, and in CI. Monorepo-aware. |
-| `govkit validate` | Level-aware compliance check over **features** (artifact existence, Gherkin structure, NFR coverage, eval-criteria schema, prediction thresholds) and **fix records** (schema, eligibility conditions). No-op at L3. |
+| `govkit validate` | Level-aware compliance check over **features** (artifact existence, Gherkin structure, NFR coverage, eval-criteria schema, prediction thresholds), **fix records** (schema, eligibility conditions) and **ADR approval attestation** (the policy is well-formed and names a real approver; ADRs claiming `Accepted` without an approval record). No-op at L3. |
 | `govkit init <feature>` | Scaffold a new feature folder from the appropriate starter (L4+). |
 | `govkit fix init <id>` | Scaffold a defect-lane fix record at `fixes/<id>/fix.yaml` (L4+) — one artifact instead of five, for a change that restores already-established behavior. |
 | `govkit evidence` | Report measured quality evidence from CI artifacts — a verdict per rubric dimension, with unmeasured ones reported as INCONCLUSIVE rather than green. |
@@ -413,6 +413,38 @@ source and creates none passes it untouched. `ci/*/fix-lane-gate.yml` is the
 only gate that can see that, because it is the only one with the diff. It is
 **inactive until you set `SOURCE_PATHS`** in the workflow, so a fresh install
 stays green — see [ci/README.md](ci/README.md).
+
+---
+
+## ADR approval is derived, not typed
+
+The governance rules gate implementation on an ADR being `Accepted`. That was a
+word someone typed into a markdown file, and nothing read it.
+
+`Accepted` is now a **derived state**: true because an approver named in
+`governance/approval_policy.yaml` submitted an approving review of the commit
+carrying the decision. Three things make that real:
+
+- **The policy** — `governance/approval_policy.yaml` names which platform
+  logins hold the Approver role. `AUTHORITY_AND_APPROVAL_CONTRACT.md` is
+  explicit that *a reviewer does not gain approval authority*, so a review only
+  becomes an approval once a policy says that identity may give one. Ships with
+  a `YOUR_APPROVER_LOGIN` sentinel; edit it before the gate can pass.
+- **The gate** — `ci/*/adr-approval-gate.yml` checks every ADR changed in a PR
+  that claims `Accepted`, and **fails closed** if the policy names no approver.
+- **The author** — the `adr-author` skill writes `Proposed` and stops. Without
+  that, the record still says whatever the agent typed and the gate is cleanup
+  after the fact.
+
+`govkit validate` covers what the working tree can see: that the policy is
+well-formed and resolvable, and which ADRs claim `Accepted` with no approval
+record. It warns rather than fails — an ADR merged before you adopted this keeps
+its status, and no upgrade turns it into a merge blocker retroactively.
+
+**govkit verifies; the platform enforces.** Make `adr-approval-check` a required
+status check and add a CODEOWNERS entry for `docs/*/architecture/ADR/`, or the
+proof is advisory. Setup and the honest limits are in
+[ci/README.md](ci/README.md).
 
 ---
 

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -51,6 +51,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_backend/",
             "features/schema_contract_example/"
           ],
@@ -60,7 +61,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -90,6 +92,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_backend_l5/",
             "features/schema_contract_example/"
           ],
@@ -98,7 +101,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -129,6 +133,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_cli/"
           ],
           "governed": [
@@ -137,7 +142,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -167,6 +173,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_cli_l5/"
           ],
           "governed": [
@@ -174,7 +181,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -205,13 +213,15 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -229,6 +239,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
@@ -240,7 +251,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -271,13 +283,15 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -295,6 +309,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
@@ -306,7 +321,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -337,12 +353,14 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui_nextjs/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -360,6 +378,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui_nextjs/"
           ],
           "governed": [
@@ -370,7 +389,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -401,11 +421,13 @@
             { "src": "skills/backend/fix-record/", "dest": ".claude/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_data/"
           ],
           "governed": [
             "governance/data/schemas/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       }

--- a/agents/claude-code/manifest.json
+++ b/agents/claude-code/manifest.json
@@ -477,22 +477,28 @@
           "by_type": {
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
@@ -517,6 +523,7 @@
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
@@ -537,6 +544,7 @@
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
@@ -556,6 +564,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
@@ -567,6 +576,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
@@ -577,6 +587,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] }
           }
@@ -626,22 +637,28 @@
           "by_type": {
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
@@ -666,6 +683,7 @@
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
@@ -686,6 +704,7 @@
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
@@ -705,6 +724,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
@@ -716,6 +736,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
@@ -726,6 +747,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] }
           }

--- a/agents/claude-code/skills/backend/adr-author/SKILL.md
+++ b/agents/claude-code/skills/backend/adr-author/SKILL.md
@@ -27,7 +27,13 @@ Short, action-oriented statement describing the decision.
 
 ## Status
 
-Proposed | Accepted | Rejected | Superseded
+Write `Proposed`. Never write `Accepted`.
+
+`Accepted` is a derived state, not a word an author types. It is true because an
+approver named in `governance/approval_policy.yaml` approved *this decision* at
+*this commit* — the `adr-approval-check` CI gate verifies exactly that, and fails
+a pull request whose ADR claims `Accepted` without it. `Rejected` and
+`Superseded` are recorded by whoever makes that call, not by you.
 
 ## Consequences
 
@@ -50,6 +56,10 @@ Does this violate any part of `ARCH_CONTRACT.md`, `BOUNDARIES.md`, `SECURITY_AUT
 
 Required reviewers (team lead, architect, or security lead based on scope) and link to PR or issue.
 
+Naming someone here *requests* a decision; it does not record one. A reviewer assesses evidence or content; only an approver listed in `governance/approval_policy.yaml` commits the decision, and only their approving review — bound to the head commit — makes the ADR Accepted. Leave no signature, date, or approver name here as though the decision were already made.
+
 ---
 
-Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.
+Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md` with status `Proposed`. If required information is missing, stop and ask before drafting.
+
+Implementation of a dependent feature waits until the ADR is Accepted. That is something you observe — `govkit validate` reports ADRs claiming it without provenance, and `adr-approval-check` proves it — never something you assert by editing the status line.

--- a/agents/claude-code/skills/ui/adr-author/SKILL.md
+++ b/agents/claude-code/skills/ui/adr-author/SKILL.md
@@ -15,14 +15,18 @@ Use the template at `docs/ui/architecture/ADR/TEMPLATE.md` and produce the ADR i
 
 The ADR must cover:
 
-1. **Status** — Proposed
+1. **Status** — write `Proposed`, and never `Accepted`
 2. **Context** — What situation requires this decision? What constraints apply?
 3. **Decision** — What is being decided and why?
 4. **MVVM Impact** — Which layers are affected? Do any boundary rules change?
 5. **Consequences** — What becomes easier? What becomes harder? What is the rollback path?
 6. **Alternatives Considered** — At least two alternatives with reasons for rejection
 
-The ADR is not Accepted until reviewed. Implementation must not begin on dependent features until status is Accepted.
+`Accepted` is a derived state, not a word an author types. It is true because an approver named in `governance/approval_policy.yaml` approved *this decision* at *this commit* — the `adr-approval-check` CI gate verifies exactly that, and fails a pull request whose ADR claims `Accepted` without it. `Rejected` and `Superseded` are recorded by whoever makes that call, not by you.
+
+The Approval section requests a decision; it does not record one. A reviewer assesses evidence or content; only an approver in the policy commits the decision. Leave no signature, date, or approver name there as though it were already made.
+
+Implementation of a dependent feature waits until the ADR is Accepted. That is something you observe — `govkit validate` reports ADRs claiming it without provenance — never something you assert by editing the status line.
 
 An ADR can document a backend API contract or thin-BFF tradeoff. It cannot
 permit SQL, database clients/drivers, ORMs, migrations, connection strings, or

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -499,22 +499,28 @@
           "by_type": {
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
@@ -539,6 +545,7 @@
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
@@ -559,6 +566,7 @@
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
@@ -578,6 +586,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
@@ -589,6 +598,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
@@ -599,6 +609,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] }
           }
@@ -648,22 +659,28 @@
           "by_type": {
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
@@ -688,6 +705,7 @@
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
@@ -708,6 +726,7 @@
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
@@ -727,6 +746,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
@@ -738,6 +758,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
@@ -748,6 +769,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] }
           }

--- a/agents/codex/manifest.json
+++ b/agents/codex/manifest.json
@@ -51,11 +51,13 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_data/"
           ],
           "governed": [
             "governance/data/schemas/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -86,6 +88,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_backend/",
             "features/schema_contract_example/"
           ],
@@ -95,7 +98,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -125,6 +129,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_backend_l5/",
             "features/schema_contract_example/"
           ],
@@ -133,7 +138,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -164,6 +170,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_cli/"
           ],
           "governed": [
@@ -172,7 +179,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -202,6 +210,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_cli_l5/"
           ],
           "governed": [
@@ -209,7 +218,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -244,13 +254,15 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -272,6 +284,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
@@ -283,7 +296,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -318,13 +332,15 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -346,6 +362,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
@@ -357,7 +374,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -391,12 +409,14 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui_nextjs/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -417,6 +437,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".agents/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui_nextjs/"
           ],
           "governed": [
@@ -427,7 +448,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       }

--- a/agents/codex/skills/backend/adr-author/SKILL.md
+++ b/agents/codex/skills/backend/adr-author/SKILL.md
@@ -27,7 +27,13 @@ Short, action-oriented statement describing the decision.
 
 ## Status
 
-Proposed | Accepted | Rejected | Superseded
+Write `Proposed`. Never write `Accepted`.
+
+`Accepted` is a derived state, not a word an author types. It is true because an
+approver named in `governance/approval_policy.yaml` approved *this decision* at
+*this commit* — the `adr-approval-check` CI gate verifies exactly that, and fails
+a pull request whose ADR claims `Accepted` without it. `Rejected` and
+`Superseded` are recorded by whoever makes that call, not by you.
 
 ## Consequences
 
@@ -50,6 +56,10 @@ Does this violate any part of `ARCH_CONTRACT.md`, `BOUNDARIES.md`, `SECURITY_AUT
 
 Required reviewers (team lead, architect, or security lead based on scope) and link to PR or issue.
 
+Naming someone here *requests* a decision; it does not record one. A reviewer assesses evidence or content; only an approver listed in `governance/approval_policy.yaml` commits the decision, and only their approving review — bound to the head commit — makes the ADR Accepted. Leave no signature, date, or approver name here as though the decision were already made.
+
 ---
 
-Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.
+Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md` with status `Proposed`. If required information is missing, stop and ask before drafting.
+
+Implementation of a dependent feature waits until the ADR is Accepted. That is something you observe — `govkit validate` reports ADRs claiming it without provenance, and `adr-approval-check` proves it — never something you assert by editing the status line.

--- a/agents/codex/skills/ui/adr-author/SKILL.md
+++ b/agents/codex/skills/ui/adr-author/SKILL.md
@@ -15,14 +15,18 @@ Use the template at `docs/ui/architecture/ADR/TEMPLATE.md` and produce the ADR i
 
 The ADR must cover:
 
-1. **Status** — Proposed
+1. **Status** — write `Proposed`, and never `Accepted`
 2. **Context** — What situation requires this decision? What constraints apply?
 3. **Decision** — What is being decided and why?
 4. **MVVM Impact** — Which layers are affected? Do any boundary rules change?
 5. **Consequences** — What becomes easier? What becomes harder? What is the rollback path?
 6. **Alternatives Considered** — At least two alternatives with reasons for rejection
 
-The ADR is not Accepted until reviewed. Implementation must not begin on dependent features until status is Accepted.
+`Accepted` is a derived state, not a word an author types. It is true because an approver named in `governance/approval_policy.yaml` approved *this decision* at *this commit* — the `adr-approval-check` CI gate verifies exactly that, and fails a pull request whose ADR claims `Accepted` without it. `Rejected` and `Superseded` are recorded by whoever makes that call, not by you.
+
+The Approval section requests a decision; it does not record one. A reviewer assesses evidence or content; only an approver in the policy commits the decision. Leave no signature, date, or approver name there as though it were already made.
+
+Implementation of a dependent feature waits until the ADR is Accepted. That is something you observe — `govkit validate` reports ADRs claiming it without provenance — never something you assert by editing the status line.
 
 An ADR can document a backend API contract or thin-BFF tradeoff. It cannot
 permit SQL, database clients/drivers, ORMs, migrations, connection strings, or

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -51,11 +51,13 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_data/"
           ],
           "governed": [
             "governance/data/schemas/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -86,6 +88,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_backend/",
             "features/schema_contract_example/"
           ],
@@ -95,7 +98,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -118,6 +122,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_backend_l5/",
             "features/schema_contract_example/"
           ],
@@ -126,7 +131,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -157,6 +163,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_cli/"
           ],
           "governed": [
@@ -165,7 +172,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -188,6 +196,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_cli_l5/"
           ],
           "governed": [
@@ -195,7 +204,8 @@
             "governance/backend/schemas/",
             "governance/backend/templates/",
             "governance/schemas/evaluation_prediction.schema.json",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -229,13 +239,15 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -256,6 +268,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
@@ -267,7 +280,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -301,13 +315,15 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -328,6 +344,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui/",
             "features/ui_task_dashboard/"
           ],
@@ -339,7 +356,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       },
@@ -373,12 +391,14 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui_nextjs/"
           ],
           "governed": [
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         },
         "level_5": {
@@ -399,6 +419,7 @@
             { "src": "skills/backend/fix-record/", "dest": ".github/skills/govkit-fix-record/" }
           ],
           "shared": [
+            "governance/approval_policy.yaml",
             "features/starter_ui_nextjs/"
           ],
           "governed": [
@@ -409,7 +430,8 @@
             "docs/ui/design/",
             "docs/ui/evaluation/",
             "governance/ui/",
-            "governance/schemas/fix_record.schema.json"
+            "governance/schemas/fix_record.schema.json",
+            "governance/schemas/approval_policy.schema.json"
           ]
         }
       }

--- a/agents/copilot/manifest.json
+++ b/agents/copilot/manifest.json
@@ -481,22 +481,28 @@
           "by_type": {
             "api":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/github/quality-gate.yml", "ci/github/eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/github/ui-quality-gate.yml", "ci/github/ui-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/github/ui-nextjs-quality-gate.yml", "ci/github/ui-nextjs-eval-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/github/repo-scope-check.yml", "ci/github/data-common-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/github/dbt-gate.yml"] },
@@ -521,6 +527,7 @@
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
@@ -541,6 +548,7 @@
                 "ci/github/multi-agent-gate.yml",
                 "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
               ],
               "by_stack": {
@@ -560,6 +568,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
@@ -571,6 +580,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
@@ -581,6 +591,7 @@
               "ci/github/multi-agent-gate.yml",
               "ci/github/promptfoo-gate.yml",
                 "ci/github/fix-lane-gate.yml",
+                "ci/github/adr-approval-gate.yml",
                 "ci/github/evidence-gate.yml"
             ] }
           }
@@ -630,22 +641,28 @@
           "by_type": {
             "api":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "cli":        { "governed": ["ci/azure/quality-gate.yml", "ci/azure/eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-react":   { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-angular": { "governed": ["ci/azure/ui-quality-gate.yml", "ci/azure/ui-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "ui-nextjs":  { "governed": ["ci/azure/ui-nextjs-quality-gate.yml", "ci/azure/ui-nextjs-eval-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"] },
             "data":       {
               "governed": ["ci/azure/repo-scope-check.yml", "ci/azure/data-common-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"],
               "by_stack": {
                 "python-dbt": { "governed": ["ci/azure/dbt-gate.yml"] },
@@ -670,6 +687,7 @@
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
@@ -690,6 +708,7 @@
                 "ci/azure/multi-agent-gate.yml",
                 "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
               ],
               "by_stack": {
@@ -709,6 +728,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] },
             "ui-angular": { "governed": [
@@ -720,6 +740,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] },
             "ui-nextjs": { "governed": [
@@ -730,6 +751,7 @@
               "ci/azure/multi-agent-gate.yml",
               "ci/azure/promptfoo-gate.yml",
                 "ci/azure/fix-lane-gate.yml",
+                "ci/azure/adr-approval-gate.yml",
                 "ci/azure/evidence-gate.yml"
             ] }
           }

--- a/agents/copilot/skills/backend/adr-author/SKILL.md
+++ b/agents/copilot/skills/backend/adr-author/SKILL.md
@@ -27,7 +27,13 @@ Short, action-oriented statement describing the decision.
 
 ## Status
 
-Proposed | Accepted | Rejected | Superseded
+Write `Proposed`. Never write `Accepted`.
+
+`Accepted` is a derived state, not a word an author types. It is true because an
+approver named in `governance/approval_policy.yaml` approved *this decision* at
+*this commit* — the `adr-approval-check` CI gate verifies exactly that, and fails
+a pull request whose ADR claims `Accepted` without it. `Rejected` and
+`Superseded` are recorded by whoever makes that call, not by you.
 
 ## Consequences
 
@@ -50,6 +56,10 @@ Does this violate any part of `ARCH_CONTRACT.md`, `BOUNDARIES.md`, `SECURITY_AUT
 
 Required reviewers (team lead, architect, or security lead based on scope) and link to PR or issue.
 
+Naming someone here *requests* a decision; it does not record one. A reviewer assesses evidence or content; only an approver listed in `governance/approval_policy.yaml` commits the decision, and only their approving review — bound to the head commit — makes the ADR Accepted. Leave no signature, date, or approver name here as though the decision were already made.
+
 ---
 
-Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md`. If required information is missing, stop and ask before drafting.
+Write the ADR to `docs/{{docs_area}}/architecture/ADR/<slug>.md` with status `Proposed`. If required information is missing, stop and ask before drafting.
+
+Implementation of a dependent feature waits until the ADR is Accepted. That is something you observe — `govkit validate` reports ADRs claiming it without provenance, and `adr-approval-check` proves it — never something you assert by editing the status line.

--- a/agents/copilot/skills/ui/adr-author/SKILL.md
+++ b/agents/copilot/skills/ui/adr-author/SKILL.md
@@ -15,14 +15,18 @@ Use the template at `docs/ui/architecture/ADR/TEMPLATE.md` and produce the ADR i
 
 The ADR must cover:
 
-1. **Status** — Proposed
+1. **Status** — write `Proposed`, and never `Accepted`
 2. **Context** — What situation requires this decision? What constraints apply?
 3. **Decision** — What is being decided and why?
 4. **MVVM Impact** — Which layers are affected? Do any boundary rules change?
 5. **Consequences** — What becomes easier? What becomes harder? What is the rollback path?
 6. **Alternatives Considered** — At least two alternatives with reasons for rejection
 
-The ADR is not Accepted until reviewed. Implementation must not begin on dependent features until status is Accepted.
+`Accepted` is a derived state, not a word an author types. It is true because an approver named in `governance/approval_policy.yaml` approved *this decision* at *this commit* — the `adr-approval-check` CI gate verifies exactly that, and fails a pull request whose ADR claims `Accepted` without it. `Rejected` and `Superseded` are recorded by whoever makes that call, not by you.
+
+The Approval section requests a decision; it does not record one. A reviewer assesses evidence or content; only an approver in the policy commits the decision. Leave no signature, date, or approver name there as though it were already made.
+
+Implementation of a dependent feature waits until the ADR is Accepted. That is something you observe — `govkit validate` reports ADRs claiming it without provenance — never something you assert by editing the status line.
 
 An ADR can document a backend API contract or thin-BFF tradeoff. It cannot
 permit SQL, database clients/drivers, ORMs, migrations, connection strings, or

--- a/ci/README.md
+++ b/ci/README.md
@@ -43,6 +43,7 @@ Copy the relevant templates for your project type:
 | `ui-nextjs-quality-gate.yml` | — | — | Next.js L4/L5 | — |
 | `ui-nextjs-eval-gate.yml` | — | — | Next.js L4/L5 | — |
 | `fix-lane-gate.yml` (L4+, configure first) | ✓ | ✓ | ✓ | ✓ |
+| `adr-approval-gate.yml` (L4+, configure first) | ✓ | ✓ | ✓ | ✓ |
 | `data-common-gate.yml` | — | — | — | ✓ |
 | `dbt-gate.yml` | — | — | — | `python-dbt` |
 | `databricks-gate.yml` | — | — | — | `databricks-lakehouse` |
@@ -212,6 +213,7 @@ A critical distinction in this governance framework: some checks enforce **actua
 | Code quality metrics | l3-quality-gate | SonarQube duplication and complexity |
 | Governing artifact coverage | fix-lane-gate | Source changed in the PR is accounted for by a fix record or a feature |
 | Fix record correspondence | fix-lane-gate | A fix record's `surface.paths` matches what the diff actually changed, and the diff carries a test |
+| ADR approval attestation | adr-approval-gate | An ADR changed in the PR that claims `Accepted` carries an approving review from an approver in `governance/approval_policy.yaml`, submitted against the head commit |
 | Measured quality evidence | evidence-gate | `govkit evidence` reads the test report and axe results and gives a verdict per rubric dimension. Unmeasured dimensions report INCONCLUSIVE, which is **not** a pass |
 
 #### The fix-lane gate needs configuring before it does anything
@@ -231,6 +233,76 @@ fix record's declarations meet reality: `validate` can prove a record is
 internally consistent, but `surface.paths` and the risk flags are both authored,
 so they can agree with each other while disagreeing with the diff. Only CI has
 the diff.
+
+#### ADR approval attestation
+
+`Accepted` on an ADR used to be a word someone typed. The L4 governance rule
+gates implementation on it — *"ADRs … must be Accepted before implementation
+proceeds"* — and nothing read it. `adr-approval-gate.yml` makes it a **derived
+state**: for every ADR changed in a pull request that claims `Accepted`, it
+requires an approving review whose author holds the Approver role in
+`governance/approval_policy.yaml` and whose review was submitted against the
+head commit.
+
+**Set it up:**
+
+1. Edit `governance/approval_policy.yaml` and replace `YOUR_APPROVER_LOGIN` with
+   the login(s) that hold approval authority. On GitHub that is the account
+   name; on Azure DevOps it is the reviewer's `uniqueName` (usually their UPN).
+2. Copy `adr-approval-gate.yml` into your workflows and make
+   `adr-approval-check` a **required status check** under branch protection.
+3. Add a CODEOWNERS entry so the review is requested in the first place:
+
+   ```
+   docs/*/architecture/ADR/   @your-org/architects
+   ```
+
+4. Require at least one approving review on the protected branch, and enable
+   *"Dismiss stale pull request approvals when new commits are pushed"* so the
+   platform and the gate agree about what a new push invalidates.
+
+**Why a policy file rather than "any approving review".**
+`AUTHORITY_AND_APPROVAL_CONTRACT.md` separates the Reviewer role ("assesses
+evidence or content") from the Approver role ("commits a scoped consequential
+decision") and states that *a reviewer does not gain approval authority*.
+Treating any authenticated review as an approval would land on that contract's
+prohibited pattern *"approval by an unauthorized identity"*. The policy file is
+what turns a review into an approval — it is the mechanism, not paperwork.
+
+**Honest limits:**
+
+- **govkit verifies; the platform enforces.** This gate can prove an approval
+  happened. Only branch protection can make the proof mandatory. Without it the
+  check is advisory, which is why the CODEOWNERS setup above is part of the
+  work rather than an optional extra.
+- **The gate only sees ADRs changed in the PR.** An `Accepted` ADR merged
+  before you adopted this keeps its status forever. That is the migration
+  posture working as intended — `govkit validate` warns about those so they are
+  visible, and no upgrade turns them into a merge blocker retroactively.
+- **A govkit-authored ADR is skipped.** govkit ships one
+  (`docs/data/architecture/ADR/0001-…`), and requiring your approver to attest a
+  decision govkit made for you would be incoherent. The `govkit:editable` body
+  hash tells govkit's copy from one you have edited; edit it and it becomes
+  yours, approval and all.
+- **Azure binds a vote to the pull request, not to a commit.** A GitHub review
+  carries the `commit_id` it was submitted against; an Azure reviewer vote does
+  not. The Azure template treats an approving vote as approval of
+  `System.PullRequest.SourceCommitId`, which is only true with the branch policy
+  *"Reset code reviewer votes when there are new changes"* enabled. It prints
+  that requirement on every run. Azure also needs the build service to have
+  pull-request read access and `System.AccessToken` available — it is the only
+  shipped Azure template that calls a platform API.
+
+**It fails closed.** Unlike every other opt-in gate, an unconfigured policy does
+not make this one inert: a PR that sets an ADR to `Accepted` fails while
+`governance/approval_policy.yaml` still holds the sentinel. An ADR cannot be
+accepted in a repository that declares nobody able to accept it. A fresh install
+still stays green, because a PR that changes no ADR is untouched.
+
+`govkit validate` covers the half CI cannot: it proves the policy is well-formed
+and names a real approver, and reports ADRs claiming `Accepted` with no approval
+record. It can never prove an approval happened — the working tree holds no
+reviews.
 
 ### Prediction-only (plan.md scores, not actuals)
 
@@ -257,7 +329,6 @@ These governance rules are communicated to agents via CLAUDE.md / copilot-instru
 
 | Rule | Why no CI gate | Recommendation |
 |---|---|---|
-| ADR required when preflight flags it | No ADR validation | Add a job that checks for ADR files when preflight contains "ADR required" |
 | Gherkin scenarios must map to tests | No test coverage gate | Add a job that cross-references `@nfr-*` tags with test files |
 
 ---
@@ -390,3 +461,16 @@ ui-eval-gate.yml    → FIRST prediction check, accessibility prediction, E2E
 | `ANTHROPIC_API_KEY` | eval-gate (LLM eval) | Only if features use `mode: llm` |
 
 If your team doesn't use SonarQube or Snyk, remove or skip those jobs rather than letting them fail.
+
+### Workflow permissions
+
+`adr-approval-gate.yml` is the only shipped workflow that declares a
+`permissions:` block. It reads the pull request's reviews, which the default
+`GITHUB_TOKEN` can do with `pull-requests: read`; declaring the block at all
+drops every other scope to none, so `contents: read` is restated for checkout.
+No secret is required — team-slug lookups would need `read:org` and a PAT, which
+is why the policy names logins rather than teams.
+
+On Azure DevOps the equivalent is `System.AccessToken`: leave *"Allow scripts to
+access the OAuth token"* enabled and give the build service read access to pull
+requests. Without the token the gate fails closed rather than passing blind.

--- a/ci/README.md
+++ b/ci/README.md
@@ -244,6 +244,13 @@ requires an approving review whose author holds the Approver role in
 `governance/approval_policy.yaml` and whose review was submitted against the
 head commit.
 
+What counts is an approver's **current standing**, not anything they once said.
+If they approve and then request changes on the same commit, the gate fails —
+no new push is needed to take an approval back. A later `COMMENTED` review does
+*not* withdraw one, matching how the platform itself computes a reviewer's
+state. Logins are matched case-insensitively, so the policy need not reproduce
+the exact casing the platform returns.
+
 **Set it up:**
 
 1. Edit `governance/approval_policy.yaml` and replace `YOUR_APPROVER_LOGIN` with

--- a/ci/azure/adr-approval-gate.yml
+++ b/ci/azure/adr-approval-gate.yml
@@ -59,7 +59,12 @@ stages:
             fetchDepth: 0
             persistCredentials: true
 
-          - script: pip install pyyaml
+          # Pinned for the same reason the govkit-invoking gates pin govkit: an
+          # unpinned install makes your merge criteria depend on whatever PyPI
+          # served that morning, while the prose beside it is frozen at install
+          # time. `~=` rather than `==` so a patch release can still fix a build
+          # on a Python this version predates.
+          - script: pip install pyyaml~=6.0.2
             displayName: Install pyyaml
 
           - script: |
@@ -83,6 +88,12 @@ stages:
               # Azure votes: 10 approved, 5 approved with suggestions, 0 no vote,
               # -5 waiting, -10 rejected. Only an unqualified 10 counts — an
               # approval with suggestions is not a commitment to the decision.
+              #
+              # This endpoint returns each reviewer's CURRENT vote — one entry
+              # per reviewer, already superseding anything they voted earlier —
+              # so the checker's latest-review collapse is a no-op here and the
+              # ordering fields it reads are constant. On GitHub the reviews API
+              # returns the whole history instead, and those fields do the work.
               head = os.environ["HEAD_SHA"]
               with open("reviewers.json", encoding="utf-8") as fh:
                   data = json.load(fh)
@@ -93,6 +104,7 @@ stages:
                       login = reviewer.get("uniqueName") or reviewer.get("displayName")
                       out.write(json.dumps({
                           "login": login, "state": "APPROVED", "commit_id": head,
+                          "submitted_at": None, "id": 0,
                       }) + "\n")
               NORMALIZE
             env:
@@ -130,6 +142,19 @@ stages:
 
               def in_scope(path, prefixes):
                   return not prefixes or any(path.startswith(p) for p in prefixes)
+
+
+              def norm(login):
+                  """Fold a platform login for comparison.
+
+                  GitHub usernames are case-insensitive and Azure `uniqueName`s are
+                  too; Python string equality is not. Comparing raw strings made a
+                  policy naming `Octo-Architect` reject that same person's review
+                  returned as `octo-architect` — failing closed, but reporting that
+                  no authorised approval existed, which is untrue and leaves a team
+                  nothing to act on. Matching folds; output keeps the original.
+                  """
+                  return login.strip().casefold() if isinstance(login, str) else ""
 
 
               def strip_header(text):
@@ -224,11 +249,15 @@ stages:
                   if not isinstance(entry, dict) or entry.get("role") != APPROVER_ROLE:
                       continue
                   login = entry.get("login")
-                  if not isinstance(login, str) or not login.strip() or login == SENTINEL:
+                  key = norm(login)
+                  if not key or key == norm(SENTINEL):
                       continue
-                  approvers[login] = [
-                      s for s in (entry.get("scope") or []) if isinstance(s, str)
-                  ]
+                  # Keyed by the folded login, carrying the policy's own spelling
+                  # so a human reads the name their team wrote.
+                  approvers[key] = (
+                      login.strip(),
+                      [s for s in (entry.get("scope") or []) if isinstance(s, str)],
+                  )
 
               if not approvers:
                   fail(
@@ -252,21 +281,51 @@ stages:
               except (OSError, ValueError) as exc:
                   fail(f"FAIL: could not read the review list: {exc}")
 
-              # Bound to this commit. A review submitted against an earlier push
-              # approved a different decision — "approval after the side effect" and
-              # "reusing stale activation authority" are both prohibited patterns.
+              # An approval is a reviewer's CURRENT standing, not something they
+              # once said. Two filters, and both are load-bearing:
+              #
+              #   Bound to this commit. A review submitted against an earlier push
+              #   approved a different decision — "approval after the side effect"
+              #   and "reusing stale activation authority" are both prohibited
+              #   patterns in AUTHORITY_AND_APPROVAL_CONTRACT.md.
+              #
+              #   Latest decisive review wins. The API returns every review the PR
+              #   has collected, so counting any historical APPROVED let a reviewer
+              #   who had since asked for changes — with no new push to invalidate
+              #   anything — still satisfy this gate.
+              #
+              # Decisive means APPROVED / CHANGES_REQUESTED / DISMISSED, matching
+              # how the platform itself computes a reviewer's standing. A COMMENTED
+              # review afterwards does not withdraw an approval, and treating it as
+              # though it did would block pull requests GitHub considers approved.
+              DECISIVE = ("APPROVED", "CHANGES_REQUESTED", "DISMISSED")
+
+              standing = {}
+              for r in reviews:
+                  if not isinstance(r, dict) or r.get("commit_id") != head_sha:
+                      continue
+                  if r.get("state") not in DECISIVE:
+                      continue
+                  login = norm(r.get("login"))
+                  if not login:
+                      continue
+                  # submitted_at has second resolution, so two reviews can share
+                  # one; the review id is monotonic and settles the tie. Ordering
+                  # never depends on the order the API paged the reviews out in.
+                  order = (str(r.get("submitted_at") or ""), r.get("id") or 0)
+                  if login not in standing or order > standing[login][0]:
+                      standing[login] = (order, r.get("state"))
+
               approved_by = {
-                  r.get("login") for r in reviews
-                  if isinstance(r, dict)
-                  and r.get("state") == "APPROVED"
-                  and r.get("commit_id") == head_sha
+                  login for login, (_order, state) in standing.items()
+                  if state == "APPROVED"
               }
 
               unattested = []
               for path in needing:
                   who = sorted(
-                      login for login in approved_by & set(approvers)
-                      if in_scope(path, approvers[login])
+                      approvers[login][0] for login in approved_by & set(approvers)
+                      if in_scope(path, approvers[login][1])
                   )
                   if who:
                       print(f"OK   {path} — approved by {', '.join(who)} at {head_sha[:7]}")

--- a/ci/azure/adr-approval-gate.yml
+++ b/ci/azure/adr-approval-gate.yml
@@ -1,0 +1,294 @@
+# Azure DevOps mirror of ci/github/adr-approval-gate.yml.
+#
+# PURPOSE: Make an ADR's `Accepted` status a derived state rather than typed
+#          text — true because an authorised approver approved *this decision*
+#          at *this commit*, not because the word is there.
+#
+# validate is a working-tree tool and the working tree holds no reviews, so it
+# can prove the policy is well-formed but never that an approval happened. Only
+# the reviewers API can, and only CI has it.
+#
+# A policy file rather than "any approving vote":
+# AUTHORITY_AND_APPROVAL_CONTRACT.md separates Reviewer ("assesses evidence or
+# content") from Approver ("commits a scoped consequential decision") and states
+# that "a reviewer does not gain approval authority". Accepting any
+# authenticated vote lands on its prohibited pattern "approval by an
+# unauthorized identity".
+#
+# CONFIGURE THIS: edit governance/approval_policy.yaml and replace
+#   YOUR_APPROVER_LOGIN. On Azure DevOps a login is the reviewer's `uniqueName`
+#   — usually their UPN / sign-in address, not a GitHub username. Until you set
+#   it, the gate FAILS CLOSED on any PR that changes an ADR to `Accepted`.
+#   PRs that change no ADR are unaffected, so a fresh install stays green.
+#
+# TWO SETUP STEPS THIS GATE CANNOT DO FOR YOU:
+#
+#   1. Grant the build service read access to pull requests, and leave
+#      "Allow scripts to access the OAuth token" enabled so $(System.AccessToken)
+#      is present. This is the only shipped Azure template that calls a platform
+#      API; without the token the gate fails closed rather than passing blind.
+#
+#   2. Enable the branch policy "Reset code reviewer votes when there are new
+#      changes". Azure DevOps binds a vote to the pull request, not to a commit,
+#      so an approval survives a later push unless that policy is on. The gate
+#      treats an approving vote as approval of $(System.PullRequest.SourceCommitId)
+#      and says so on every run — that statement is only true with the policy
+#      enabled. The GitHub half needs no equivalent: a GitHub review carries the
+#      commit_id it was submitted against.
+#
+# govkit verifies; the platform enforces. Make this a required check under
+# branch policies, or the proof is advisory. See ci/README.md.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+stages:
+  - stage: AdrApproval
+    displayName: ADR approval attestation
+    jobs:
+      - job: AdrApprovalCheck
+        displayName: Authorised approval for Accepted ADRs
+        steps:
+          - checkout: self
+            fetchDepth: 0
+            persistCredentials: true
+
+          - script: pip install pyyaml
+            displayName: Install pyyaml
+
+          - script: |
+              set -e
+              echo "NOTE: Azure DevOps binds a reviewer vote to the pull request,"
+              echo "      not to a commit. This gate reads an approving vote as an"
+              echo "      approval of $(System.PullRequest.SourceCommitId) — true"
+              echo "      ONLY IF the branch policy 'Reset code reviewer votes when"
+              echo "      there are new changes' is enabled. Enable it, or an"
+              echo "      approval here outlives the commit it was given for."
+              curl -sS --fail \
+                -H "Authorization: Bearer $(System.AccessToken)" \
+                "$(System.CollectionUri)$(System.TeamProject)/_apis/git/repositories/$(Build.Repository.Name)/pullRequests/$(System.PullRequest.PullRequestId)/reviewers?api-version=7.1" \
+                -o reviewers.json
+              python - <<'NORMALIZE'
+              import json
+              import os
+
+              # Normalize to the shape the shared checker reads, so the two
+              # platform embeddings stay byte-identical below.
+              # Azure votes: 10 approved, 5 approved with suggestions, 0 no vote,
+              # -5 waiting, -10 rejected. Only an unqualified 10 counts — an
+              # approval with suggestions is not a commitment to the decision.
+              head = os.environ["HEAD_SHA"]
+              with open("reviewers.json", encoding="utf-8") as fh:
+                  data = json.load(fh)
+              with open("reviews.jsonl", "w", encoding="utf-8") as out:
+                  for reviewer in data.get("value") or []:
+                      if reviewer.get("vote") != 10:
+                          continue
+                      login = reviewer.get("uniqueName") or reviewer.get("displayName")
+                      out.write(json.dumps({
+                          "login": login, "state": "APPROVED", "commit_id": head,
+                      }) + "\n")
+              NORMALIZE
+            env:
+              HEAD_SHA: $(System.PullRequest.SourceCommitId)
+            displayName: Collect approving reviews
+
+          - script: |
+              # Three-dot: what this branch changed relative to the merge base.
+              # Two-dot would also report changes main made since the branch point.
+              # --diff-filter=d drops deletions — a removed ADR has nothing to attest.
+              git diff --name-only --diff-filter=d origin/main...HEAD \
+                -- 'docs/*/architecture/ADR/*.md' | python - <<'EOF'
+              import hashlib
+              import json
+              import os
+              import re
+              import sys
+
+              import yaml
+
+              POLICY = "governance/approval_policy.yaml"
+              SENTINEL = "YOUR_APPROVER_LOGIN"
+              GATE_STATUS = "Accepted"
+              APPROVER_ROLE = "approver"
+              HEADER_START = "<!-- govkit:editable"
+              STATUS_RE = re.compile(r"^## Status\s*\n(.+)$", re.MULTILINE)
+              HASH_RE = re.compile(r"^\s*hash:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
+
+
+              def fail(*lines):
+                  for line in lines:
+                      print(line)
+                  sys.exit(1)
+
+
+              def in_scope(path, prefixes):
+                  return not prefixes or any(path.startswith(p) for p in prefixes)
+
+
+              def strip_header(text):
+                  """Drop a leading govkit:editable header, matching cli/headers.py."""
+                  stripped = text.lstrip()
+                  end = stripped.find("-->")
+                  if not stripped.startswith(HEADER_START) or end == -1:
+                      return text
+                  body = stripped[end + 3:]
+                  for _ in range(2):
+                      if body.startswith("\n"):
+                          body = body[1:]
+                  return body
+
+
+              def govkit_authored(text):
+                  """Is this govkit's own decision, unmodified by the team?
+
+                  Requiring a customer's approver to attest a decision govkit made
+                  for them is incoherent. govkit ships exactly one real ADR — data's
+                  0001 — and it says Accepted with no approval record, so without
+                  this carve-out every data repo would fail its first PR. The
+                  discriminator is the body hash cli/headers.py already writes for
+                  edit-protection; no new mechanism is invented here.
+                  """
+                  stripped = text.lstrip()
+                  end = stripped.find("-->")
+                  if not stripped.startswith(HEADER_START) or end == -1:
+                      return False
+                  match = HASH_RE.search(stripped[:end])
+                  if not match:
+                      # Pre-hash install: govkit wrote it, and whether the team has
+                      # since edited it is undecidable. A false alarm on a file the
+                      # team never authored costs more than a false silence.
+                      return True
+                  digest = hashlib.sha256(strip_header(text).encode("utf-8")).hexdigest()
+                  return digest == match.group(1)
+
+
+              head_sha = os.environ.get("HEAD_SHA", "").strip()
+
+              changed = [ln.strip() for ln in sys.stdin if ln.strip()]
+              changed = [p for p in changed if not p.endswith("TEMPLATE.md")]
+              if not changed:
+                  print("No ADR changed in this PR; nothing for this gate to check.")
+                  sys.exit(0)
+
+              try:
+                  with open(POLICY, encoding="utf-8") as fh:
+                      policy = yaml.safe_load(fh)
+              except FileNotFoundError:
+                  fail(
+                      f"FAIL: {POLICY} is missing.",
+                      "      An ADR cannot be Accepted in a repository that declares",
+                      "      nobody able to accept it. Run `govkit upgrade` to install it.",
+                  )
+              except (OSError, yaml.YAMLError) as exc:
+                  fail(f"FAIL: {POLICY} could not be read: {exc}")
+              if not isinstance(policy, dict):
+                  fail(f"FAIL: {POLICY} is not a YAML mapping.")
+
+              scope = [
+                  p for p in (policy.get("require_approval_for") or []) if isinstance(p, str)
+              ]
+
+              needing = []
+              for path in changed:
+                  if not in_scope(path, scope):
+                      continue
+                  try:
+                      with open(path, encoding="utf-8") as fh:
+                          text = fh.read()
+                  except (OSError, UnicodeDecodeError) as exc:
+                      fail(f"FAIL: {path} could not be read: {exc}")
+                  match = STATUS_RE.search(text)
+                  if not match or match.group(1).strip() != GATE_STATUS:
+                      continue
+                  if govkit_authored(text):
+                      print(f"skipped {path} — govkit-authored and unmodified")
+                      continue
+                  needing.append(path)
+
+              if not needing:
+                  print(f"No changed ADR claims {GATE_STATUS}; nothing to attest.")
+                  sys.exit(0)
+
+              # A reviewer does not gain approval authority, and the shipped
+              # sentinel authorises nobody — both are excluded here rather than
+              # anywhere else, so neither can be mistaken for a configured approver.
+              approvers = {}
+              for entry in policy.get("approvers") or []:
+                  if not isinstance(entry, dict) or entry.get("role") != APPROVER_ROLE:
+                      continue
+                  login = entry.get("login")
+                  if not isinstance(login, str) or not login.strip() or login == SENTINEL:
+                      continue
+                  approvers[login] = [
+                      s for s in (entry.get("scope") or []) if isinstance(s, str)
+                  ]
+
+              if not approvers:
+                  fail(
+                      f"FAIL: {len(needing)} ADR(s) claim {GATE_STATUS} but {POLICY}",
+                      "      names no approver, so this gate fails closed.",
+                      f"      Replace {SENTINEL} with the login(s) that hold approval",
+                      "      authority here. A reviewer does not gain it —",
+                      "      see AUTHORITY_AND_APPROVAL_CONTRACT.md.",
+                      *[f"        - {p}" for p in needing],
+                  )
+
+              if not head_sha:
+                  fail(
+                      "FAIL: no head SHA available, so an approval cannot be bound to",
+                      "      a commit. This gate must run on pull_request.",
+                  )
+
+              try:
+                  with open("reviews.jsonl", encoding="utf-8") as fh:
+                      reviews = [json.loads(ln) for ln in fh if ln.strip()]
+              except (OSError, ValueError) as exc:
+                  fail(f"FAIL: could not read the review list: {exc}")
+
+              # Bound to this commit. A review submitted against an earlier push
+              # approved a different decision — "approval after the side effect" and
+              # "reusing stale activation authority" are both prohibited patterns.
+              approved_by = {
+                  r.get("login") for r in reviews
+                  if isinstance(r, dict)
+                  and r.get("state") == "APPROVED"
+                  and r.get("commit_id") == head_sha
+              }
+
+              unattested = []
+              for path in needing:
+                  who = sorted(
+                      login for login in approved_by & set(approvers)
+                      if in_scope(path, approvers[login])
+                  )
+                  if who:
+                      print(f"OK   {path} — approved by {', '.join(who)} at {head_sha[:7]}")
+                  else:
+                      unattested.append(path)
+
+              if unattested:
+                  print("")
+                  for path in unattested:
+                      print(f"FAIL: {path} claims {GATE_STATUS} with no authorised")
+                      print(f"      approval of {head_sha[:7]}.")
+                  print("")
+                  print(f"An ADR is {GATE_STATUS} because an approver accepted it at this")
+                  print("commit. Either:")
+                  print(f"  1. have an approver named in {POLICY} approve this PR")
+                  print("     (a new push invalidates an earlier approval — that is the point)")
+                  print("  2. set the ADR's status back to Proposed until they do")
+                  sys.exit(1)
+
+              print("")
+              print(f"Every changed {GATE_STATUS} ADR carries an authorised approval.")
+              EOF
+            env:
+              HEAD_SHA: $(System.PullRequest.SourceCommitId)
+            displayName: Require an authorised approval for each Accepted ADR

--- a/ci/github/adr-approval-gate.yml
+++ b/ci/github/adr-approval-gate.yml
@@ -65,18 +65,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Pinned for the same reason the govkit-invoking gates pin govkit: an
+      # unpinned install makes your merge criteria depend on whatever PyPI
+      # served that morning, while the prose beside it is frozen at install
+      # time. `~=` rather than `==` so a patch release can still fix a build on
+      # a Python this version predates.
       - name: Install pyyaml
-        run: pip install pyyaml
+        run: pip install pyyaml~=6.0.2
 
-      - name: Collect approving reviews
+      - name: Collect reviews
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # One JSON object per line, across all pages. The default repo-scoped
           # GITHUB_TOKEN is enough for logins; team slugs would need read:org.
+          #
+          # `submitted_at` and `id` are what let the checker tell a reviewer's
+          # CURRENT standing from anything they said earlier and have since
+          # changed. Without them, an approval a reviewer later withdrew would
+          # still be sitting in this list looking like an approval.
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
-            --jq '.[] | {login: .user.login, state: .state, commit_id: .commit_id}' \
+            --jq '.[] | {login: .user.login, state: .state, commit_id: .commit_id, submitted_at: .submitted_at, id: .id}' \
             > reviews.jsonl
 
       - name: Require an authorised approval for each Accepted ADR
@@ -113,6 +123,19 @@ jobs:
 
           def in_scope(path, prefixes):
               return not prefixes or any(path.startswith(p) for p in prefixes)
+
+
+          def norm(login):
+              """Fold a platform login for comparison.
+
+              GitHub usernames are case-insensitive and Azure `uniqueName`s are
+              too; Python string equality is not. Comparing raw strings made a
+              policy naming `Octo-Architect` reject that same person's review
+              returned as `octo-architect` — failing closed, but reporting that
+              no authorised approval existed, which is untrue and leaves a team
+              nothing to act on. Matching folds; output keeps the original.
+              """
+              return login.strip().casefold() if isinstance(login, str) else ""
 
 
           def strip_header(text):
@@ -207,11 +230,15 @@ jobs:
               if not isinstance(entry, dict) or entry.get("role") != APPROVER_ROLE:
                   continue
               login = entry.get("login")
-              if not isinstance(login, str) or not login.strip() or login == SENTINEL:
+              key = norm(login)
+              if not key or key == norm(SENTINEL):
                   continue
-              approvers[login] = [
-                  s for s in (entry.get("scope") or []) if isinstance(s, str)
-              ]
+              # Keyed by the folded login, carrying the policy's own spelling
+              # so a human reads the name their team wrote.
+              approvers[key] = (
+                  login.strip(),
+                  [s for s in (entry.get("scope") or []) if isinstance(s, str)],
+              )
 
           if not approvers:
               fail(
@@ -235,21 +262,51 @@ jobs:
           except (OSError, ValueError) as exc:
               fail(f"FAIL: could not read the review list: {exc}")
 
-          # Bound to this commit. A review submitted against an earlier push
-          # approved a different decision — "approval after the side effect" and
-          # "reusing stale activation authority" are both prohibited patterns.
+          # An approval is a reviewer's CURRENT standing, not something they
+          # once said. Two filters, and both are load-bearing:
+          #
+          #   Bound to this commit. A review submitted against an earlier push
+          #   approved a different decision — "approval after the side effect"
+          #   and "reusing stale activation authority" are both prohibited
+          #   patterns in AUTHORITY_AND_APPROVAL_CONTRACT.md.
+          #
+          #   Latest decisive review wins. The API returns every review the PR
+          #   has collected, so counting any historical APPROVED let a reviewer
+          #   who had since asked for changes — with no new push to invalidate
+          #   anything — still satisfy this gate.
+          #
+          # Decisive means APPROVED / CHANGES_REQUESTED / DISMISSED, matching
+          # how the platform itself computes a reviewer's standing. A COMMENTED
+          # review afterwards does not withdraw an approval, and treating it as
+          # though it did would block pull requests GitHub considers approved.
+          DECISIVE = ("APPROVED", "CHANGES_REQUESTED", "DISMISSED")
+
+          standing = {}
+          for r in reviews:
+              if not isinstance(r, dict) or r.get("commit_id") != head_sha:
+                  continue
+              if r.get("state") not in DECISIVE:
+                  continue
+              login = norm(r.get("login"))
+              if not login:
+                  continue
+              # submitted_at has second resolution, so two reviews can share
+              # one; the review id is monotonic and settles the tie. Ordering
+              # never depends on the order the API paged the reviews out in.
+              order = (str(r.get("submitted_at") or ""), r.get("id") or 0)
+              if login not in standing or order > standing[login][0]:
+                  standing[login] = (order, r.get("state"))
+
           approved_by = {
-              r.get("login") for r in reviews
-              if isinstance(r, dict)
-              and r.get("state") == "APPROVED"
-              and r.get("commit_id") == head_sha
+              login for login, (_order, state) in standing.items()
+              if state == "APPROVED"
           }
 
           unattested = []
           for path in needing:
               who = sorted(
-                  login for login in approved_by & set(approvers)
-                  if in_scope(path, approvers[login])
+                  approvers[login][0] for login in approved_by & set(approvers)
+                  if in_scope(path, approvers[login][1])
               )
               if who:
                   print(f"OK   {path} — approved by {', '.join(who)} at {head_sha[:7]}")

--- a/ci/github/adr-approval-gate.yml
+++ b/ci/github/adr-approval-gate.yml
@@ -1,0 +1,274 @@
+# adr-approval-gate.yml
+#
+# PURPOSE: Make an ADR's `Accepted` status a derived state rather than typed
+#          text. `Accepted` is true because an authorised approver approved
+#          *this decision* at *this commit* — not because the word is there.
+#
+# JOBS:
+#   adr-approval-check — for each ADR changed in the PR that claims `Accepted`,
+#                        require an approving review whose reviewer holds the
+#                        Approver role in governance/approval_policy.yaml and
+#                        whose review was submitted against the head SHA
+#
+# WHY THIS GATE AND NOT `govkit validate`:
+#   validate is a working-tree tool. The working tree holds no reviews, so it
+#   can prove the policy is well-formed and report an ADR claiming `Accepted`
+#   with nothing behind it — but it cannot prove an approval happened. Only the
+#   reviews API can, and only CI has it.
+#
+# WHY A POLICY FILE AND NOT "ANY APPROVING REVIEW":
+#   docs/backend/architecture/AUTHORITY_AND_APPROVAL_CONTRACT.md separates the
+#   Reviewer role ("assesses evidence or content") from the Approver role
+#   ("commits a scoped consequential decision") and states that "a reviewer does
+#   not gain approval authority". Accepting any authenticated review would land
+#   on that contract's prohibited pattern, "approval by an unauthorized
+#   identity". The policy file is what turns a review into an approval.
+#
+# CONFIGURE THIS: edit governance/approval_policy.yaml and replace
+#   YOUR_APPROVER_LOGIN with the login(s) that hold approval authority here.
+#   Until you do, the gate FAILS CLOSED on any PR that changes an ADR to
+#   `Accepted` — an ADR cannot be accepted in a repository that declares nobody
+#   able to accept it. PRs that change no ADR are unaffected, so a fresh install
+#   stays green.
+#
+# govkit VERIFIES; THE PLATFORM ENFORCES. This job proves an approval happened.
+#   Only branch protection can make the proof mandatory. Make
+#   `adr-approval-check` a required status check and add a CODEOWNERS entry for
+#   `docs/*/architecture/ADR/` so the review is requested in the first place.
+#   See ci/README.md, "ADR approval attestation".
+#
+# KNOWN LIMIT: the gate only sees ADRs changed in the PR. An `Accepted` ADR
+#   merged before you adopted this keeps its status. That is the migration
+#   posture working as intended — `govkit validate` warns about those.
+#
+# Copy this file to .github/workflows/adr-approval-gate.yml.
+
+name: ADR Approval Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+# The payload's first `permissions:` block. Required: reading the reviews API
+# needs `pull-requests: read`, and declaring the block at all drops every other
+# scope to none, so `contents: read` must be restated for checkout.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  adr-approval-check:
+    name: Authorised approval for Accepted ADRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      - name: Collect approving reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # One JSON object per line, across all pages. The default repo-scoped
+          # GITHUB_TOKEN is enough for logins; team slugs would need read:org.
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            --jq '.[] | {login: .user.login, state: .state, commit_id: .commit_id}' \
+            > reviews.jsonl
+
+      - name: Require an authorised approval for each Accepted ADR
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Three-dot: what this branch changed relative to the merge base.
+          # Two-dot would also report changes main made since the branch point.
+          # --diff-filter=d drops deletions — a removed ADR has nothing to attest.
+          git diff --name-only --diff-filter=d origin/main...HEAD \
+            -- 'docs/*/architecture/ADR/*.md' | python - <<'EOF'
+          import hashlib
+          import json
+          import os
+          import re
+          import sys
+
+          import yaml
+
+          POLICY = "governance/approval_policy.yaml"
+          SENTINEL = "YOUR_APPROVER_LOGIN"
+          GATE_STATUS = "Accepted"
+          APPROVER_ROLE = "approver"
+          HEADER_START = "<!-- govkit:editable"
+          STATUS_RE = re.compile(r"^## Status\s*\n(.+)$", re.MULTILINE)
+          HASH_RE = re.compile(r"^\s*hash:\s*([0-9a-f]{64})\s*$", re.MULTILINE)
+
+
+          def fail(*lines):
+              for line in lines:
+                  print(line)
+              sys.exit(1)
+
+
+          def in_scope(path, prefixes):
+              return not prefixes or any(path.startswith(p) for p in prefixes)
+
+
+          def strip_header(text):
+              """Drop a leading govkit:editable header, matching cli/headers.py."""
+              stripped = text.lstrip()
+              end = stripped.find("-->")
+              if not stripped.startswith(HEADER_START) or end == -1:
+                  return text
+              body = stripped[end + 3:]
+              for _ in range(2):
+                  if body.startswith("\n"):
+                      body = body[1:]
+              return body
+
+
+          def govkit_authored(text):
+              """Is this govkit's own decision, unmodified by the team?
+
+              Requiring a customer's approver to attest a decision govkit made
+              for them is incoherent. govkit ships exactly one real ADR — data's
+              0001 — and it says Accepted with no approval record, so without
+              this carve-out every data repo would fail its first PR. The
+              discriminator is the body hash cli/headers.py already writes for
+              edit-protection; no new mechanism is invented here.
+              """
+              stripped = text.lstrip()
+              end = stripped.find("-->")
+              if not stripped.startswith(HEADER_START) or end == -1:
+                  return False
+              match = HASH_RE.search(stripped[:end])
+              if not match:
+                  # Pre-hash install: govkit wrote it, and whether the team has
+                  # since edited it is undecidable. A false alarm on a file the
+                  # team never authored costs more than a false silence.
+                  return True
+              digest = hashlib.sha256(strip_header(text).encode("utf-8")).hexdigest()
+              return digest == match.group(1)
+
+
+          head_sha = os.environ.get("HEAD_SHA", "").strip()
+
+          changed = [ln.strip() for ln in sys.stdin if ln.strip()]
+          changed = [p for p in changed if not p.endswith("TEMPLATE.md")]
+          if not changed:
+              print("No ADR changed in this PR; nothing for this gate to check.")
+              sys.exit(0)
+
+          try:
+              with open(POLICY, encoding="utf-8") as fh:
+                  policy = yaml.safe_load(fh)
+          except FileNotFoundError:
+              fail(
+                  f"FAIL: {POLICY} is missing.",
+                  "      An ADR cannot be Accepted in a repository that declares",
+                  "      nobody able to accept it. Run `govkit upgrade` to install it.",
+              )
+          except (OSError, yaml.YAMLError) as exc:
+              fail(f"FAIL: {POLICY} could not be read: {exc}")
+          if not isinstance(policy, dict):
+              fail(f"FAIL: {POLICY} is not a YAML mapping.")
+
+          scope = [
+              p for p in (policy.get("require_approval_for") or []) if isinstance(p, str)
+          ]
+
+          needing = []
+          for path in changed:
+              if not in_scope(path, scope):
+                  continue
+              try:
+                  with open(path, encoding="utf-8") as fh:
+                      text = fh.read()
+              except (OSError, UnicodeDecodeError) as exc:
+                  fail(f"FAIL: {path} could not be read: {exc}")
+              match = STATUS_RE.search(text)
+              if not match or match.group(1).strip() != GATE_STATUS:
+                  continue
+              if govkit_authored(text):
+                  print(f"skipped {path} — govkit-authored and unmodified")
+                  continue
+              needing.append(path)
+
+          if not needing:
+              print(f"No changed ADR claims {GATE_STATUS}; nothing to attest.")
+              sys.exit(0)
+
+          # A reviewer does not gain approval authority, and the shipped
+          # sentinel authorises nobody — both are excluded here rather than
+          # anywhere else, so neither can be mistaken for a configured approver.
+          approvers = {}
+          for entry in policy.get("approvers") or []:
+              if not isinstance(entry, dict) or entry.get("role") != APPROVER_ROLE:
+                  continue
+              login = entry.get("login")
+              if not isinstance(login, str) or not login.strip() or login == SENTINEL:
+                  continue
+              approvers[login] = [
+                  s for s in (entry.get("scope") or []) if isinstance(s, str)
+              ]
+
+          if not approvers:
+              fail(
+                  f"FAIL: {len(needing)} ADR(s) claim {GATE_STATUS} but {POLICY}",
+                  "      names no approver, so this gate fails closed.",
+                  f"      Replace {SENTINEL} with the login(s) that hold approval",
+                  "      authority here. A reviewer does not gain it —",
+                  "      see AUTHORITY_AND_APPROVAL_CONTRACT.md.",
+                  *[f"        - {p}" for p in needing],
+              )
+
+          if not head_sha:
+              fail(
+                  "FAIL: no head SHA available, so an approval cannot be bound to",
+                  "      a commit. This gate must run on pull_request.",
+              )
+
+          try:
+              with open("reviews.jsonl", encoding="utf-8") as fh:
+                  reviews = [json.loads(ln) for ln in fh if ln.strip()]
+          except (OSError, ValueError) as exc:
+              fail(f"FAIL: could not read the review list: {exc}")
+
+          # Bound to this commit. A review submitted against an earlier push
+          # approved a different decision — "approval after the side effect" and
+          # "reusing stale activation authority" are both prohibited patterns.
+          approved_by = {
+              r.get("login") for r in reviews
+              if isinstance(r, dict)
+              and r.get("state") == "APPROVED"
+              and r.get("commit_id") == head_sha
+          }
+
+          unattested = []
+          for path in needing:
+              who = sorted(
+                  login for login in approved_by & set(approvers)
+                  if in_scope(path, approvers[login])
+              )
+              if who:
+                  print(f"OK   {path} — approved by {', '.join(who)} at {head_sha[:7]}")
+              else:
+                  unattested.append(path)
+
+          if unattested:
+              print("")
+              for path in unattested:
+                  print(f"FAIL: {path} claims {GATE_STATUS} with no authorised")
+                  print(f"      approval of {head_sha[:7]}.")
+              print("")
+              print(f"An ADR is {GATE_STATUS} because an approver accepted it at this")
+              print("commit. Either:")
+              print(f"  1. have an approver named in {POLICY} approve this PR")
+              print("     (a new push invalidates an earlier approval — that is the point)")
+              print("  2. set the ADR's status back to Proposed until they do")
+              sys.exit(1)
+
+          print("")
+          print(f"Every changed {GATE_STATUS} ADR carries an authorised approval.")
+          EOF

--- a/cli/approval.py
+++ b/cli/approval.py
@@ -201,22 +201,36 @@ def _validate_against_schema(target: Path) -> tuple[list[str], list[str]]:
     return [], []
 
 
+def normalize_login(value: object) -> str:
+    """Fold a platform login for comparison.
+
+    GitHub usernames are case-insensitive, and so are Azure `uniqueName`s;
+    Python string equality is not. Everything that *matches* a login folds it —
+    here and in the CI gate — while everything a human reads keeps the spelling
+    the policy chose.
+    """
+    return value.strip().casefold() if isinstance(value, str) else ""
+
+
 def resolve_approvers(policy: dict) -> list[str]:
-    """The logins that actually hold approval authority.
+    """The logins that actually hold approval authority, as the policy spells them.
 
     Reviewers are excluded by design, and so is the shipped sentinel: a policy
     nobody has edited authorises nobody. Both exclusions exist so "no findings"
-    can never be mistaken for "attestation is on".
+    can never be mistaken for "attestation is on" — which is why the sentinel is
+    matched folded. A `your_approver_login` that slipped through on casing alone
+    would read as configured while authorising an account that does not exist.
     """
-    return [
-        entry["login"]
-        for entry in policy.get("approvers") or []
-        if isinstance(entry, dict)
-        and entry.get("role") == APPROVER_ROLE
-        and isinstance(entry.get("login"), str)
-        and entry["login"].strip()
-        and entry["login"] != SENTINEL_LOGIN
-    ]
+    sentinel = normalize_login(SENTINEL_LOGIN)
+    resolved = []
+    for entry in policy.get("approvers") or []:
+        if not isinstance(entry, dict) or entry.get("role") != APPROVER_ROLE:
+            continue
+        login = normalize_login(entry.get("login"))
+        if not login or login == sentinel:
+            continue
+        resolved.append(entry["login"].strip())
+    return resolved
 
 
 def _in_scope(rel: str, prefixes: list) -> bool:

--- a/cli/approval.py
+++ b/cli/approval.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ADR approval attestation — the working-tree half.
+
+`Accepted` was a word someone typed. The L4 governance rule gates
+implementation on it and nothing in `cli/` or `ci/` had ever read it.
+`governance/approval_policy.yaml` makes it derivable by naming which identities
+hold approval authority; this module proves that policy is well-formed and
+reports ADRs claiming `Accepted` with nothing standing behind the claim.
+
+**What this module cannot do, by construction.** The working tree holds no
+reviews, so it cannot prove an approval happened — only `ci/*/adr-approval-gate`
+can, where the diff and the reviews API exist. The split is the same one the
+defect lane draws: validate proves internal consistency, CI proves
+correspondence with reality.
+
+Modelled on `cli/fixes.py`: its own module, the `(issues, warnings)` ABI
+(`CheckStatus` lives in `cli/validate.py`, which imports this, so sharing the
+type would make a cycle), and silent when absent.
+
+**Everything here is a warning, never an issue, except a malformed policy.**
+That is the migration posture — warn on pre-existing, fail on changed — and it
+is not politeness. govkit ships exactly one real ADR
+(`docs/data/architecture/ADR/0001-...`), it says `Accepted`, it has no Approval
+section at all, and it lands in every `--type data` install. A hard check would
+have failed every data customer's repo on their next upgrade, which is the exact
+defect class PR #133 existed to fix.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from .headers import compute_body_hash, has_editable_header, parse_editable_header
+
+POLICY_REL = Path("governance") / "approval_policy.yaml"
+SCHEMA_REL = Path("governance") / "schemas" / "approval_policy.schema.json"
+
+# Where the shipped templates put ADRs, for every project type.
+ADR_GLOB = "docs/*/architecture/ADR/*.md"
+TEMPLATE_NAME = "TEMPLATE.md"
+
+# The status the L4 rule gates implementation on.
+GATE_STATUS = "Accepted"
+
+# The one role that confers approval authority. AUTHORITY_AND_APPROVAL_CONTRACT.md:
+# "a reviewer does not gain approval authority."
+APPROVER_ROLE = "approver"
+
+# Shipped inert. Mirrors repo-scope-check's REPO_OWNER and the fix-lane gate's
+# SOURCE_PATHS, so a fresh install stays green rather than failing on arrival.
+SENTINEL_LOGIN = "YOUR_APPROVER_LOGIN"
+
+# The `## Status` line, as parsed in tests/test_adr_contract_consistency.py.
+_STATUS_RE = re.compile(r"^## Status\s*\n(.+)$", re.MULTILINE)
+
+# Two ADR vocabularies ship from govkit: the templates emit `## 10. Approval`
+# (UI numbers it `## 11.`), the adr-author skill teaches `## Review`. A
+# customer's ADR may carry either, so the parser tolerates both — and the
+# numbered prefix, which `check_nfrs_sections`'s `^##\s+<name>` would miss.
+_APPROVAL_SECTION_RE = re.compile(
+    r"^##\s+(?:\d+\.\s*)?(?:Approval|Review)\b.*$", re.MULTILINE | re.IGNORECASE,
+)
+
+# A colon-terminated label with nothing after it. The shipped template's
+# Approval section is three of these — bound to no identity, no date, no commit
+# — so a section made only of them is empty for this purpose.
+_EMPTY_LABEL_RE = re.compile(r"^\s*(?:[-*]\s*)?[A-Za-z][^:\n]*:\s*$", re.MULTILINE)
+
+
+def discover_adrs(target: Path) -> list[Path]:
+    """Every ADR in the target, template excluded.
+
+    Returns [] when there is no docs tree — absence is not a finding. Never
+    raises: an unreadable tree yields nothing rather than a traceback.
+    """
+    try:
+        found = sorted(target.glob(ADR_GLOB))
+    except OSError:
+        return []
+    return [p for p in found if p.is_file() and p.name != TEMPLATE_NAME]
+
+
+def parse_adr_status(text: str) -> str | None:
+    """The declared status, or None when there is no parseable `## Status`.
+
+    The template's own line is the vocabulary menu
+    (`Proposed | Accepted | Rejected | Superseded`), which is returned verbatim
+    and so never equals `Accepted` — a menu is not a claim.
+    """
+    match = _STATUS_RE.search(text)
+    return match.group(1).strip() if match else None
+
+
+def _section_body(text: str, match: re.Match) -> str:
+    nxt = re.search(r"^##\s", text[match.end():], re.MULTILINE)
+    return text[match.end():match.end() + nxt.start()] if nxt else text[match.end():]
+
+
+def has_approval_record(text: str) -> bool:
+    """Does an Approval/Review section carry anything at all?
+
+    Populated means real content after HTML comments and bare colon-terminated
+    labels are stripped. `Approved by:` with nothing after the colon records
+    nothing, which is precisely the state this work exists to end.
+    """
+    for match in _APPROVAL_SECTION_RE.finditer(text):
+        body = _section_body(text, match)
+        body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+        body = _EMPTY_LABEL_RE.sub("", body)
+        if body.strip():
+            return True
+    return False
+
+
+def is_govkit_authored(text: str) -> bool:
+    """Is this ADR govkit's own decision, unmodified by the team?
+
+    Reuses the edit-protection machinery rather than inventing a marker:
+    `cli/headers.py` writes a `govkit:editable` header carrying a SHA-256 of the
+    body it installed, so a matching hash means govkit wrote it and nobody has
+    touched it since.
+
+    A header with no `hash:` field — a pre-hash install — counts as govkit's.
+    The alternative is warning a data customer about the ADR govkit put in their
+    repo, and under a warn-only migration posture, a false silence costs less
+    than a false alarm on a file the team never authored.
+    """
+    if not has_editable_header(text):
+        return False
+    fields = parse_editable_header(text) or {}
+    if "hash" not in fields:
+        return True
+    return compute_body_hash(text) == fields["hash"]
+
+
+def _load_policy(target: Path) -> tuple[dict | None, list[str]]:
+    """Read the policy. Returns (data, issues); data is None when unusable."""
+    path = target / POLICY_REL
+    rel = POLICY_REL.as_posix()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return None, [f"{rel} could not be read: {exc}"]
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        return None, [f"{rel} could not be parsed: {exc}"]
+    if not isinstance(data, dict):
+        return None, [f"{rel} is not a YAML mapping"]
+    if not isinstance(data.get("approvers"), list):
+        return None, [f"{rel} must declare an `approvers` list"]
+    return data, []
+
+
+def _validate_against_schema(target: Path) -> tuple[list[str], list[str]]:
+    """Instance validation with the three-tier degradation `check_eval_criteria`
+    established: a missing schema or absent tool is a visible warning, never a
+    silent pass."""
+    rel = POLICY_REL.as_posix()
+    schema = target / SCHEMA_REL
+    if not schema.is_file():
+        return [], [
+            f"{rel} instance validation skipped — no approval_policy schema installed"
+        ]
+    try:
+        result = subprocess.run(
+            ["check-jsonschema", "--schemafile", str(schema), str(target / POLICY_REL)],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return [], [
+            f"{rel} instance validation skipped — "
+            "install check-jsonschema for full validation"
+        ]
+    if result.returncode != 0:
+        detail = (result.stdout or result.stderr or "").strip().splitlines()
+        snippet = detail[-1] if detail else "schema validation failed"
+        return [f"{rel} fails {schema.name}: {snippet}"], []
+    return [], []
+
+
+def resolve_approvers(policy: dict) -> list[str]:
+    """The logins that actually hold approval authority.
+
+    Reviewers are excluded by design, and so is the shipped sentinel: a policy
+    nobody has edited authorises nobody. Both exclusions exist so "no findings"
+    can never be mistaken for "attestation is on".
+    """
+    return [
+        entry["login"]
+        for entry in policy.get("approvers") or []
+        if isinstance(entry, dict)
+        and entry.get("role") == APPROVER_ROLE
+        and isinstance(entry.get("login"), str)
+        and entry["login"].strip()
+        and entry["login"] != SENTINEL_LOGIN
+    ]
+
+
+def _in_scope(rel: str, prefixes: list) -> bool:
+    if not prefixes:
+        return True
+    return any(rel.startswith(p) for p in prefixes if isinstance(p, str))
+
+
+def check_approval_policy(target: Path) -> tuple[list[str], list[str]]:
+    """Return (issues, warnings) for the target's ADR approval attestation.
+
+    Silent when the repo has neither ADRs nor a policy — a repo that never
+    adopted this sees no change, the same contract the defect lane carries.
+    """
+    adrs = discover_adrs(target)
+    policy_path = target / POLICY_REL
+    rel = POLICY_REL.as_posix()
+
+    if not adrs and not policy_path.is_file():
+        return [], []
+
+    if not policy_path.is_file():
+        return [], [
+            f"{len(adrs)} ADR(s) present but no {rel} — `Accepted` cannot be "
+            "derived from an approval until the policy names who may give one "
+            "(run `govkit upgrade` to install it)"
+        ]
+
+    policy, issues = _load_policy(target)
+    if policy is None:
+        return issues, []
+
+    schema_issues, warnings = _validate_against_schema(target)
+    if schema_issues:
+        return schema_issues, warnings
+
+    approvers = resolve_approvers(policy)
+    if not approvers:
+        warnings.append(
+            f"{rel} names no approver — attestation is not configured. Replace "
+            f"{SENTINEL_LOGIN} with the login(s) that hold approval authority "
+            "here; a reviewer does not gain it (AUTHORITY_AND_APPROVAL_CONTRACT.md)"
+        )
+
+    warnings += _check_adrs(target, adrs, policy.get("require_approval_for") or [])
+    return [], warnings
+
+
+def _check_adrs(target: Path, adrs: list[Path], scope: list) -> list[str]:
+    warnings = []
+    for path in adrs:
+        rel = path.relative_to(target).as_posix()
+        if not _in_scope(rel, scope):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            warnings.append(f"{rel} could not be read: {exc}")
+            continue
+        if parse_adr_status(text) != GATE_STATUS:
+            continue
+        # govkit's own decision, unmodified. Requiring a customer's approver to
+        # attest a decision govkit made for them is incoherent.
+        if is_govkit_authored(text):
+            continue
+        if has_approval_record(text):
+            continue
+        warnings.append(
+            f"{rel} claims {GATE_STATUS} with no approval record — "
+            f"{GATE_STATUS} is derived from an approving review by an approver "
+            f"in {POLICY_REL.as_posix()}, which the adr-approval-check CI gate "
+            "verifies against the head SHA"
+        )
+    return warnings

--- a/cli/approval.py
+++ b/cli/approval.py
@@ -117,6 +117,13 @@ def has_approval_record(text: str) -> bool:
     Populated means real content after HTML comments and bare colon-terminated
     labels are stripped. `Approved by:` with nothing after the colon records
     nothing, which is precisely the state this work exists to end.
+
+    Both exclusions are load-bearing, because the commonest way to write an ADR
+    is to copy `TEMPLATE.md`. Anything govkit prints in that section arrives in
+    every ADR built that way, so text that counted would silence this check for
+    exactly the ADRs it exists to look at. The templates keep their guidance in
+    a comment for that reason — the same device `check_nfrs_sections` uses to
+    stop a placeholder reading as a populated section.
     """
     for match in _APPROVAL_SECTION_RE.finditer(text):
         body = _section_body(text, match)

--- a/cli/validate.py
+++ b/cli/validate.py
@@ -778,6 +778,38 @@ def _run_fix_checks(target: Path) -> int:
     return 1 if any_fail else 0
 
 
+def _run_approval_checks(target: Path) -> int:
+    """Validate ADR approval attestation. Silent when the repo has neither ADRs
+    nor an approval policy — a repo that never adopted it sees no change.
+
+    A malformed policy is a hard failure: the policy is what turns an
+    authenticated review into an approval, so a broken one means the repo cannot
+    derive `Accepted` at all. Everything else warns. That asymmetry is the
+    migration posture — warn on pre-existing, fail on changed — and only CI can
+    see "changed", so nothing here fails on an ADR.
+    """
+    from .approval import POLICY_REL, check_approval_policy
+
+    issues, warnings = check_approval_policy(target)
+    if not issues and not warnings:
+        # Silence means either nothing to check or everything clean. Say so only
+        # when a policy is actually installed, so untouched repos stay quiet.
+        if not (target / POLICY_REL).is_file():
+            return 0
+        print("\ngovkit validate — ADR approval attestation\n")
+        print(f"  {PASS}  {POLICY_REL.as_posix()}")
+        print()
+        return 0
+
+    print("\ngovkit validate — ADR approval attestation\n")
+    for msg in warnings:
+        print(f"  {WARN}  {msg}")
+    for msg in issues:
+        print(f"  {FAIL}  {msg}")
+    print()
+    return 1 if issues else 0
+
+
 def run_validation(target: Path, level: str | None = None, strict: bool = False) -> int:
     """Run all governance checks on the target project. Returns exit code."""
     if not target.exists():
@@ -807,6 +839,10 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
     # fix record rather than only the missing directory.
     fix_exit = _run_fix_checks(target)
 
+    # Same reason as the defect lane: checked before the features/ guard so a
+    # repo mid-setup still hears about a broken approval policy.
+    approval_exit = _run_approval_checks(target)
+
     features_dir = target / "features"
     if not features_dir.exists():
         print(f"Error: no features/ directory found in '{target}'.")
@@ -818,7 +854,7 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
 
     if not feature_dirs:
         print("No feature directories found to validate.")
-        return max(ext_exit, fix_exit)
+        return max(ext_exit, fix_exit, approval_exit)
 
     level_labels = {
         "3": "L3 Governed AI Delivery (Foundations)",
@@ -832,4 +868,4 @@ def run_validation(target: Path, level: str | None = None, strict: bool = False)
     failed = len(feature_dirs) - passed
     print(f"{len(feature_dirs)} feature(s) checked, {passed} passed, {failed} failed")
     feature_exit = 0 if failed == 0 else 1
-    return max(feature_exit, ext_exit, fix_exit)
+    return max(feature_exit, ext_exit, fix_exit, approval_exit)

--- a/docs/backend/architecture/ADR/TEMPLATE.md
+++ b/docs/backend/architecture/ADR/TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Status
 Proposed | Accepted | Rejected | Superseded
 
+Write `Proposed`. `Accepted` is a **derived** state, not a word an author types
+— see the Approval section at the end of this template for what makes it true.
+
 ## Date
 YYYY-MM-DD
 
@@ -145,7 +148,19 @@ If the decision changes scope:
 
 ## 10. Approval
 
-Approved by:
+`Accepted` in the Status section is a **derived** state. It is true because an
+approver named in `governance/approval_policy.yaml` submitted an approving
+review of the commit carrying this decision — nothing written in this section
+makes it true, and the `adr-approval-check` CI gate fails a pull request whose
+ADR claims `Accepted` without that review.
+
+So this section records **which decision authority this ADR needs**, not who
+gave it. Leave no name, date, or signature here as though the decision were
+already made: a reviewer assesses evidence or content, an approver commits the
+decision, and the approval itself lives where it cannot be typed.
+
+Decision authority required:
+
 - Architect:
 - Security (if applicable):
 - Product (if scope impact):

--- a/docs/backend/architecture/ADR/TEMPLATE.md
+++ b/docs/backend/architecture/ADR/TEMPLATE.md
@@ -148,16 +148,22 @@ If the decision changes scope:
 
 ## 10. Approval
 
-`Accepted` in the Status section is a **derived** state. It is true because an
+<!--
+`Accepted` in the Status section is a derived state. It is true because an
 approver named in `governance/approval_policy.yaml` submitted an approving
 review of the commit carrying this decision — nothing written in this section
 makes it true, and the `adr-approval-check` CI gate fails a pull request whose
 ADR claims `Accepted` without that review.
 
-So this section records **which decision authority this ADR needs**, not who
-gave it. Leave no name, date, or signature here as though the decision were
-already made: a reviewer assesses evidence or content, an approver commits the
-decision, and the approval itself lives where it cannot be typed.
+So this section records WHICH DECISION AUTHORITY THIS ADR NEEDS, not who gave
+it. Leave no name, date, or signature below as though the decision were already
+made: a reviewer assesses evidence or content, an approver commits the decision,
+and the approval itself lives where it cannot be typed.
+
+This guidance is a comment so that copying the template does not leave text
+here that reads as an approval record. `govkit validate` strips comments and
+empty labels before deciding whether this section says anything.
+-->
 
 Decision authority required:
 

--- a/docs/data/architecture/ADR/TEMPLATE.md
+++ b/docs/data/architecture/ADR/TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Status
 Proposed | Accepted | Rejected | Superseded
 
+Write `Proposed`. `Accepted` is a **derived** state, not a word an author types
+— see the Approval section at the end of this template for what makes it true.
+
 ## Date
 YYYY-MM-DD
 
@@ -151,7 +154,19 @@ If the decision changes scope:
 
 ## 10. Approval
 
-Approved by:
+`Accepted` in the Status section is a **derived** state. It is true because an
+approver named in `governance/approval_policy.yaml` submitted an approving
+review of the commit carrying this decision — nothing written in this section
+makes it true, and the `adr-approval-check` CI gate fails a pull request whose
+ADR claims `Accepted` without that review.
+
+So this section records **which decision authority this ADR needs**, not who
+gave it. Leave no name, date, or signature here as though the decision were
+already made: a reviewer assesses evidence or content, an approver commits the
+decision, and the approval itself lives where it cannot be typed.
+
+Decision authority required:
+
 - Data architect / lead:
 - Privacy / compliance (if PII impact):
 - Product / downstream owner (if contract impact):

--- a/docs/data/architecture/ADR/TEMPLATE.md
+++ b/docs/data/architecture/ADR/TEMPLATE.md
@@ -154,16 +154,22 @@ If the decision changes scope:
 
 ## 10. Approval
 
-`Accepted` in the Status section is a **derived** state. It is true because an
+<!--
+`Accepted` in the Status section is a derived state. It is true because an
 approver named in `governance/approval_policy.yaml` submitted an approving
 review of the commit carrying this decision — nothing written in this section
 makes it true, and the `adr-approval-check` CI gate fails a pull request whose
 ADR claims `Accepted` without that review.
 
-So this section records **which decision authority this ADR needs**, not who
-gave it. Leave no name, date, or signature here as though the decision were
-already made: a reviewer assesses evidence or content, an approver commits the
-decision, and the approval itself lives where it cannot be typed.
+So this section records WHICH DECISION AUTHORITY THIS ADR NEEDS, not who gave
+it. Leave no name, date, or signature below as though the decision were already
+made: a reviewer assesses evidence or content, an approver commits the decision,
+and the approval itself lives where it cannot be typed.
+
+This guidance is a comment so that copying the template does not leave text
+here that reads as an approval record. `govkit validate` strips comments and
+empty labels before deciding whether this section says anything.
+-->
 
 Decision authority required:
 

--- a/docs/ui/architecture/ADR/TEMPLATE.md
+++ b/docs/ui/architecture/ADR/TEMPLATE.md
@@ -157,16 +157,22 @@ If the decision changes scope: `plan.md` must be updated.
 
 ## 11. Approval
 
-`Accepted` in the Status section is a **derived** state. It is true because an
+<!--
+`Accepted` in the Status section is a derived state. It is true because an
 approver named in `governance/approval_policy.yaml` submitted an approving
 review of the commit carrying this decision — nothing written in this section
 makes it true, and the `adr-approval-check` CI gate fails a pull request whose
 ADR claims `Accepted` without that review.
 
-So this section records **which decision authority this ADR needs**, not who
-gave it. Leave no name, date, or signature here as though the decision were
-already made: a reviewer assesses evidence or content, an approver commits the
-decision, and the approval itself lives where it cannot be typed.
+So this section records WHICH DECISION AUTHORITY THIS ADR NEEDS, not who gave
+it. Leave no name, date, or signature below as though the decision were already
+made: a reviewer assesses evidence or content, an approver commits the decision,
+and the approval itself lives where it cannot be typed.
+
+This guidance is a comment so that copying the template does not leave text
+here that reads as an approval record. `govkit validate` strips comments and
+empty labels before deciding whether this section says anything.
+-->
 
 Decision authority required:
 

--- a/docs/ui/architecture/ADR/TEMPLATE.md
+++ b/docs/ui/architecture/ADR/TEMPLATE.md
@@ -3,6 +3,9 @@
 ## Status
 Proposed | Accepted | Rejected | Superseded
 
+Write `Proposed`. `Accepted` is a **derived** state, not a word an author types
+— see the Approval section at the end of this template for what makes it true.
+
 ## Date
 YYYY-MM-DD
 
@@ -154,6 +157,18 @@ If the decision changes scope: `plan.md` must be updated.
 
 ## 11. Approval
 
-Approved by:
+`Accepted` in the Status section is a **derived** state. It is true because an
+approver named in `governance/approval_policy.yaml` submitted an approving
+review of the commit carrying this decision — nothing written in this section
+makes it true, and the `adr-approval-check` CI gate fails a pull request whose
+ADR claims `Accepted` without that review.
+
+So this section records **which decision authority this ADR needs**, not who
+gave it. Leave no name, date, or signature here as though the decision were
+already made: a reviewer assesses evidence or content, an approver commits the
+decision, and the approval itself lives where it cannot be typed.
+
+Decision authority required:
+
 - Architect:
 - Product (if scope impact):

--- a/governance/approval_policy.yaml
+++ b/governance/approval_policy.yaml
@@ -1,0 +1,62 @@
+# Approval policy — who may accept an Architecture Decision Record.
+#
+# WHY THIS FILE EXISTS
+#   An ADR's `Accepted` status is a *derived* state, not typed text. It is true
+#   because an authorised approver approved that decision at that commit. This
+#   file is what makes the derivation possible: it says which platform
+#   identities hold approval authority in this repository.
+#
+#   AUTHORITY_AND_APPROVAL_CONTRACT.md keeps two roles distinct — a Reviewer
+#   "assesses evidence or content", an Approver "commits a scoped consequential
+#   decision" — and states plainly that "a reviewer does not gain approval
+#   authority". Without this mapping, any authenticated review would count, and
+#   that is the contract's prohibited pattern "approval by an unauthorized
+#   identity".
+#
+# CONFIGURE THIS: replace YOUR_APPROVER_LOGIN with the platform login(s) that
+#   hold approval authority here. The gate is INACTIVE until you do, so a fresh
+#   install stays green. Add one entry per identity.
+#
+#   `login` is the account name (a GitHub username), matched against the
+#   `user.login` of an approving review — not a display name or an email.
+#
+# HOW IT IS ENFORCED
+#   `govkit validate` proves this file is well-formed and reports ADRs claiming
+#   `Accepted` without provenance. It cannot prove an approval happened — the
+#   working tree holds no reviews. The `adr-approval-gate` CI workflow does
+#   that: for each ADR changed in a PR, it requires an approving review whose
+#   `commit_id` is the head SHA and whose `user.login` is an `approver` below.
+#
+#   govkit verifies; the platform enforces. Make the gate a required check
+#   (branch protection + CODEOWNERS) or it is advisory — govkit can prove an
+#   approval happened, only the platform can make the proof mandatory.
+#   See ci/README.md, "ADR approval attestation".
+#
+# Validated against governance/schemas/approval_policy.schema.json.
+
+version: 1
+
+approvers:
+  # Roles come from AUTHORITY_AND_APPROVAL_CONTRACT.md's human-roles table:
+  #   approver              — commits a scoped consequential decision
+  #   reviewer              — assesses evidence or content (CANNOT accept an ADR)
+  #   human-execution-owner — owns active task execution after takeover
+  #   accountable-principal — retains accountability for intent and consequences
+  # Only `approver` can accept an ADR. Declaring the others records the
+  # governance loop in one place without any of them reading as authorisation.
+  - login: YOUR_APPROVER_LOGIN
+    role: approver
+
+    # Optional: repo-relative path prefixes this identity may approve within.
+    # Omit for repository-wide authority. Approval is scoped by the authority
+    # contract, so a security lead who accepts only security ADRs is declarable:
+    #
+    # scope:
+    #   - docs/backend/architecture/ADR/
+
+# Optional: restrict which ADR directories the gate covers. Omitted means every
+# `docs/*/architecture/ADR/` directory, which is where the shipped templates
+# put them.
+#
+# require_approval_for:
+#   - docs/backend/architecture/ADR/

--- a/governance/schemas/approval_policy.schema.json
+++ b/governance/schemas/approval_policy.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:governed-ai-delivery:schemas:approval_policy",
+  "title": "Approval Policy Schema",
+  "description": "Schema for governance/approval_policy.yaml — the file that turns an authenticated review into an approval. An ADR's `Accepted` status is meant to be a derived state: true because an authorised approver approved that decision at that commit, not because the word was typed. Nothing can derive it until something says which identities hold approval authority, which is what this file declares. Area-agnostic: an ADR approval has the same shape whether the repo is api, cli, ui, or data, so this lives in governance/schemas/ rather than governance/<area>/schemas/.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "approvers"],
+  "properties": {
+    "version": {
+      "description": "Approval policy format version.",
+      "type": "integer",
+      "minimum": 1
+    },
+
+    "approvers": {
+      "description": "The identities this repository recognises, each with the role it holds. An empty list is well-formed but authorises nobody — the CI gate fails closed on it, so the message names the real problem instead of a schema error.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["login", "role"],
+        "properties": {
+          "login": {
+            "description": "Platform account login (a GitHub username). Matched against the `user.login` of an approving review, so it must be the account name, not a display name or email.",
+            "type": "string",
+            "minLength": 1
+          },
+          "role": {
+            "description": "The role this identity holds, drawn from AUTHORITY_AND_APPROVAL_CONTRACT.md's human-roles table. Only `approver` confers approval authority: 'a reviewer does not gain approval authority', and an approval by anyone else is the contract's prohibited pattern 'approval by an unauthorized identity'. The other roles are declarable so the governance loop is recorded in one place without any of them silently reading as authorisation.",
+            "type": "string",
+            "enum": [
+              "approver",
+              "reviewer",
+              "human-execution-owner",
+              "accountable-principal"
+            ]
+          },
+          "scope": {
+            "description": "Optional repo-relative path prefixes this identity may approve within. Absent means every ADR in the repository. Approval is scoped by the authority contract, so a security lead who approves only security ADRs can be declared as such.",
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+
+    "require_approval_for": {
+      "description": "Optional repo-relative path prefixes the ADR approval gate covers. Absent means every `docs/*/architecture/ADR/` directory, which is where the shipped templates put ADRs.",
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/plans/APPROVAL_ATTESTATION_PLAN.md
+++ b/plans/APPROVAL_ATTESTATION_PLAN.md
@@ -1,9 +1,9 @@
 # Approval Attestation Plan (Decision 2)
 
-**Status:** Approved, not started
+**Status:** Implemented on `feat/approval-attestation`, all eight increments
 **Scope:** Make an ADR's `Accepted` status a derived state rather than typed text
 **Date:** 2026-08-13
-**Branch:** none yet — start from `main` at `89195a7`
+**Branch:** `feat/approval-attestation`, from `main` at `751b844` (#137)
 
 > The third and last of the three decisions recorded in
 > `plans/AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md`. Decision 1 (defect lane) shipped in
@@ -222,3 +222,52 @@ warn about the ADR govkit put there.
   insertion with a bracket-matching scanner.
 - `.gitignore` carries an unstaged edit that predates this work and belongs to
   the user. Leave it out of every commit.
+
+---
+
+## What shipped, and where it differed from this plan
+
+All eight increments landed, TDD throughout, one commit each.
+
+**Three decisions the plan left open:**
+
+- **Level.** The policy, schema and gate ship at **L4+**, mirroring the defect
+  lane rather than the L3 ADR template. The plan pointed at both shapes
+  (`l4-backend-api.md:16` for the policy, `_run_extension_checks` — which runs
+  at every level — for the wiring). L4 keeps the attestation model beside the
+  contract that gates on `Accepted` and matches this plan's own `--level 4`
+  verification.
+- **Install category.** `governance/approval_policy.yaml` ships as **`shared`,
+  not `governed`** — the first non-`features/` shared entry in any manifest.
+  Governed contracts are refreshed by `upgrade`, which would overwrite a team's
+  approver list and silently revert the repo to authorising nobody. The schema
+  stays governed. Verified against a real install: the edited list survives even
+  `upgrade --force`.
+- **Gate self-containment.** The gate never invokes govkit, following
+  `tests/test_fix_lane_gate_checks.py`'s argument — a blocking gate must not
+  depend on an unpinned PyPI release, and one delegating to `govkit validate`
+  could be switched off from inside the PR it is reviewing. So the
+  `govkit~=<version>` pin the plan anticipated is not needed, and
+  `tests/test_ci_govkit_dependency.py` does not enrol it. The duplicated status
+  and body-hash logic is held in check by executing both platform embeddings
+  against fixtures and pinning them byte-identical.
+
+**One defect found and fixed during verification.** Increment 7's Approval-section
+prose defeated increment 3's check: the commonest way to write an ADR is to copy
+`TEMPLATE.md`, so that text arrived in every ADR built that way and read as an
+approval record — silencing the check for exactly the ADRs it exists to look at.
+The guidance moved into an HTML comment, the device `check_nfrs_sections`
+already uses for the same reason. The CI gate was never affected; it requires a
+review, not a sentence.
+
+**Azure, as predicted, was the bigger lift.** It is now the only shipped Azure
+template that calls a platform API. Azure binds a reviewer vote to the pull
+request rather than to a commit, so the template requires the *"Reset code
+reviewer votes when there are new changes"* branch policy and prints that
+requirement on every run — the GitHub half needs no equivalent, since a review
+carries the `commit_id` it was submitted against.
+
+**Verification:** 2761 fast + 134 e2e passing; `pytest -k parity` green; the
+three-case sandbox walkthrough above reproduced against the real CLI, including
+the one that matters — a fresh `--type data` install says nothing about
+ADR-0001.

--- a/tests/test_adr_approval_gate_checks.py
+++ b/tests/test_adr_approval_gate_checks.py
@@ -1,0 +1,426 @@
+"""Behavior tests for the ADR approval gate's embedded checker.
+
+This gate exists because `govkit validate` structurally cannot do its job: the
+working tree holds no reviews, so validate can prove `governance/approval_policy.yaml`
+is well-formed and report an ADR claiming `Accepted` with nothing behind it, but
+it can never prove an approval happened. Only the reviews API can, and only CI
+has it.
+
+Following `tests/test_fix_lane_gate_checks.py`: extract the heredoc, execute it
+against fixtures, and pin the two platform embeddings identical so they cannot
+drift. Asserting on the YAML text would prove only that words are present —
+these tests run the checker.
+
+Like the fix-lane gate, this one is deliberately self-contained. It never
+invokes govkit: a blocking gate must not depend on an unpinned PyPI release, and
+`run_validation` exits 0 on a missing marker, so a gate delegating to it could be
+switched off from inside the PR it is reviewing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_PATHS = {
+    "github": REPO_ROOT / "ci" / "github" / "adr-approval-gate.yml",
+    "azure": REPO_ROOT / "ci" / "azure" / "adr-approval-gate.yml",
+}
+
+HEAD_SHA = "2f8c1ab9d4e6f70123456789abcdef0123456789"
+OLD_SHA = "1111111111111111111111111111111111111111"
+APPROVER = "octo-architect"
+SENTINEL = "YOUR_APPROVER_LOGIN"
+ADR_REL = "docs/backend/architecture/ADR/0001-service-layer.md"
+
+
+def _extract_checker(gate_path: Path) -> str:
+    raw = gate_path.read_text(encoding="utf-8")
+    marker = "python - <<'EOF'\n"
+    start = raw.index(marker) + len(marker)
+    body = []
+    for line in raw[start:].splitlines():
+        if line.strip() == "EOF":
+            break
+        body.append(line)
+    return textwrap.dedent("\n".join(body)) + "\n"
+
+
+def _adr(status: str = "Accepted", approval: str | None = None) -> str:
+    text = (
+        "# ADR-0001: Introduce a service layer\n\n"
+        f"## Status\n{status}\n\n## 1. Context\n\nWhy.\n"
+    )
+    if approval:
+        text += f"\n## 10. Approval\n{approval}\n"
+    return text
+
+
+def _govkit_authored(body: str, tamper: bool = False) -> str:
+    """Reproduce what `cli.headers.prepend_header_to_file` writes on install."""
+    from cli.headers import format_editable_header
+
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    if tamper:
+        body += "\n## 2. Decision\n\nOurs now.\n"
+    return format_editable_header(baseline="0.18.0", body_hash=digest) + body
+
+
+def _policy(
+    approvers: list[dict] | None = None, **extra,
+) -> dict:
+    if approvers is None:
+        approvers = [{"login": APPROVER, "role": "approver"}]
+    return {"version": 1, "approvers": approvers, **extra}
+
+
+def _run(
+    tmp_path: Path,
+    changed: list[str],
+    *,
+    files: dict[str, str] | None = None,
+    policy: dict | str | None = None,
+    reviews: list[dict] | None = None,
+    head_sha: str = HEAD_SHA,
+    platform: str = "github",
+) -> subprocess.CompletedProcess:
+    for rel, text in (files or {}).items():
+        path = tmp_path / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    if policy is not None:
+        path = tmp_path / "governance" / "approval_policy.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            policy if isinstance(policy, str)
+            else yaml.safe_dump(policy, sort_keys=False),
+            encoding="utf-8",
+        )
+
+    (tmp_path / "reviews.jsonl").write_text(
+        "".join(json.dumps(r) + "\n" for r in (reviews or [])), encoding="utf-8",
+    )
+
+    script = tmp_path / "_gate.py"
+    script.write_text(_extract_checker(GATE_PATHS[platform]), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(script)],
+        cwd=tmp_path,
+        input="\n".join(changed),
+        capture_output=True,
+        text=True,
+        env={"HEAD_SHA": head_sha, "PATH": "", "SYSTEMROOT": ""},
+    )
+
+
+def _approval(login: str = APPROVER, commit: str = HEAD_SHA, state: str = "APPROVED"):
+    return {"login": login, "state": state, "commit_id": commit}
+
+
+def test_checker_extraction_is_not_empty():
+    """Non-vacuous guard: a changed heredoc marker would make every test below
+    run an empty script and trivially pass."""
+    body = _extract_checker(GATE_PATHS["github"])
+    assert "approval_policy.yaml" in body and "commit_id" in body, body[:300]
+
+
+class TestNothingToAttest:
+    def test_no_adr_changed_passes(self, tmp_path):
+        result = _run(tmp_path, [], policy=_policy())
+        assert result.returncode == 0, result.stdout
+        assert "No ADR changed" in result.stdout
+
+    def test_the_template_is_not_an_adr(self, tmp_path):
+        """`Proposed | Accepted | Rejected | Superseded` is the vocabulary menu.
+        Editing the template is not accepting a decision."""
+        result = _run(
+            tmp_path,
+            ["docs/backend/architecture/ADR/TEMPLATE.md"],
+            files={
+                "docs/backend/architecture/ADR/TEMPLATE.md":
+                    _adr(status="Proposed | Accepted | Rejected | Superseded"),
+            },
+            policy=_policy(),
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_a_proposed_adr_needs_no_approval(self, tmp_path):
+        """The agent authors Proposed and stops; that is the point of the skill
+        change, and this is the gate agreeing with it."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr(status="Proposed")},
+            policy=_policy(),
+        )
+        assert result.returncode == 0, result.stdout
+        assert "nothing to attest" in result.stdout
+
+    def test_a_deleted_adr_is_not_read(self, tmp_path):
+        """--diff-filter=d keeps deletions out of the list; if one slipped
+        through, the checker must not crash on the missing file."""
+        result = _run(tmp_path, [], policy=_policy())
+        assert result.returncode == 0, result.stdout
+
+
+class TestFailsClosed:
+    def test_unconfigured_policy_fails_on_an_accepted_adr(self, tmp_path):
+        """The opposite of the fix-lane gate's inert sentinel, deliberately: an
+        ADR cannot be accepted in a repo that declares nobody able to accept it."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": SENTINEL, "role": "approver"}]),
+            reviews=[_approval()],
+        )
+        assert result.returncode == 1, result.stdout
+        assert "names no approver" in result.stdout
+
+    def test_a_fresh_install_touching_no_adr_stays_green(self, tmp_path):
+        """Failing closed must not mean failing on arrival."""
+        result = _run(
+            tmp_path, [], policy=_policy([{"login": SENTINEL, "role": "approver"}]),
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_a_missing_policy_fails(self, tmp_path):
+        result = _run(tmp_path, [ADR_REL], files={ADR_REL: _adr()}, reviews=[_approval()])
+        assert result.returncode == 1, result.stdout
+        assert "is missing" in result.stdout
+
+    def test_a_malformed_policy_fails(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy="approvers: [unclosed\n", reviews=[_approval()],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_a_policy_that_is_not_a_mapping_fails(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy="- a\n- list\n", reviews=[_approval()],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_no_head_sha_fails_rather_than_matching_everything(self, tmp_path):
+        """An empty HEAD_SHA against an empty commit_id would compare equal and
+        wave through an unbound approval."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=[_approval(commit="")], head_sha="",
+        )
+        assert result.returncode == 1, result.stdout
+        assert "head SHA" in result.stdout
+
+
+class TestIdentityAndAuthority:
+    def test_an_approver_at_the_head_sha_passes(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=[_approval()],
+        )
+        assert result.returncode == 0, result.stdout
+        assert APPROVER in result.stdout
+
+    def test_no_approval_at_all_fails(self, tmp_path):
+        """The whole point: `Accepted` was true because someone typed it."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+        )
+        assert result.returncode == 1, result.stdout
+        assert "no authorised" in result.stdout
+
+    def test_a_reviewer_cannot_accept_an_adr(self, tmp_path):
+        """AUTHORITY_AND_APPROVAL_CONTRACT.md: 'a reviewer does not gain approval
+        authority'. Their review is authenticated and still insufficient."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": "octo-qa", "role": "reviewer"}]),
+            reviews=[_approval(login="octo-qa")],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_an_identity_absent_from_the_policy_cannot_accept(self, tmp_path):
+        """'Approval by an unauthorized identity' — a prohibited pattern. An
+        authenticated review is not, by itself, an approval."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=[_approval(login="passing-stranger")],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_a_non_approving_review_does_not_count(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=[_approval(state="COMMENTED")],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_an_approval_of_an_earlier_push_does_not_carry(self, tmp_path):
+        """Approval is bound to a commit. Reusing it for a later one is
+        'reusing stale activation authority' — the contract's own words."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=[_approval(commit=OLD_SHA)],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_a_scoped_approver_cannot_accept_outside_their_scope(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{
+                "login": APPROVER, "role": "approver",
+                "scope": ["docs/data/architecture/ADR/"],
+            }]),
+            reviews=[_approval()],
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_a_scoped_approver_accepts_inside_their_scope(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{
+                "login": APPROVER, "role": "approver",
+                "scope": ["docs/backend/architecture/ADR/"],
+            }]),
+            reviews=[_approval()],
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_every_accepted_adr_needs_its_own_cover(self, tmp_path):
+        second = "docs/data/architecture/ADR/0002-marts.md"
+        result = _run(
+            tmp_path, [ADR_REL, second],
+            files={ADR_REL: _adr(), second: _adr()},
+            policy=_policy([{
+                "login": APPROVER, "role": "approver",
+                "scope": ["docs/backend/"],
+            }]),
+            reviews=[_approval()],
+        )
+        assert result.returncode == 1, result.stdout
+        assert second in result.stdout
+
+
+class TestGovkitAuthoredAdrs:
+    """govkit ships exactly one real ADR — `docs/data/architecture/ADR/0001-...`
+    — it says Accepted, it has no approval record, and it lands in every
+    `--type data` install at L3, L4 and L5 as a governed file `upgrade`
+    rewrites. Without this carve-out the gate would fail every data customer's
+    repo, which is the exact defect class PR #133 existed to fix."""
+
+    DATA_ADR = "docs/data/architecture/ADR/0001-data-features-skip-prediction-gate.md"
+
+    def test_an_unmodified_govkit_adr_needs_no_customer_approval(self, tmp_path):
+        result = _run(
+            tmp_path, [self.DATA_ADR],
+            files={self.DATA_ADR: _govkit_authored(_adr())},
+            policy=_policy(),
+        )
+        assert result.returncode == 0, result.stdout
+        assert "govkit-authored" in result.stdout
+
+    def test_editing_a_govkit_adr_makes_it_the_teams_decision(self, tmp_path):
+        result = _run(
+            tmp_path, [self.DATA_ADR],
+            files={self.DATA_ADR: _govkit_authored(_adr(), tamper=True)},
+            policy=_policy(),
+        )
+        assert result.returncode == 1, result.stdout
+
+    def test_a_customer_adr_cannot_borrow_the_carve_out_without_a_real_hash(
+        self, tmp_path,
+    ):
+        """A hand-written header with a wrong hash must not buy silence."""
+        forged = (
+            "<!-- govkit:editable\n  baseline: 0.18.0\n"
+            f"  hash: {'0' * 64}\n  see: GOVKIT_SETUP_REVIEW.md\n-->\n\n"
+        ) + _adr()
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: forged}, policy=_policy(),
+        )
+        assert result.returncode == 1, result.stdout
+
+
+class TestScopeConfiguration:
+    def test_require_approval_for_narrows_what_the_gate_covers(self, tmp_path):
+        other = "docs/data/architecture/ADR/0002-marts.md"
+        result = _run(
+            tmp_path, [other], files={other: _adr()},
+            policy=_policy(require_approval_for=["docs/backend/"]),
+        )
+        assert result.returncode == 0, result.stdout
+
+
+def test_platform_embeddings_are_identical():
+    github = _extract_checker(GATE_PATHS["github"])
+    azure = _extract_checker(GATE_PATHS["azure"])
+    assert github == azure, "github and azure adr-approval checkers have drifted"
+
+
+@pytest.mark.parametrize("platform", sorted(GATE_PATHS))
+def test_the_azure_embedding_behaves_identically(tmp_path, platform):
+    """Running the azure copy proves the dedent equality above is not the only
+    thing standing between the platforms."""
+    result = _run(
+        tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+        reviews=[_approval()], platform=platform,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+@pytest.mark.parametrize("platform", sorted(GATE_PATHS))
+def test_gate_does_not_invoke_govkit(platform):
+    """Self-contained by design, for the same reason the fix-lane gate is: a
+    blocking gate must not depend on an unpinned PyPI release, and a gate
+    delegating to `govkit validate` could be switched off from inside the PR it
+    is reviewing."""
+    text = GATE_PATHS[platform].read_text(encoding="utf-8")
+    invocations = [
+        ln for ln in text.splitlines()
+        if ln.strip().startswith(("run: govkit", "- script: govkit", "govkit "))
+    ]
+    assert not invocations, invocations
+
+
+def test_github_gate_declares_least_privilege_permissions():
+    """The payload's first `permissions:` block. Reading reviews needs
+    pull-requests: read; declaring the block drops every other scope to none, so
+    contents: read has to be restated for checkout."""
+    parsed = yaml.safe_load(GATE_PATHS["github"].read_text(encoding="utf-8"))
+    assert parsed["permissions"] == {"contents": "read", "pull-requests": "read"}
+
+
+def test_the_gate_job_name_is_the_one_the_docs_tell_teams_to_require():
+    parsed = yaml.safe_load(GATE_PATHS["github"].read_text(encoding="utf-8"))
+    assert "adr-approval-check" in parsed["jobs"]
+
+
+@pytest.mark.parametrize("agent", ["claude-code", "codex", "copilot"])
+@pytest.mark.parametrize("ci", ["github", "azure"])
+def test_the_gate_ships_wherever_the_policy_does(agent, ci):
+    """The policy without the gate is a file nothing reads — the state this
+    work exists to end. They must arrive together."""
+    from cli.manifest import load_manifest, resolve_variant_files
+
+    manifest = load_manifest(agent)
+    for project_type in ("api", "cli", "ui-react", "ui-angular", "ui-nextjs", "data"):
+        for level in ("3", "4", "5"):
+            if project_type == "data" and level == "5":
+                continue  # data is an L3/L4 shape; dbt has no L5 tier.
+            _files, shared, governed = resolve_variant_files(
+                manifest,
+                {"level": level, "type": project_type, "ci": ci,
+                 "stack": "python-dbt" if project_type == "data" else "python-fastapi"},
+            )
+            where = f"{agent} {project_type} L{level} ({ci})"
+            assert (
+                (f"ci/{ci}/adr-approval-gate.yml" in governed)
+                == ("governance/approval_policy.yaml" in shared)
+            ), where

--- a/tests/test_adr_approval_gate_checks.py
+++ b/tests/test_adr_approval_gate_checks.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import subprocess
 import sys
 import textwrap
@@ -122,8 +123,26 @@ def _run(
     )
 
 
+def _review(
+    login: str = APPROVER,
+    commit: str = HEAD_SHA,
+    state: str = "APPROVED",
+    at: str = "2026-08-14T09:00:00Z",
+    review_id: int = 1,
+) -> dict:
+    """One entry of the normalized review list the gate's shell step writes.
+
+    `submitted_at` and `id` are what let the checker tell a reviewer's *latest*
+    standing from any earlier one they have since changed.
+    """
+    return {
+        "login": login, "state": state, "commit_id": commit,
+        "submitted_at": at, "id": review_id,
+    }
+
+
 def _approval(login: str = APPROVER, commit: str = HEAD_SHA, state: str = "APPROVED"):
-    return {"login": login, "state": state, "commit_id": commit}
+    return _review(login=login, commit=commit, state=state)
 
 
 def test_checker_extraction_is_not_empty():
@@ -348,6 +367,167 @@ class TestGovkitAuthoredAdrs:
         assert result.returncode == 1, result.stdout
 
 
+class TestLatestReviewWins:
+    """An approval is a reviewer's *current* standing, not something they ever
+    said. The reviews API returns every review a PR has collected, so counting
+    any historical `APPROVED` let an approver who had since asked for changes —
+    without a new push to invalidate anything — still satisfy the gate.
+
+    GitHub's own model: a reviewer's standing is their latest `APPROVED`,
+    `CHANGES_REQUESTED` or `DISMISSED`. A `COMMENTED` review afterwards does not
+    withdraw an approval, and treating it as though it did would block pull
+    requests the platform itself considers approved.
+    """
+
+    def _adr_run(self, tmp_path, reviews, **kw):
+        return _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=reviews, **kw,
+        )
+
+    def test_changes_requested_after_approving_the_same_commit_revokes_it(
+        self, tmp_path,
+    ):
+        """The bug this class exists for. No new push, so nothing else in the
+        pipeline notices the approver changed their mind."""
+        result = self._adr_run(tmp_path, [
+            _review(state="APPROVED", at="2026-08-14T09:00:00Z", review_id=1),
+            _review(state="CHANGES_REQUESTED", at="2026-08-14T10:00:00Z", review_id=2),
+        ])
+        assert result.returncode == 1, result.stdout
+        assert "no authorised" in result.stdout
+
+    def test_a_later_comment_does_not_withdraw_an_approval(self, tmp_path):
+        """Matching the platform. A blanket 'latest review wins' would fail
+        here, and the PR would be blocked while GitHub shows it approved."""
+        result = self._adr_run(tmp_path, [
+            _review(state="APPROVED", at="2026-08-14T09:00:00Z", review_id=1),
+            _review(state="COMMENTED", at="2026-08-14T10:00:00Z", review_id=2),
+        ])
+        assert result.returncode == 0, result.stdout
+
+    def test_a_dismissed_approval_does_not_count(self, tmp_path):
+        result = self._adr_run(tmp_path, [
+            _review(state="APPROVED", at="2026-08-14T09:00:00Z", review_id=1),
+            _review(state="DISMISSED", at="2026-08-14T10:00:00Z", review_id=2),
+        ])
+        assert result.returncode == 1, result.stdout
+
+    def test_re_approving_after_requesting_changes_passes(self, tmp_path):
+        """The ordering has to work in both directions, or the fix would just
+        trade a false pass for a false block."""
+        result = self._adr_run(tmp_path, [
+            _review(state="CHANGES_REQUESTED", at="2026-08-14T09:00:00Z", review_id=1),
+            _review(state="APPROVED", at="2026-08-14T10:00:00Z", review_id=2),
+        ])
+        assert result.returncode == 0, result.stdout
+
+    def test_changes_requested_on_an_earlier_push_does_not_block_this_one(
+        self, tmp_path,
+    ):
+        """Standing is per-commit. Asking for changes on an old push and
+        approving the fix is the normal shape of a review."""
+        result = self._adr_run(tmp_path, [
+            _review(state="CHANGES_REQUESTED", commit=OLD_SHA,
+                    at="2026-08-14T09:00:00Z", review_id=1),
+            _review(state="APPROVED", at="2026-08-14T10:00:00Z", review_id=2),
+        ])
+        assert result.returncode == 0, result.stdout
+
+    def test_review_id_breaks_a_timestamp_tie(self, tmp_path):
+        """`submitted_at` has second resolution, so two reviews can share one.
+        The id is monotonic and settles it."""
+        result = self._adr_run(tmp_path, [
+            _review(state="APPROVED", at="2026-08-14T09:00:00Z", review_id=1),
+            _review(state="CHANGES_REQUESTED", at="2026-08-14T09:00:00Z", review_id=2),
+        ])
+        assert result.returncode == 1, result.stdout
+
+    def test_order_in_the_file_does_not_decide_it(self, tmp_path):
+        """The same two reviews, written newest-first. Nothing may depend on the
+        order the API happened to page them out in."""
+        result = self._adr_run(tmp_path, [
+            _review(state="CHANGES_REQUESTED", at="2026-08-14T10:00:00Z", review_id=2),
+            _review(state="APPROVED", at="2026-08-14T09:00:00Z", review_id=1),
+        ])
+        assert result.returncode == 1, result.stdout
+
+    def test_one_reviewers_withdrawal_does_not_cancel_anothers_approval(
+        self, tmp_path,
+    ):
+        result = self._adr_run(tmp_path, [
+            _review(state="CHANGES_REQUESTED", login="octo-qa",
+                    at="2026-08-14T10:00:00Z", review_id=2),
+            _review(state="APPROVED", at="2026-08-14T09:00:00Z", review_id=1),
+        ])
+        assert result.returncode == 0, result.stdout
+
+
+class TestLoginCasing:
+    """Platform logins are case-insensitive; Python string equality is not.
+
+    This failed *closed* — a policy naming `Octo-Architect` rejected the same
+    person's review returned as `octo-architect` — so it blocked legitimate
+    approvals rather than admitting bad ones. It is still a defect: the failure
+    message says no authorised approval exists, which is untrue and gives a team
+    nothing to act on.
+    """
+
+    def test_policy_may_spell_the_login_differently_from_the_platform(
+        self, tmp_path,
+    ):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": "Octo-Architect", "role": "approver"}]),
+            reviews=[_review(login="octo-architect")],
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_the_platform_may_spell_it_differently_from_the_policy(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": "octo-architect", "role": "approver"}]),
+            reviews=[_review(login="Octo-Architect")],
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_surrounding_whitespace_in_the_policy_is_tolerated(self, tmp_path):
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": "  octo-architect  ", "role": "approver"}]),
+            reviews=[_review()],
+        )
+        assert result.returncode == 0, result.stdout
+
+    def test_the_sentinel_is_recognised_whatever_its_casing(self, tmp_path):
+        """Otherwise a lower-cased sentinel reads as a configured approver, and
+        the gate would authorise an account that does not exist."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": "your_approver_login", "role": "approver"}]),
+            reviews=[_review(login="your_approver_login")],
+        )
+        assert result.returncode == 1, result.stdout
+        assert "names no approver" in result.stdout
+
+    def test_output_uses_the_spelling_the_policy_chose(self, tmp_path):
+        """Normalising is for matching, not for what a human reads."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()},
+            policy=_policy([{"login": "Octo-Architect", "role": "approver"}]),
+            reviews=[_review(login="octo-architect")],
+        )
+        assert "Octo-Architect" in result.stdout, result.stdout
+
+    def test_casing_does_not_let_an_unlisted_identity_in(self, tmp_path):
+        """Non-vacuous guard: normalisation must widen nothing but case."""
+        result = _run(
+            tmp_path, [ADR_REL], files={ADR_REL: _adr()}, policy=_policy(),
+            reviews=[_review(login="octo-architect-2")],
+        )
+        assert result.returncode == 1, result.stdout
+
+
 class TestScopeConfiguration:
     def test_require_approval_for_narrows_what_the_gate_covers(self, tmp_path):
         other = "docs/data/architecture/ADR/0002-marts.md"
@@ -395,6 +575,29 @@ def test_github_gate_declares_least_privilege_permissions():
     contents: read has to be restated for checkout."""
     parsed = yaml.safe_load(GATE_PATHS["github"].read_text(encoding="utf-8"))
     assert parsed["permissions"] == {"contents": "read", "pull-requests": "read"}
+
+
+@pytest.mark.parametrize("platform", sorted(GATE_PATHS))
+def test_the_gate_pins_pyyaml(platform):
+    """Same argument test_ci_govkit_dependency makes for the govkit pin: an
+    unpinned install makes a customer's merge criteria depend on whatever PyPI
+    served that morning, while the payload prose beside it is frozen at install
+    time. `~=` rather than `==` so a patch release can still fix a build on a
+    Python the pinned version predates."""
+    text = GATE_PATHS[platform].read_text(encoding="utf-8")
+    assert re.search(r"pip install\s+pyyaml~=\d+\.\d+\.\d+", text), (
+        f"ci/{platform}/adr-approval-gate.yml installs pyyaml unpinned"
+    )
+
+
+def test_both_gates_pin_pyyaml_to_the_same_version():
+    """The two platforms run byte-identical checker code; they must not run it
+    against different libraries."""
+    pins = {
+        platform: re.findall(r"pip install\s+(pyyaml~=[\d.]+)", path.read_text(encoding="utf-8"))
+        for platform, path in GATE_PATHS.items()
+    }
+    assert pins["github"] == pins["azure"], pins
 
 
 def test_the_gate_job_name_is_the_one_the_docs_tell_teams_to_require():

--- a/tests/test_adr_contract_consistency.py
+++ b/tests/test_adr_contract_consistency.py
@@ -104,6 +104,53 @@ def test_skill_points_at_an_adr_template(layer: str, skill: Path):
     )
 
 
+# ---------------------------------------------------------------------------
+# The agent must never write `Accepted`
+# ---------------------------------------------------------------------------
+#
+# This is the payload half of the approval-attestation decision. A CI gate that
+# catches an agent-typed `Accepted` after the fact is cleanup; the record still
+# says whatever the agent wrote. `Accepted` is a derived state — true because an
+# approver named in governance/approval_policy.yaml approved that decision at
+# that commit — so the only status an author can honestly write is `Proposed`.
+#
+# AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md §2 lists ADR-must-be-Accepted as the only
+# "No. Hard stop." for an autonomous agent, precisely because nothing let a
+# non-human set it. After this, nothing lets a *human* set it by typing either.
+
+STATUS_MENU = "Proposed | Accepted | Rejected | Superseded"
+POLICY_PATH = "governance/approval_policy.yaml"
+GATE_JOB = "adr-approval-check"
+
+
+@pytest.mark.parametrize("layer, skill", ADR_SKILLS, ids=lambda v: v if isinstance(v, str) else _rel(v))
+def test_skill_does_not_hand_the_agent_the_status_menu(layer: str, skill: Path):
+    """The template offers the vocabulary because a human reads it and picks.
+    Repeating the menu in the skill is what let an agent pick `Accepted`."""
+    assert STATUS_MENU not in skill.read_text(encoding="utf-8"), (
+        f"{_rel(skill)} hands the agent the full status vocabulary, so nothing "
+        f"stops it writing '{GATE_TOKEN}' — the one status it cannot earn"
+    )
+
+
+@pytest.mark.parametrize("layer, skill", ADR_SKILLS, ids=lambda v: v if isinstance(v, str) else _rel(v))
+def test_skill_tells_the_agent_to_author_proposed(layer: str, skill: Path):
+    assert "Proposed" in skill.read_text(encoding="utf-8"), (
+        f"{_rel(skill)} never names the one status an author may write"
+    )
+
+
+@pytest.mark.parametrize("layer, skill", ADR_SKILLS, ids=lambda v: v if isinstance(v, str) else _rel(v))
+def test_skill_names_where_approval_authority_lives(layer: str, skill: Path):
+    """An instruction not to write `Accepted` is a rule in prose — the exact
+    prohibited pattern AUTHORITY_AND_APPROVAL_CONTRACT.md names ('permission
+    declarations inside prompt text') if it is not backed by something real. The
+    skill must point at the policy and the gate that enforce it."""
+    text = skill.read_text(encoding="utf-8")
+    assert POLICY_PATH in text, f"{_rel(skill)} does not reference {POLICY_PATH}"
+    assert GATE_JOB in text, f"{_rel(skill)} does not name the {GATE_JOB} gate"
+
+
 @pytest.mark.parametrize("layer", ["backend", "ui"])
 def test_adr_skill_body_parity_across_agents(layer: str):
     """[[feedback_agent_parity]] — the ADR skill must not drift between agents."""

--- a/tests/test_adr_contract_consistency.py
+++ b/tests/test_adr_contract_consistency.py
@@ -151,6 +151,75 @@ def test_skill_names_where_approval_authority_lives(layer: str, skill: Path):
     assert GATE_JOB in text, f"{_rel(skill)} does not name the {GATE_JOB} gate"
 
 
+# ---------------------------------------------------------------------------
+# The templates' Approval section
+# ---------------------------------------------------------------------------
+#
+# `## Status` and `## Approval` sat ~140 lines apart, unlinked, and Approval was
+# three empty colon-terminated labels bound to no identity, no date and no
+# commit. A name typed on one of those lines is not an approval — it is the
+# prohibited pattern "treating chat acknowledgment ... as approval" written down.
+
+ALL_ADR_TEMPLATES = ADR_TEMPLATES | {
+    "data": REPO_ROOT / "docs" / "data" / "architecture" / "ADR" / "TEMPLATE.md",
+}
+
+# The numbered prefix differs by layer (UI numbers Approval `## 11.`), so match
+# it the way cli/approval.py does rather than by an exact heading.
+APPROVAL_HEADING_RE = re.compile(
+    r"^##\s+(?:\d+\.\s*)?Approval\b.*$", re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _approval_section(layer: str) -> str:
+    text = ALL_ADR_TEMPLATES[layer].read_text(encoding="utf-8")
+    match = APPROVAL_HEADING_RE.search(text)
+    assert match, f"{_rel(ALL_ADR_TEMPLATES[layer])} has no Approval section"
+    nxt = re.search(r"^##\s", text[match.end():], re.MULTILINE)
+    return text[match.end():match.end() + nxt.start()] if nxt else text[match.end():]
+
+
+def test_every_layer_ships_an_adr_template():
+    """Non-vacuous guard for the parametrized tests below."""
+    assert len(ALL_ADR_TEMPLATES) == 3
+    for path in ALL_ADR_TEMPLATES.values():
+        assert path.is_file(), f"missing {_rel(path)}"
+
+
+@pytest.mark.parametrize("layer", sorted(ALL_ADR_TEMPLATES))
+def test_approval_section_offers_no_name_field_to_fill_in(layer: str):
+    """`Approved by:` invites a typed name to stand in for an approval."""
+    section = _approval_section(layer)
+    assert "Approved by:" not in section, (
+        f"{_rel(ALL_ADR_TEMPLATES[layer])} still offers an 'Approved by:' field — "
+        "a name typed there is bound to no identity, no date and no commit"
+    )
+
+
+@pytest.mark.parametrize("layer", sorted(ALL_ADR_TEMPLATES))
+def test_approval_section_says_where_the_approval_actually_comes_from(layer: str):
+    section = _approval_section(layer)
+    for expected in ("governance/approval_policy.yaml", "adr-approval-check"):
+        assert expected in section, (
+            f"{_rel(ALL_ADR_TEMPLATES[layer])} Approval section never mentions "
+            f"{expected}, so a reader cannot tell what makes this ADR Accepted"
+        )
+
+
+@pytest.mark.parametrize("layer", sorted(ALL_ADR_TEMPLATES))
+def test_status_section_is_linked_to_the_approval_it_derives_from(layer: str):
+    """The two sections were ~140 lines apart and unlinked. A reader who sees
+    the vocabulary menu has to be told that one of those words is not theirs."""
+    text = ALL_ADR_TEMPLATES[layer].read_text(encoding="utf-8")
+    status = re.search(r"^## Status\s*\n(.+)$", text, re.MULTILINE)
+    nxt = re.search(r"^##\s", text[status.end():], re.MULTILINE)
+    body = text[status.end():status.end() + nxt.start()]
+    assert "derived" in body.lower(), (
+        f"{_rel(ALL_ADR_TEMPLATES[layer])} Status section does not say that "
+        f"'{GATE_TOKEN}' is derived rather than typed"
+    )
+
+
 @pytest.mark.parametrize("layer", ["backend", "ui"])
 def test_adr_skill_body_parity_across_agents(layer: str):
     """[[feedback_agent_parity]] — the ADR skill must not drift between agents."""

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -308,6 +308,29 @@ class TestPolicyChecks:
         assert not issues
         assert any("not configured" in w for w in warnings), warnings
 
+    @pytest.mark.parametrize(
+        "login", ["your_approver_login", "Your_Approver_Login", "  YOUR_APPROVER_LOGIN "],
+    )
+    def test_the_sentinel_is_recognised_whatever_its_casing(self, tmp_path, login):
+        """Platform logins are case-insensitive; Python string equality is not.
+        A sentinel that slipped through on casing alone would read as configured
+        while authorising an account that does not exist."""
+        _install_policy(
+            tmp_path, {"version": 1, "approvers": [{"login": login, "role": "approver"}]},
+        )
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert any("not configured" in w for w in warnings), warnings
+
+    def test_a_real_login_is_not_mistaken_for_the_sentinel(self, tmp_path):
+        """Non-vacuous guard: folding must widen nothing but case."""
+        _install_policy(
+            tmp_path,
+            {"version": 1,
+             "approvers": [{"login": "your_approver_login_2", "role": "approver"}]},
+        )
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert not any("not configured" in w for w in warnings), warnings
+
     def test_reviewers_alone_do_not_configure_attestation(self, tmp_path):
         """AUTHORITY_AND_APPROVAL_CONTRACT.md: 'a reviewer does not gain
         approval authority'. A policy of reviewers authorises nobody."""

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -1,0 +1,148 @@
+"""ADR approval attestation — the shipped policy and the checks that read it.
+
+`Accepted` on an ADR was a word someone typed. The L4 governance rule gates
+implementation on it and nothing in `cli/` or `ci/` had ever read it, while the
+templates' `## Status` and `## Approval` sections sat ~140 lines apart, unlinked,
+with Approval three empty colon-terminated labels bound to no identity, no date,
+no commit.
+
+`AUTHORITY_AND_APPROVAL_CONTRACT.md` — which govkit ships to govern the agent
+systems its users build — lists among prohibited patterns "permission
+declarations inside prompt text" and "approval by an unauthorized identity", and
+requires an approval be scoped, identity-bound, time-bounded and evidence-linked.
+`governance/approval_policy.yaml` is what turns an authenticated review into an
+approval: without a policy saying *this identity holds the Approver role*, the
+design collapses the distinction the contract requires.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POLICY_SRC = REPO_ROOT / "governance" / "approval_policy.yaml"
+SCHEMA_SRC = REPO_ROOT / "governance" / "schemas" / "approval_policy.schema.json"
+AGENTS = ("claude-code", "codex", "copilot")
+
+# The value a fresh install ships, mirroring repo-scope-check's REPO_OWNER and
+# the fix-lane gate's SOURCE_PATHS: inert until a team edits it.
+SENTINEL = "YOUR_APPROVER_LOGIN"
+
+
+def _policy() -> dict:
+    return yaml.safe_load(POLICY_SRC.read_text(encoding="utf-8"))
+
+
+class TestShippedPolicy:
+    def test_policy_ships(self):
+        assert POLICY_SRC.is_file(), f"missing {POLICY_SRC.relative_to(REPO_ROOT)}"
+
+    def test_policy_validates_against_the_shipped_schema(self):
+        jsonschema = pytest.importorskip("jsonschema")
+        schema = json.loads(SCHEMA_SRC.read_text(encoding="utf-8"))
+        errors = list(
+            jsonschema.Draft202012Validator(schema).iter_errors(_policy())
+        )
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_policy_carries_the_sentinel_login(self):
+        """A fresh install must stay green. govkit cannot know a customer's
+        approvers, and guessing one would be the prohibited pattern itself."""
+        logins = [a["login"] for a in _policy()["approvers"]]
+        assert SENTINEL in logins, logins
+
+    def test_every_shipped_entry_is_the_sentinel(self):
+        """No real login may ship — an unedited policy must authorise nobody."""
+        logins = [a["login"] for a in _policy()["approvers"]]
+        assert set(logins) == {SENTINEL}, logins
+
+    def test_the_sentinel_holds_the_approver_role(self):
+        """Editing the login is the whole setup step. If the shipped entry were
+        a reviewer, a team that edited only the login would still authorise
+        nobody and never learn why."""
+        entry = next(a for a in _policy()["approvers"] if a["login"] == SENTINEL)
+        assert entry["role"] == "approver"
+
+    def test_policy_version_is_an_integer(self):
+        """House convention, asserted here too so the shipped instance cannot
+        drift from the schema it is validated against."""
+        assert isinstance(_policy()["version"], int)
+
+
+class TestPolicyShipsToTargets:
+    """The schema is govkit's; the policy is the customer's.
+
+    That split is the whole point of the two install categories: `governed`
+    files are refreshed by `govkit upgrade`, `shared` files are skipped when
+    present. A policy in `governed` would have its approver list overwritten by
+    the next upgrade — silently reverting a repo to authorising nobody.
+    """
+
+    def _entries(self, agent: str, key: str) -> set[str]:
+        manifest = json.loads(
+            (REPO_ROOT / "agents" / agent / "manifest.json").read_text(encoding="utf-8")
+        )
+        found: set[str] = set()
+
+        def walk(node, level: str | None):
+            if isinstance(node, dict):
+                for k, v in node.items():
+                    if k in ("level_4", "level_5"):
+                        walk(v, k)
+                    elif k == key and isinstance(v, list) and level:
+                        found.update(v)
+                    else:
+                        walk(v, level)
+            elif isinstance(node, list):
+                for v in node:
+                    walk(v, level)
+
+        walk(manifest["variants"], None)
+        return found
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    def test_schema_is_governed(self, agent):
+        assert "governance/schemas/approval_policy.schema.json" in self._entries(
+            agent, "governed",
+        ), agent
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    def test_policy_is_shared_not_governed(self, agent):
+        assert "governance/approval_policy.yaml" in self._entries(agent, "shared"), agent
+        assert "governance/approval_policy.yaml" not in self._entries(
+            agent, "governed",
+        ), (
+            f"{agent} installs the approval policy as a governed contract — "
+            "`govkit upgrade` would overwrite the team's approver list"
+        )
+
+    # data is an L3/L4 shape — dbt has no L5 GenAI-ops tier, so the data type
+    # declares no level_5 and resolves to an empty set there.
+    TYPE_LEVELS = [
+        (t, lvl)
+        for t in ("api", "cli", "ui-react", "ui-angular", "ui-nextjs", "data")
+        for lvl in ("4", "5")
+        if not (t == "data" and lvl == "5")
+    ]
+
+    @pytest.mark.parametrize("agent", AGENTS)
+    def test_every_project_type_receives_both(self, agent):
+        """Every type ships an ADR template, so every type needs the policy that
+        makes its `Accepted` status derivable."""
+        from cli.manifest import load_manifest, resolve_variant_files
+
+        manifest = load_manifest(agent)
+        for project_type, level in self.TYPE_LEVELS:
+            _files, shared, governed = resolve_variant_files(
+                manifest,
+                {"level": level, "type": project_type, "ci": "github",
+                 "stack": "python-dbt" if project_type == "data" else "python-fastapi"},
+            )
+            assert "governance/approval_policy.yaml" in shared, (
+                f"{agent} {project_type} L{level}"
+            )
+            assert "governance/schemas/approval_policy.schema.json" in governed, (
+                f"{agent} {project_type} L{level}"
+            )

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -371,6 +371,26 @@ class TestAdrStatusChecks:
         )
         assert check_approval_policy(tmp_path) == ([], [])
 
+    def test_template_boilerplate_is_not_an_approval_record(self, tmp_path):
+        """The commonest way to write an ADR is to copy TEMPLATE.md. Whatever
+        govkit prints in its Approval section arrives in every ADR built that
+        way, so if that text counted, the check would go silent for exactly the
+        ADRs it exists to look at."""
+        template = (
+            REPO_ROOT / "docs" / "backend" / "architecture" / "ADR" / "TEMPLATE.md"
+        ).read_text(encoding="utf-8")
+        copied = template.replace(
+            "Proposed | Accepted | Rejected | Superseded", "Accepted", 1,
+        )
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        path = tmp_path / "docs" / "backend" / "architecture" / "ADR" / "0001-alpha.md"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(copied, encoding="utf-8")
+
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert any("0001-alpha.md" in w for w in warnings), warnings
+
     def test_a_govkit_authored_unmodified_adr_is_silent(self, tmp_path):
         """govkit ships exactly one real ADR — data's 0001 — with no Approval
         section at all. Requiring a customer's approver to attest a decision

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -21,6 +21,13 @@ from pathlib import Path
 import pytest
 import yaml
 
+from cli.approval import (
+    check_approval_policy,
+    discover_adrs,
+    parse_adr_status,
+)
+from cli.headers import format_editable_header
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 POLICY_SRC = REPO_ROOT / "governance" / "approval_policy.yaml"
 SCHEMA_SRC = REPO_ROOT / "governance" / "schemas" / "approval_policy.schema.json"
@@ -146,3 +153,261 @@ class TestPolicyShipsToTargets:
             assert "governance/schemas/approval_policy.schema.json" in governed, (
                 f"{agent} {project_type} L{level}"
             )
+
+
+# ---------------------------------------------------------------------------
+# The working-tree half: cli/approval.py
+# ---------------------------------------------------------------------------
+
+
+def _write_adr(
+    target: Path, name: str, status: str = "Accepted",
+    area: str = "backend", approval: str | None = None,
+    heading: str = "## 10. Approval",
+    govkit_authored: bool = False,
+) -> Path:
+    body = f"# ADR-0001: {name}\n\n## Status\n{status}\n\n## 1. Context\n\nWhy.\n"
+    if approval is not None:
+        body += f"\n{heading}\n{approval}\n"
+    if govkit_authored:
+        from cli.headers import compute_body_hash
+
+        body = format_editable_header(
+            baseline="0.18.0", body_hash=compute_body_hash(body),
+        ) + body
+    path = target / "docs" / area / "architecture" / "ADR" / f"{name}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _install_policy(target: Path, data: dict | str | None = None) -> Path:
+    """Mirror what `govkit apply` ships. `None` installs the real shipped file."""
+    path = target / "governance" / "approval_policy.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if data is None:
+        path.write_text(POLICY_SRC.read_text(encoding="utf-8"), encoding="utf-8")
+    elif isinstance(data, str):
+        path.write_text(data, encoding="utf-8")
+    else:
+        path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _install_schema(target: Path) -> None:
+    dest = target / "governance" / "schemas"
+    dest.mkdir(parents=True, exist_ok=True)
+    (dest / "approval_policy.schema.json").write_text(
+        SCHEMA_SRC.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+def _configured(login: str = "octo-architect") -> dict:
+    return {"version": 1, "approvers": [{"login": login, "role": "approver"}]}
+
+
+class TestDiscovery:
+    def test_no_docs_tree_is_silent(self, tmp_path):
+        assert discover_adrs(tmp_path) == []
+
+    def test_finds_adrs_under_every_area(self, tmp_path):
+        _write_adr(tmp_path, "0001-alpha", area="backend")
+        _write_adr(tmp_path, "0002-beta", area="data")
+        _write_adr(tmp_path, "0003-gamma", area="ui")
+        assert [p.name for p in discover_adrs(tmp_path)] == [
+            "0001-alpha.md", "0002-beta.md", "0003-gamma.md",
+        ]
+
+    def test_excludes_the_template(self, tmp_path):
+        _write_adr(tmp_path, "0001-alpha")
+        _write_adr(tmp_path, "TEMPLATE")
+        assert [p.name for p in discover_adrs(tmp_path)] == ["0001-alpha.md"]
+
+    def test_ignores_non_markdown_and_other_doc_dirs(self, tmp_path):
+        _write_adr(tmp_path, "0001-alpha")
+        (tmp_path / "docs" / "backend" / "architecture" / "ADR" / "notes.txt").write_text(
+            "x", encoding="utf-8",
+        )
+        stray = tmp_path / "docs" / "backend" / "architecture" / "BOUNDARIES.md"
+        stray.write_text("## Status\nAccepted\n", encoding="utf-8")
+        assert [p.name for p in discover_adrs(tmp_path)] == ["0001-alpha.md"]
+
+
+class TestStatusParsing:
+    def test_reads_the_status_line(self, tmp_path):
+        path = _write_adr(tmp_path, "0001-alpha", status="Accepted")
+        assert parse_adr_status(path.read_text(encoding="utf-8")) == "Accepted"
+
+    def test_reads_a_non_accepted_status(self, tmp_path):
+        path = _write_adr(tmp_path, "0001-alpha", status="Proposed")
+        assert parse_adr_status(path.read_text(encoding="utf-8")) == "Proposed"
+
+    def test_unparseable_status_is_none(self):
+        assert parse_adr_status("# ADR-0001\n\nno status here\n") is None
+
+    def test_the_shipped_template_vocabulary_line_is_not_an_accepted_claim(self):
+        """`Proposed | Accepted | Rejected | Superseded` is a menu, not a claim."""
+        text = "# ADR-XXX\n\n## Status\nProposed | Accepted | Rejected | Superseded\n"
+        assert parse_adr_status(text) != "Accepted"
+
+
+class TestPolicyChecks:
+    def test_silent_when_nothing_is_installed(self, tmp_path):
+        """A repo with no ADRs and no policy hears nothing — absence is not a
+        finding, the same contract the defect lane carries."""
+        assert check_approval_policy(tmp_path) == ([], [])
+
+    def test_adrs_without_a_policy_warn(self, tmp_path):
+        _write_adr(tmp_path, "0001-alpha")
+        issues, warnings = check_approval_policy(tmp_path)
+        assert not issues
+        assert any("approval_policy.yaml" in w for w in warnings), warnings
+
+    def test_unparseable_policy_is_an_issue(self, tmp_path):
+        _install_policy(tmp_path, "version: 1\napprovers: [oops\n")
+        issues, _warnings = check_approval_policy(tmp_path)
+        assert any("could not be parsed" in i for i in issues), issues
+
+    def test_policy_that_is_not_a_mapping_is_an_issue(self, tmp_path):
+        _install_policy(tmp_path, "- just\n- a\n- list\n")
+        issues, _warnings = check_approval_policy(tmp_path)
+        assert issues
+
+    def test_missing_approvers_key_is_an_issue(self, tmp_path):
+        _install_policy(tmp_path, "version: 1\n")
+        issues, _warnings = check_approval_policy(tmp_path)
+        assert any("approvers" in i for i in issues), issues
+
+    def test_unedited_sentinel_policy_warns_that_attestation_is_unconfigured(
+        self, tmp_path,
+    ):
+        """The shipped file authorises nobody by design. Saying so is the point:
+        a repo must not read 'no findings' as 'attestation is on'."""
+        _install_policy(tmp_path)
+        issues, warnings = check_approval_policy(tmp_path)
+        assert not issues
+        assert any("not configured" in w for w in warnings), warnings
+
+    def test_empty_approver_list_warns(self, tmp_path):
+        _install_policy(tmp_path, {"version": 1, "approvers": []})
+        issues, warnings = check_approval_policy(tmp_path)
+        assert not issues
+        assert any("not configured" in w for w in warnings), warnings
+
+    def test_reviewers_alone_do_not_configure_attestation(self, tmp_path):
+        """AUTHORITY_AND_APPROVAL_CONTRACT.md: 'a reviewer does not gain
+        approval authority'. A policy of reviewers authorises nobody."""
+        _install_policy(
+            tmp_path,
+            {"version": 1, "approvers": [{"login": "octo-qa", "role": "reviewer"}]},
+        )
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert any("not configured" in w for w in warnings), warnings
+
+    def test_a_configured_policy_is_silent(self, tmp_path):
+        _install_schema(tmp_path)
+        _install_policy(tmp_path, _configured())
+        assert check_approval_policy(tmp_path) == ([], [])
+
+    def test_schema_violation_is_an_issue_when_the_schema_is_installed(self, tmp_path):
+        _install_schema(tmp_path)
+        _install_policy(
+            tmp_path,
+            {"version": 1, "approvers": [{"login": "octo", "role": "wizard"}]},
+        )
+        issues, _warnings = check_approval_policy(tmp_path)
+        assert any("approval_policy.schema.json" in i for i in issues), issues
+
+    def test_missing_schema_reduces_coverage_visibly(self, tmp_path):
+        """Three-tier degradation, as check_eval_criteria established: reduced
+        coverage is a warning, never a silent pass."""
+        _install_policy(tmp_path, _configured())
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert any("no approval_policy schema installed" in w for w in warnings), warnings
+
+
+class TestAdrStatusChecks:
+    def test_a_proposed_adr_is_silent(self, tmp_path):
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        _write_adr(tmp_path, "0001-alpha", status="Proposed")
+        assert check_approval_policy(tmp_path) == ([], [])
+
+    def test_accepted_without_an_approval_section_warns(self, tmp_path):
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        _write_adr(tmp_path, "0001-alpha", status="Accepted")
+        issues, warnings = check_approval_policy(tmp_path)
+        assert not issues, "migration posture: warn on pre-existing, never fail"
+        assert any("0001-alpha.md" in w for w in warnings), warnings
+
+    def test_an_empty_approval_section_does_not_count(self, tmp_path):
+        """The shipped template's three empty colon-terminated labels are bound
+        to no identity, no date and no commit — that is the defect, not the fix."""
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        _write_adr(
+            tmp_path, "0001-alpha",
+            approval="Approved by:\n- Architect:\n- Security (if applicable):",
+        )
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert any("0001-alpha.md" in w for w in warnings), warnings
+
+    @pytest.mark.parametrize(
+        "heading",
+        ["## 10. Approval", "## 11. Approval", "## Approval", "## Review"],
+    )
+    def test_both_shipped_vocabularies_and_the_numbered_prefix_are_accepted(
+        self, tmp_path, heading,
+    ):
+        """The templates emit `## 10. Approval` (UI numbers it `## 11.`) while the
+        adr-author skill teaches `## Review`. Both ship from govkit, so a
+        customer's ADR may carry either."""
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        _write_adr(
+            tmp_path, "0001-alpha", heading=heading,
+            approval="Approved by @octo-architect in PR #12 at 2f8c1ab.",
+        )
+        assert check_approval_policy(tmp_path) == ([], [])
+
+    def test_a_govkit_authored_unmodified_adr_is_silent(self, tmp_path):
+        """govkit ships exactly one real ADR — data's 0001 — with no Approval
+        section at all. Requiring a customer's approver to attest a decision
+        govkit made for them is incoherent, and would have failed every data
+        repo on the next upgrade."""
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        _write_adr(tmp_path, "0001-alpha", area="data", govkit_authored=True)
+        assert check_approval_policy(tmp_path) == ([], [])
+
+    def test_an_edited_govkit_adr_is_the_customers_again(self, tmp_path):
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        path = _write_adr(tmp_path, "0001-alpha", area="data", govkit_authored=True)
+        path.write_text(
+            path.read_text(encoding="utf-8") + "\n## 2. Decision\n\nOurs now.\n",
+            encoding="utf-8",
+        )
+        _issues, warnings = check_approval_policy(tmp_path)
+        assert any("0001-alpha.md" in w for w in warnings), warnings
+
+    def test_require_approval_for_scopes_which_adrs_are_checked(self, tmp_path):
+        _install_policy(
+            tmp_path,
+            _configured() | {"require_approval_for": ["docs/backend/"]},
+        )
+        _install_schema(tmp_path)
+        _write_adr(tmp_path, "0001-alpha", area="backend")
+        _write_adr(tmp_path, "0002-beta", area="data")
+        _issues, warnings = check_approval_policy(tmp_path)
+        joined = " ".join(warnings)
+        assert "0001-alpha.md" in joined and "0002-beta.md" not in joined, warnings
+
+    def test_never_raises_on_an_unreadable_adr(self, tmp_path):
+        _install_policy(tmp_path, _configured())
+        _install_schema(tmp_path)
+        path = _write_adr(tmp_path, "0001-alpha")
+        path.write_bytes(b"\xff\xfe\x00bad")
+        issues, warnings = check_approval_policy(tmp_path)
+        assert any("0001-alpha.md" in m for m in issues + warnings)

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -206,6 +206,20 @@ def _configured(login: str = "octo-architect") -> dict:
     return {"version": 1, "approvers": [{"login": login, "role": "approver"}]}
 
 
+# `check-jsonschema` is an optional extra — `cli/fixes.py` established it as
+# opt-in, and it is deliberately absent from `[test]`, so CI runs without it.
+# Whether it is installed is a property of the machine, not of the behavior
+# under test, so assertions about findings drop its degradation warning.
+# The three tiers of that degradation are covered directly in
+# TestSchemaValidationTiers, without needing the binary.
+_TOOLING_WARNING = "instance validation skipped"
+
+
+def _findings(target: Path) -> tuple[list[str], list[str]]:
+    issues, warnings = check_approval_policy(target)
+    return issues, [w for w in warnings if _TOOLING_WARNING not in w]
+
+
 class TestDiscovery:
     def test_no_docs_tree_is_silent(self, tmp_path):
         assert discover_adrs(tmp_path) == []
@@ -255,7 +269,7 @@ class TestPolicyChecks:
     def test_silent_when_nothing_is_installed(self, tmp_path):
         """A repo with no ADRs and no policy hears nothing — absence is not a
         finding, the same contract the defect lane carries."""
-        assert check_approval_policy(tmp_path) == ([], [])
+        assert _findings(tmp_path) == ([], [])
 
     def test_adrs_without_a_policy_warn(self, tmp_path):
         _write_adr(tmp_path, "0001-alpha")
@@ -307,23 +321,65 @@ class TestPolicyChecks:
     def test_a_configured_policy_is_silent(self, tmp_path):
         _install_schema(tmp_path)
         _install_policy(tmp_path, _configured())
-        assert check_approval_policy(tmp_path) == ([], [])
+        assert _findings(tmp_path) == ([], [])
 
-    def test_schema_violation_is_an_issue_when_the_schema_is_installed(self, tmp_path):
+
+class TestSchemaValidationTiers:
+    """The three-tier degradation `check_eval_criteria` established: a real
+    failure is an issue, a missing schema or absent validator is a visible
+    warning, and neither is ever a silent pass.
+
+    `check-jsonschema` is an optional extra — `cli/fixes.py` established it as
+    opt-in and it is not in `[test]`, so it is absent on CI and usually present
+    on a developer's machine. Asserting an outcome that depends on which of
+    those you are sitting at is not a test of anything, so the validator is
+    driven directly rather than being required or skipped around.
+    """
+
+    def _invalid_policy(self, tmp_path: Path) -> None:
         _install_schema(tmp_path)
         _install_policy(
             tmp_path,
             {"version": 1, "approvers": [{"login": "octo", "role": "wizard"}]},
         )
+
+    def test_a_reported_violation_becomes_an_issue(self, tmp_path, monkeypatch):
+        import subprocess
+
+        self._invalid_policy(tmp_path)
+        monkeypatch.setattr(
+            "cli.approval.subprocess.run",
+            lambda *a, **k: subprocess.CompletedProcess(
+                a[0], 1, stdout="approvers[0].role: 'wizard' is not one of [...]\n",
+                stderr="",
+            ),
+        )
         issues, _warnings = check_approval_policy(tmp_path)
         assert any("approval_policy.schema.json" in i for i in issues), issues
 
-    def test_missing_schema_reduces_coverage_visibly(self, tmp_path):
-        """Three-tier degradation, as check_eval_criteria established: reduced
-        coverage is a warning, never a silent pass."""
+    def test_an_absent_validator_reduces_coverage_visibly(self, tmp_path, monkeypatch):
+        self._invalid_policy(tmp_path)
+        monkeypatch.setattr(
+            "cli.approval.subprocess.run",
+            lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError()),
+        )
+        issues, warnings = check_approval_policy(tmp_path)
+        assert not issues
+        assert any("check-jsonschema" in w for w in warnings), warnings
+
+    def test_a_missing_schema_reduces_coverage_visibly(self, tmp_path):
+        """No monkeypatch needed: the schema file simply is not installed."""
         _install_policy(tmp_path, _configured())
         _issues, warnings = check_approval_policy(tmp_path)
         assert any("no approval_policy schema installed" in w for w in warnings), warnings
+
+    def test_the_real_validator_accepts_the_shipped_policy(self, tmp_path):
+        """Runs whichever tier this machine offers, and proves the plumbing
+        produces no *issue* for a valid policy either way."""
+        _install_schema(tmp_path)
+        _install_policy(tmp_path, _configured())
+        issues, _warnings = check_approval_policy(tmp_path)
+        assert not issues, issues
 
 
 class TestAdrStatusChecks:
@@ -331,7 +387,7 @@ class TestAdrStatusChecks:
         _install_policy(tmp_path, _configured())
         _install_schema(tmp_path)
         _write_adr(tmp_path, "0001-alpha", status="Proposed")
-        assert check_approval_policy(tmp_path) == ([], [])
+        assert _findings(tmp_path) == ([], [])
 
     def test_accepted_without_an_approval_section_warns(self, tmp_path):
         _install_policy(tmp_path, _configured())
@@ -369,7 +425,7 @@ class TestAdrStatusChecks:
             tmp_path, "0001-alpha", heading=heading,
             approval="Approved by @octo-architect in PR #12 at 2f8c1ab.",
         )
-        assert check_approval_policy(tmp_path) == ([], [])
+        assert _findings(tmp_path) == ([], [])
 
     def test_template_boilerplate_is_not_an_approval_record(self, tmp_path):
         """The commonest way to write an ADR is to copy TEMPLATE.md. Whatever
@@ -399,7 +455,7 @@ class TestAdrStatusChecks:
         _install_policy(tmp_path, _configured())
         _install_schema(tmp_path)
         _write_adr(tmp_path, "0001-alpha", area="data", govkit_authored=True)
-        assert check_approval_policy(tmp_path) == ([], [])
+        assert _findings(tmp_path) == ([], [])
 
     def test_an_edited_govkit_adr_is_the_customers_again(self, tmp_path):
         _install_policy(tmp_path, _configured())

--- a/tests/test_approval.py
+++ b/tests/test_approval.py
@@ -411,3 +411,93 @@ class TestAdrStatusChecks:
         path.write_bytes(b"\xff\xfe\x00bad")
         issues, warnings = check_approval_policy(tmp_path)
         assert any("0001-alpha.md" in m for m in issues + warnings)
+
+
+class TestValidateIntegration:
+    """`run_validation` gains a third artifact family, exactly as extensions and
+    the defect lane did: silent when absent, its own exit code, combined via
+    max(). No new command — the CLI should not grow one whose only real answer
+    lives in CI."""
+
+    def _target(self, tmp_path: Path, level: str = "4") -> Path:
+        (tmp_path / ".govkit").mkdir(parents=True, exist_ok=True)
+        (tmp_path / ".govkit" / "marker.json").write_text(
+            json.dumps({
+                "version": "0.18.0", "level": level, "agent": "claude-code",
+                "options": {"type": "api", "ci": "github"},
+                "applied_at": "2026-08-13T00:00:00Z",
+            }),
+            encoding="utf-8",
+        )
+        # Empty features/ isolates the approval checks: list_user_features
+        # returns [], so nothing else can move the exit code.
+        (tmp_path / "features").mkdir(exist_ok=True)
+        return tmp_path
+
+    def test_absent_attestation_is_silent(self, tmp_path, capsys):
+        """A repo with neither ADRs nor a policy sees no output change."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        assert run_validation(target) == 0
+        assert "approval" not in capsys.readouterr().out.lower()
+
+    def test_a_configured_policy_is_reported_as_passing(self, tmp_path, capsys):
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        _install_schema(target)
+        _install_policy(target, _configured())
+        assert run_validation(target) == 0
+        assert "approval_policy.yaml" in capsys.readouterr().out
+
+    def test_an_accepted_adr_without_provenance_warns_without_failing(
+        self, tmp_path, capsys,
+    ):
+        """Migration posture: warn on pre-existing, fail on changed. Only CI
+        sees 'changed', so validate never fails on this."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        _install_schema(target)
+        _install_policy(target, _configured())
+        _write_adr(target, "0001-alpha")
+        assert run_validation(target) == 0
+        assert "0001-alpha.md" in capsys.readouterr().out
+
+    def test_a_malformed_policy_fails_the_run(self, tmp_path):
+        """The policy is what makes an approval an approval. A broken one means
+        the repo cannot derive Accepted at all, so this is not a warning."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        _install_policy(target, "- not\n- a mapping\n")
+        assert run_validation(target) == 1
+
+    def test_not_checked_at_l3(self, tmp_path, capsys):
+        """L3 receives neither the policy nor the gate; the attestation model
+        starts at L4 beside the contract that gates on Accepted."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path, level="3")
+        _install_policy(target, "- not\n- a mapping\n")
+        assert run_validation(target) == 0
+
+    def test_checked_at_l5(self, tmp_path):
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path, level="5")
+        _install_policy(target, "- not\n- a mapping\n")
+        assert run_validation(target) == 1
+
+    def test_a_govkit_authored_adr_alone_produces_no_finding(self, tmp_path, capsys):
+        """The case that matters: a fresh `--type data` install must not warn
+        about the ADR govkit put there."""
+        from cli.validate import run_validation
+
+        target = self._target(tmp_path)
+        _install_schema(target)
+        _install_policy(target, _configured())
+        _write_adr(target, "0001-data-features", area="data", govkit_authored=True)
+        assert run_validation(target) == 0
+        assert "0001-data-features" not in capsys.readouterr().out

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -4181,7 +4181,13 @@ class TestNoUiDimensionInManifests:
         assert "docs/ui/design/" in variant["governed"]
         assert "docs/ui/architecture/react/" not in variant["governed"]
         assert "docs/ui/architecture/angular/" not in variant["governed"]
-        assert variant["level_4"]["shared"] == ["features/starter_ui_nextjs/"]
+        # Isolation is about which *starters* land, so compare the features/
+        # entries rather than the whole list — shared also carries repo-wide
+        # governance every type receives (e.g. governance/approval_policy.yaml).
+        starters = [
+            e for e in variant["level_4"]["shared"] if e.startswith("features/")
+        ]
+        assert starters == ["features/starter_ui_nextjs/"]
         assert "features/ui_task_dashboard/" not in variant["level_4"]["shared"]
         assert "level_5" in variant
 

--- a/tests/test_govkit.py
+++ b/tests/test_govkit.py
@@ -4303,6 +4303,7 @@ class TestDataCiContract:
         # per-change artifact model, so neither applies there.
         l4_gates = [] if level == "3" else [
             f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/adr-approval-gate.yml",
             f"ci/{platform}/evidence-gate.yml",
         ]
         assert ci_governed == [repo_scope, data_common, *l4_gates]
@@ -4331,6 +4332,7 @@ class TestDataCiContract:
         assert ci_block["level_4"]["by_type"]["data"]["governed"] == [
             *expected,
             f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/adr-approval-gate.yml",
             f"ci/{platform}/evidence-gate.yml",
         ]
 
@@ -4454,6 +4456,7 @@ class TestPythonDbtCiGate:
         # per-change artifact model, so neither applies there.
         l4_gates = [] if level == "3" else [
             f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/adr-approval-gate.yml",
             f"ci/{platform}/evidence-gate.yml",
         ]
         assert ci_governed == [repo_scope, data_common, dbt_gate, *l4_gates]
@@ -4622,6 +4625,7 @@ class TestDatabricksCiGate:
         # per-change artifact model, so neither applies there.
         l4_gates = [] if level == "3" else [
             f"ci/{platform}/fix-lane-gate.yml",
+            f"ci/{platform}/adr-approval-gate.yml",
             f"ci/{platform}/evidence-gate.yml",
         ]
         assert ci_governed == [repo_scope, data_common, databricks_gate, *l4_gates]

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -960,3 +960,109 @@ class TestFixRecordSchema:
     def test_introduces_new_behavior_must_be_boolean(self):
         instance = self._valid_record() | {"introduces_new_behavior": "no"}
         assert self._errors(instance)
+
+
+# ---------------------------------------------------------------------------
+# Approval policy schema (ADR attestation)
+# ---------------------------------------------------------------------------
+
+APPROVAL_POLICY_SCHEMA_PATH = (
+    REPO_ROOT / "governance" / "schemas" / "approval_policy.schema.json"
+)
+
+
+class TestApprovalPolicySchema:
+    """The file that turns an authenticated review into an approval.
+
+    `Accepted` on an ADR is meant to be a derived state — true because an
+    authorised approver approved that decision at that commit. Nothing derives
+    it unless something first says *which identities hold approval authority*,
+    and AUTHORITY_AND_APPROVAL_CONTRACT.md is explicit that "a reviewer does not
+    gain approval authority". So the Reviewer / Approver split has to live in
+    the data, not only in the prose — hence a required `role` drawn from that
+    contract's vocabulary.
+
+    Area-agnostic like fix_record.schema.json: an ADR approval has the same
+    shape whether the repo is api, ui, or data.
+    """
+
+    def _schema(self) -> dict:
+        return json.loads(APPROVAL_POLICY_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    def _valid_policy(self) -> dict:
+        return {
+            "version": 1,
+            "approvers": [
+                {"login": "octo-architect", "role": "approver"},
+                {"login": "octo-security", "role": "reviewer"},
+            ],
+        }
+
+    def _errors(self, instance: dict) -> list:
+        return list(Draft202012Validator(self._schema()).iter_errors(instance))
+
+    def test_schema_is_valid_json_schema(self):
+        Draft202012Validator.check_schema(self._schema())
+
+    def test_valid_policy_validates(self):
+        errors = self._errors(self._valid_policy())
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_rejects_string_version(self):
+        """House convention: version is an integer, never a string."""
+        assert self._errors(self._valid_policy() | {"version": "1"})
+
+    def test_rejects_unknown_top_level_key(self):
+        assert self._errors(self._valid_policy() | {"approved_by": "me"})
+
+    def test_rejects_unknown_approver_key(self):
+        instance = self._valid_policy()
+        instance["approvers"][0]["email"] = "a@example.com"
+        assert self._errors(instance)
+
+    @pytest.mark.parametrize("field", ["version", "approvers"])
+    def test_top_level_fields_are_required(self, field):
+        instance = self._valid_policy()
+        del instance[field]
+        assert self._errors(instance), f"{field} should be required"
+
+    @pytest.mark.parametrize("field", ["login", "role"])
+    def test_every_approver_declares_a_login_and_a_role(self, field):
+        """A login with no role is exactly the collapse the authority contract
+        forbids — an identity in the file reads as authorised by being listed."""
+        instance = self._valid_policy()
+        del instance["approvers"][0][field]
+        assert self._errors(instance), f"approvers[].{field} should be required"
+
+    def test_rejects_a_role_outside_the_authority_contract_vocabulary(self):
+        instance = self._valid_policy()
+        instance["approvers"][0]["role"] = "owner"
+        assert self._errors(instance)
+
+    @pytest.mark.parametrize(
+        "role",
+        ["approver", "reviewer", "human-execution-owner", "accountable-principal"],
+    )
+    def test_accepts_every_role_the_authority_contract_names(self, role):
+        instance = self._valid_policy()
+        instance["approvers"][0]["role"] = role
+        errors = self._errors(instance)
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_rejects_an_empty_login(self):
+        instance = self._valid_policy()
+        instance["approvers"][0]["login"] = ""
+        assert self._errors(instance)
+
+    def test_accepts_an_empty_approver_list(self):
+        """A policy naming nobody is well-formed but authorises nobody. The
+        gate fails closed on it rather than the schema rejecting it, so the
+        message a team sees names the real problem."""
+        errors = self._errors(self._valid_policy() | {"approvers": []})
+        assert not errors, "\n".join(e.message for e in errors)
+
+    def test_scope_is_optional_and_constrains_which_adrs_a_login_may_approve(self):
+        instance = self._valid_policy()
+        instance["approvers"][0]["scope"] = ["docs/backend/architecture/ADR/"]
+        errors = self._errors(instance)
+        assert not errors, "\n".join(e.message for e in errors)


### PR DESCRIPTION
Implements `plans/APPROVAL_ATTESTATION_PLAN.md` — the third and last of the three decisions recorded in `AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md`. Decision 1 (defect lane) shipped in #134; decision 2 (measured evidence) in #135, corrected by #136.

## The problem

`Accepted` was a word someone typed into a markdown file. The L4 rules gate on it — *"ADRs … must be Accepted before implementation proceeds"* — and **nothing in `cli/` or `ci/` had ever read it**. The templates' `## Status` and `## Approval` sections sat ~140 lines apart, unlinked, and Approval was three empty colon-terminated labels bound to no identity, no date, no commit.

govkit forbids exactly this, in a contract it ships to govern the agent systems its *users* build. `AUTHORITY_AND_APPROVAL_CONTRACT.md` lists among prohibited patterns *"permission declarations inside prompt text"* and *"approval by an unauthorized identity"*. The delivery layer met none of it.

`Accepted` is now a **derived state**: true because an authorised approver approved *this decision* at *this commit*.

## What enforces it

| | Proves |
|---|---|
| `governance/approval_policy.yaml` + schema | which logins hold the **Approver** role — the mapping that turns a review into an approval |
| `cli/approval.py` → `govkit validate` | the policy is well-formed and names a real approver; which ADRs claim `Accepted` with no approval record |
| `ci/{github,azure}/adr-approval-gate.yml` | an approver in the policy approved **this ADR** at **this head SHA** |

Plus the payload half: the `adr-author` skill writes `Proposed` and stops, across all six files. Without it the record still says whatever the agent typed and the gate is cleanup after the fact.

`AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §2 listed ADR-must-be-Accepted as the only *"No. Hard stop."* for an autonomous agent, because nothing let a non-human set it. Nothing lets a *human* set it by typing either now.

## Why a policy file rather than "any approving review"

The authority contract separates Reviewer ("assesses evidence or content") from Approver ("commits a scoped consequential decision") and states plainly that **a reviewer does not gain approval authority**. Treating any authenticated review as an approval would collapse a distinction govkit's own contract requires, and land on *"approval by an unauthorized identity"*. The policy file is the mechanism, not paperwork.

## Migration: warn on pre-existing, fail on changed

**govkit ships exactly one real ADR, and it would have failed its own new rule.** `docs/data/architecture/ADR/0001-…` says `Accepted`, has no Approval section at all, and lands in every `--type data` install at L3, L4 and L5. A hard check would have failed every data customer's repo on their next upgrade — the exact defect class #133 existed to fix.

So a govkit-authored, unmodified ADR is skipped by both halves. The `govkit:editable` body hash already tells govkit's copy from an edited one, so no new mechanism was invented. Edit it and it becomes yours, approval and all.

## Three decisions the plan left open

- **Level: L4+**, mirroring the defect lane. The plan pointed at both shapes; L4 keeps attestation beside the contract that gates on `Accepted`.
- **Install category: the policy is `shared`, not `governed`** — the first non-`features/` shared entry in any manifest. Governed contracts are refreshed by `upgrade`, which would overwrite a team's approver list and silently revert the repo to authorising nobody. The schema stays governed: govkit owns the shape, the customer owns the identities. Verified against a real install — the edited list survives `upgrade --force`.
- **The gate never invokes govkit**, following `tests/test_fix_lane_gate_checks.py`'s argument: a blocking gate must not depend on an unpinned PyPI release, and one delegating to `govkit validate` could be switched off from inside the PR it is reviewing. So no `govkit~=` pin is carried. The duplicated status and body-hash logic is held in check by executing **both** platform embeddings against fixtures and pinning them byte-identical.

## One defect found and fixed during verification

Increment 7's Approval-section prose defeated increment 3's check. The commonest way to write an ADR is to copy `TEMPLATE.md`, so that text arrived in every ADR built that way and read as an approval record — silencing the check for exactly the ADRs it exists to look at. The guidance moved into an HTML comment, the device `check_nfrs_sections` already uses for the same reason. The CI gate was never affected; it requires a review, not a sentence.

## Honest limits, all documented in `ci/README.md`

- **govkit verifies; the platform enforces.** The gate proves an approval happened. Only branch protection can make the proof required, which is why the CODEOWNERS + required-review setup is part of the deliverable.
- **The gate only sees ADRs changed in the PR.** An `Accepted` ADR merged before adoption keeps its status. `govkit validate` warns about those so they stay visible; no upgrade turns them into a merge blocker retroactively.
- **Azure is weaker than GitHub and the gap could not be closed.** A GitHub review carries the `commit_id` it was submitted against; an Azure vote binds to the pull request, not the commit. The Azure template requires the *"Reset code reviewer votes when there are new changes"* branch policy and prints that on every run — but a team that skips it gets an approval that outlives its commit, and the gate cannot tell. It is also the first shipped Azure template to call a platform API.
- **The GitHub half carries the payload's first `permissions:` block** — `pull-requests: read`, with `contents: read` restated for checkout. No secret needed; team slugs would require `read:org` and a PAT, which is why the policy names logins.

**It fails closed.** Unlike every other opt-in gate, an unconfigured policy does not make this one inert: a PR setting an ADR to `Accepted` fails while the sentinel is still there. An ADR cannot be accepted in a repository that declares nobody able to accept it. A fresh install still stays green, because a PR that changes no ADR is untouched.

## Verification

- 2761 fast + 134 e2e passing; `pytest -k parity` green; all three agents in lockstep.
- The plan's sandbox walkthrough reproduced against the real CLI, including the case that matters: **a fresh `--type data` install says nothing about ADR-0001.**
- `ci/README.md` loses its *"ADR required when preflight flags it | No ADR validation"* gap row — that gap is what this closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
