### PR TITLE
fix(upgrade): stop reverting a team's stack to the bundled baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **`govkit upgrade` no longer reverts your stack to the bundled baseline**
+  (#132). The six architecture docs that vary by stack are installed from
+  `cli/stacks/<id>/` but live under `docs/<area>/architecture/`, a path every
+  manifest declares as `governed` — and upgrade re-installs governed contracts
+  with `skip_existing=False`. It overwrote each with the stack-agnostic copy
+  and re-stamped the header `baseline: govkit@<version>`. A Go, .NET, JVM or
+  Node team's architecture contracts silently became Python/FastAPI ones.
+  Upgrade now re-applies the marker's stack overlay after the governed refresh,
+  through the same edit-protection path, so a user-edited doc is still refused
+  and `--force` reinstates the stack's doc rather than the baseline.
+
+  The falsified baseline key mattered on its own: `doctor`'s D006 skips
+  `govkit@` baselines, so once every stack doc carried one, stale-overlay
+  detection reported nothing for the life of the repo.
+
+  The issue reported this as the `govkit:editable` guard missing local edits
+  after a "baseline key rename". There is no rename and the guard is sound — a
+  hashed, user-edited doc is correctly refused. `python-fastapi` ships the same
+  content as the baseline, so clobbering it changed the baseline key while
+  leaving the body hash identical, which is what the report observed.
+
 ### Added
 
 - **ADR approval attestation.** An ADR's `Accepted` status is now a derived

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -28,6 +28,59 @@ from .install_common import (
 )
 from .manifest import load_manifest, resolve_variant_files
 from .marker import _compare_version, read_govkit_marker, write_govkit_marker
+from .overlay import apply_overlay, load_overlay
+
+
+def _reapply_stack_overlay(
+    target: Path, stored: dict, prior_applied_at: str | None, force: bool,
+) -> None:
+    """Restore the team's stack docs after the governed refresh has run.
+
+    Six architecture docs vary by stack. They ship from `cli/stacks/<id>/` and
+    are installed by `apply_overlay`, but they *live* under
+    `docs/<area>/architecture/` — a path every manifest declares as `governed`.
+    Upgrade re-installs governed contracts with `skip_existing=False`, so
+    without this the stack-agnostic copy lands on top of the team's stack docs
+    and re-stamps the header `baseline: govkit@<version>`.
+
+    `apply` never had the problem: it copies governed paths with
+    `skip_existing=True`, so the overlay it wrote moments earlier survives.
+    Only upgrade overwrites, which is why this runs here and not there.
+
+    Two things were being lost (issue #132):
+      - the content, for every stack but `python-fastapi` — whose docs *are*
+        the baseline, which is why the reporter saw the baseline key change
+        while the body hash stayed identical;
+      - the baseline key, for all of them. `doctor`'s D006 only inspects
+        non-`govkit@` baselines, so a falsified key made stale-overlay
+        detection silently stop reporting.
+
+    Runs last, and through `apply_overlay`, so edit-protection still decides:
+    a user-edited doc is refused here exactly as it was during the governed
+    copy, and `--force` overwrites it with the stack's doc rather than the
+    baseline. Silent no-op when the marker records no stack, or names one this
+    govkit no longer bundles — a missing overlay must not abort an upgrade.
+    """
+    stack_id = (stored.get("stack") or {}).get("id")
+    if not stack_id:
+        return
+    overlay = load_overlay(stack_id)
+    if overlay is None:
+        print(
+            f"\n  warning: marker records stack '{stack_id}', which this govkit "
+            "does not bundle; its architecture docs now hold the stack-agnostic "
+            "baseline. Run `govkit stack list` and re-apply a current stack.",
+            file=sys.stderr,
+        )
+        return
+    print(f"\nStack overlay '{overlay.id}' (restored, edit-protected):")
+    copied = apply_overlay(
+        overlay, target, applied_at=prior_applied_at, force=force,
+    )
+    for dest in copied:
+        print(f"  copied  {dest}")
+    if not copied:
+        print("  (nothing to restore)")
 
 
 def _validate_stored_options(manifest: dict, stored_options: dict) -> None:
@@ -141,6 +194,8 @@ def cmd_upgrade(args: argparse.Namespace) -> None:
     copy_governed_or_shared(
         shared, target, prior_applied_at, args.force, baseline,
     )
+
+    _reapply_stack_overlay(target, stored, prior_applied_at, args.force)
 
     # Upgrade re-installs govkit's own files; it does not re-decide anything the
     # team decided. Carry stack/assumptions/calibration across or they reset to

--- a/cli/cmd_upgrade.py
+++ b/cli/cmd_upgrade.py
@@ -56,6 +56,8 @@ def _reapply_stack_overlay(
         detection silently stop reporting.
 
     Runs last, and through `apply_overlay`, so edit-protection still decides:
+    reporting is left to `copy_entry`, which is the only thing that knows
+    whether a given file was written, refused, or skipped.
     a user-edited doc is refused here exactly as it was during the governed
     copy, and `--force` overwrites it with the stack's doc rather than the
     baseline. Silent no-op when the marker records no stack, or names one this
@@ -74,13 +76,10 @@ def _reapply_stack_overlay(
         )
         return
     print(f"\nStack overlay '{overlay.id}' (restored, edit-protected):")
-    copied = apply_overlay(
-        overlay, target, applied_at=prior_applied_at, force=force,
-    )
-    for dest in copied:
-        print(f"  copied  {dest}")
-    if not copied:
-        print("  (nothing to restore)")
+    # No per-file echo here: copy_entry already prints `copied <dest>` for each
+    # file it writes and `refused <dest>` for each it declines, so restating
+    # them announced every restored doc twice.
+    apply_overlay(overlay, target, applied_at=prior_applied_at, force=force)
 
 
 def _validate_stored_options(manifest: dict, stored_options: dict) -> None:

--- a/cli/fs.py
+++ b/cli/fs.py
@@ -125,18 +125,24 @@ def _copy_file(
     src: Path, dest: Path,
     skip_existing: bool, applied_at: str | None, force: bool,
     header_baseline: str | None, header_see: str,
-) -> None:
-    """Copy a single file with edit-protection + header injection applied."""
+) -> bool:
+    """Copy a single file with edit-protection + header injection applied.
+
+    Returns True when the file was written, False when it was skipped or
+    refused, so callers can report what actually happened instead of inferring
+    it. See `copy_entry`.
+    """
     if skip_existing and dest.exists():
         print(f"  skipped {dest}  (already exists)")
-        return
+        return False
     if _copy_entry_should_refuse(dest, applied_at, force):
-        return
+        return False
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(src, dest)
     print(f"  copied  {dest}")
     if header_baseline is not None:
         prepend_header_to_file(dest, baseline=header_baseline, see=header_see)
+    return True
 
 
 def copy_entry(
@@ -148,8 +154,14 @@ def copy_entry(
     header_baseline: str | None = None,
     header_see: str = "GOVKIT_SETUP_REVIEW.md",
     exclude_basenames: set[str] | None = None,
-) -> None:
-    """Copy a file or directory tree.
+) -> bool:
+    """Copy a file or directory tree. Returns True when anything was written.
+
+    The return value is the authoritative answer to "did this land?" — a
+    directory reports True when at least one file under it was written. Callers
+    that report on a copy must use it rather than inferring from the
+    filesystem: `shutil.copy2` preserves the source's mtime, so a real
+    overwrite can leave dest's timestamp unchanged.
 
     Edit-protection: when `applied_at` is supplied, files at `dest` that
     carry a govkit:editable header and were modified after `applied_at` are
@@ -171,11 +183,13 @@ def copy_entry(
         print(f"Error: source path does not exist: {src}")
         sys.exit(1)
     if exclude_basenames and src.name in exclude_basenames and src.is_file():
-        return
+        return False
     if src.is_dir():
         dest.mkdir(parents=True, exist_ok=True)
+        wrote = False
         for item in src.iterdir():
-            copy_entry(
+            # Not `any(...)`: it short-circuits, and every child must be copied.
+            if copy_entry(
                 item, dest / item.name,
                 skip_existing=skip_existing,
                 applied_at=applied_at,
@@ -183,6 +197,9 @@ def copy_entry(
                 header_baseline=header_baseline,
                 header_see=header_see,
                 exclude_basenames=exclude_basenames,
-            )
-        return
-    _copy_file(src, dest, skip_existing, applied_at, force, header_baseline, header_see)
+            ):
+                wrote = True
+        return wrote
+    return _copy_file(
+        src, dest, skip_existing, applied_at, force, header_baseline, header_see,
+    )

--- a/cli/overlay.py
+++ b/cli/overlay.py
@@ -161,7 +161,12 @@ def apply_overlay(
     Edit-protection (A2) is honored: if a target doc is user-edited since
     `applied_at`, the copy is refused unless `force=True`.
 
-    Returns the list of destination paths that were copied.
+    Returns the list of destination paths that were written — taken from
+    `copy_entry`, which knows. This used to watch dest's mtime instead, but
+    `shutil.copy2` preserves the *source's* mtime, so a real overwrite could
+    leave the timestamp untouched and be reported as "not copied". The only
+    reason that mostly held is the header rewrite afterwards, which bumps the
+    mtime — and which returns early for anything that is not `.md`.
     """
     baseline = f"{overlay.id}@{overlay.version}"
     copied: list[Path] = []
@@ -173,15 +178,11 @@ def apply_overlay(
             # bundle. Skip silently so a missing file in one stack doesn't
             # break the whole apply. doctor (PR 4) will surface it.
             continue
-        before = dest.exists() and dest.stat().st_mtime
-        copy_entry(
+        if copy_entry(
             src, dest,
             applied_at=applied_at,
             force=force,
             header_baseline=baseline,
-        )
-        after = dest.exists() and dest.stat().st_mtime
-        # The file was copied if it didn't exist before OR mtime advanced.
-        if not before or (after and after != before):
+        ):
             copied.append(dest)
     return copied

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -263,3 +263,86 @@ class TestApplyOverlay:
         assert "my custom edits" in dest.read_text(encoding="utf-8")
         err = capsys.readouterr().err
         assert "refused" in err
+
+
+class TestCopyReportingIsTruthful:
+    """`apply_overlay` decided "was this copied?" by watching dest's mtime.
+
+    `shutil.copy2` *preserves* the source's mtime, so the only reason the
+    heuristic usually worked is that `prepend_header_to_file` rewrites the file
+    afterwards — and it returns early for anything that is not `.md`. An
+    overlay doc of any other type could be overwritten and reported as
+    untouched, which is the wrong way round for a signal a caller prints.
+
+    Nothing in the codebase consumed the return value until `cmd_upgrade` began
+    restoring stack overlays, which is what made the lie load-bearing.
+    """
+
+    def _overlay(self, tmp_path, src_name: str, body: str):
+        import yaml
+
+        from cli.overlay import load_overlay
+
+        stack = tmp_path / "stacks" / "s"
+        stack.mkdir(parents=True)
+        (stack / src_name).write_text(body, encoding="utf-8")
+        (stack / "overlay.yaml").write_text(
+            yaml.safe_dump({
+                "id": "s", "version": "1.0.0", "display_name": "S",
+                "docs": [{"src": src_name, "dest": f"docs/{src_name}"}],
+            }),
+            encoding="utf-8",
+        )
+        return stack
+
+    def test_an_overwritten_non_markdown_doc_is_reported(self, tmp_path, monkeypatch):
+        """The blind spot: same mtime after a real overwrite."""
+        import os
+
+        from cli.overlay import apply_overlay, load_overlay
+
+        stack = self._overlay(tmp_path, "reference.txt", "NEW\n")
+        monkeypatch.setattr("cli.overlay.STACKS_DIR", tmp_path / "stacks")
+
+        target = tmp_path / "proj"
+        dest = target / "docs" / "reference.txt"
+        dest.parent.mkdir(parents=True)
+        dest.write_text("OLD\n", encoding="utf-8")
+        # Force the exact collision copy2 produces: dest already carries the
+        # source's mtime, so copying cannot change it.
+        src_stat = (stack / "reference.txt").stat()
+        os.utime(dest, (src_stat.st_atime, src_stat.st_mtime))
+
+        copied = apply_overlay(load_overlay("s"), target)
+
+        assert dest.read_text(encoding="utf-8") == "NEW\n", "premise: it was overwritten"
+        assert copied == [dest], (
+            "apply_overlay overwrote the file but reported nothing copied"
+        )
+
+    def test_a_refused_doc_is_not_reported_as_copied(self, tmp_path, monkeypatch):
+        """The other direction must keep working: edit-protection refuses, and
+        the caller must not announce a restore that never happened."""
+        import os
+        from datetime import datetime, timezone
+
+        from cli.headers import format_editable_header
+        from cli.overlay import apply_overlay, load_overlay
+
+        self._overlay(tmp_path, "GUIDE.md", "# fresh\n")
+        monkeypatch.setattr("cli.overlay.STACKS_DIR", tmp_path / "stacks")
+
+        target = tmp_path / "proj"
+        dest = target / "docs" / "GUIDE.md"
+        dest.parent.mkdir(parents=True)
+        dest.write_text(
+            format_editable_header(baseline="s@1.0.0") + "# my edits\n", encoding="utf-8",
+        )
+        edited = datetime(2026, 5, 27, 11, 0, 0, tzinfo=timezone.utc).timestamp()
+        os.utime(dest, (edited, edited))
+        applied_at = datetime(2026, 5, 27, 10, 0, 0, tzinfo=timezone.utc).isoformat()
+
+        copied = apply_overlay(load_overlay("s"), target, applied_at=applied_at)
+
+        assert "my edits" in dest.read_text(encoding="utf-8")
+        assert copied == [], f"refused file reported as copied: {copied}"

--- a/tests/test_upgrade_stack_overlay.py
+++ b/tests/test_upgrade_stack_overlay.py
@@ -269,6 +269,35 @@ class TestUpgradePreservesTheStack:
         assert "BASELINE CONTENT" in text
         assert parse_editable_header(text)["baseline"] == "govkit@0.2.0"
 
+    def test_each_restored_file_is_announced_exactly_once(
+        self, bundle, tmp_path, capsys,
+    ):
+        """`copy_entry` already prints `copied <dest>` for every file it writes.
+        Echoing `apply_overlay`'s return value on top of that announced each
+        restored doc twice within the same section.
+
+        Scoped to the stack-overlay section on purpose. The doc is legitimately
+        written twice during an upgrade — once by the governed refresh, then
+        again by the restore — and reporting both is honest, because both
+        happened.
+        """
+        target = _make_target(tmp_path, bundle)
+        capsys.readouterr()  # discard the fixture's own install output
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        out = capsys.readouterr().out
+        _before, marker, section = out.partition("Stack overlay ")
+        assert marker, f"no stack-overlay section in output:\n{out}"
+        announced = [
+            ln for ln in section.splitlines()
+            if "copied" in ln and ln.rstrip().endswith("TECH_STACK.md")
+        ]
+        assert len(announced) == 1, (
+            f"TECH_STACK.md announced {len(announced)} times while restoring:\n"
+            + "\n".join(announced)
+        )
+
     def test_an_unknown_stack_is_reported_rather_than_left_silent(
         self, bundle, tmp_path, capsys,
     ):

--- a/tests/test_upgrade_stack_overlay.py
+++ b/tests/test_upgrade_stack_overlay.py
@@ -1,0 +1,343 @@
+"""`govkit upgrade` must not revert a team's stack to the bundled baseline.
+
+Issue #132, reported as "the `govkit:editable` guard misses local edits after a
+baseline key rename". There is no rename, and the guard is not broken: it is
+that **`cmd_upgrade` never knew about stacks**.
+
+Six architecture docs vary by stack. They ship from `cli/stacks/<id>/` and are
+installed by `apply_overlay`, which stamps `baseline: <stack>@<version>`. They
+also live under `docs/<area>/architecture/`, which every manifest declares as a
+`governed` path — and `upgrade` re-installs governed contracts with
+`skip_existing=False`. So upgrade overwrote each one with the stack-agnostic
+copy and re-stamped it `baseline: govkit@<version>`, which is exactly the
+header transition the issue reports.
+
+`apply` escapes this because it copies governed paths with `skip_existing=True`,
+so the overlay it wrote moments earlier is left alone. Only upgrade clobbers.
+
+Two consequences, in ascending order of severity:
+
+1. **The baseline key is falsified.** `doctor`'s D006 only checks non-`govkit@`
+   baselines, so after one upgrade it stops reporting stale overlays entirely —
+   the check silently goes blind.
+2. **The content reverts.** Every stack except `python-fastapi` ships genuinely
+   different docs, so a Go, .NET, JVM or Node team's architecture contracts
+   become Python/FastAPI ones. `python-fastapi` is the exception only because
+   its content *is* the baseline, which is why the issue reporter saw the
+   baseline key change while the body hash stayed identical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cli.cmd_upgrade import cmd_upgrade
+from cli.headers import parse_editable_header
+from cli.overlay import list_overlays
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+STACK_DOC = "docs/backend/architecture/TECH_STACK.md"
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class TestPremise:
+    """Guard the premise. If overlays stopped differing from the baseline, the
+    behavioral tests below would pass while proving nothing."""
+
+    def test_overlays_ship_docs_that_differ_from_the_stack_agnostic_baseline(self):
+        differing = {}
+        for overlay in list_overlays():
+            for doc in overlay.docs:
+                src = overlay.root / doc["src"]
+                dest = REPO_ROOT / doc["dest"]
+                if not src.is_file() or not dest.is_file():
+                    continue
+                if _sha(src.read_text(encoding="utf-8")) != _sha(
+                    dest.read_text(encoding="utf-8")
+                ):
+                    differing.setdefault(overlay.id, []).append(doc["dest"])
+        assert differing, (
+            "no bundled overlay differs from the baseline docs — the revert this "
+            "module tests would be undetectable"
+        )
+
+    def test_the_stack_docs_live_under_a_governed_path(self):
+        """The overlap that causes the clobber: an overlay writes into a
+        directory the manifest hands to upgrade as a governed contract."""
+        from cli.manifest import load_manifest, resolve_variant_files
+
+        _files, _shared, governed = resolve_variant_files(
+            load_manifest("claude-code"),
+            {"level": "4", "type": "api", "ci": "github", "stack": "go-gin"},
+        )
+        assert any(
+            STACK_DOC.startswith(entry) for entry in governed
+        ), governed
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """A minimal bundle: one agent, one governed docs/ tree, one stack overlay
+    whose doc is deliberately different from the baseline copy."""
+    repo = tmp_path / "repo"
+    agents = repo / "agents" / "test-agent"
+    agents.mkdir(parents=True)
+    (agents / "CLAUDE.md").write_text("# agent v2\n", encoding="utf-8")
+    (agents / "manifest.json").write_text(
+        json.dumps({
+            "agent": "test-agent",
+            "description": "stack upgrade test agent",
+            "options": {
+                "level": {"prompt": "Level?", "choices": ["4"], "default": "4"},
+                "type": {"prompt": "Type?", "choices": ["api"], "default": "api"},
+                "ci": {"prompt": "CI?", "choices": ["github"], "default": "github"},
+                "stack": {"choices": ["test-stack"], "default": "test-stack"},
+            },
+            "variants": {
+                "type": {
+                    "api": {
+                        "files": [{"src": "CLAUDE.md", "dest": "CLAUDE.md"}],
+                        "shared": [],
+                        "governed": ["docs/backend/architecture/"],
+                    },
+                },
+                "ci": {"github": {"files": [], "shared": [], "governed": []}},
+            },
+            "base_files": [],
+        }),
+        encoding="utf-8",
+    )
+
+    baseline = repo / STACK_DOC
+    baseline.parent.mkdir(parents=True)
+    baseline.write_text("# Tech Stack\n\nBASELINE CONTENT (stack-agnostic)\n", encoding="utf-8")
+
+    stack = repo / "stacks" / "test-stack"
+    stack.mkdir(parents=True)
+    (stack / "TECH_STACK.md").write_text(
+        "# Tech Stack\n\nSTACK CONTENT (test-stack only)\n", encoding="utf-8",
+    )
+    (stack / "overlay.yaml").write_text(
+        yaml.safe_dump({
+            "id": "test-stack",
+            "version": "0.10.0",
+            "display_name": "Test Stack",
+            "docs": [{"src": "TECH_STACK.md", "dest": STACK_DOC}],
+        }),
+        encoding="utf-8",
+    )
+    return repo
+
+
+def _make_target(tmp_path: Path, repo: Path) -> Path:
+    """A target as `apply --stack test-stack` would leave it: the overlay's doc
+    installed, carrying the overlay's own baseline header."""
+    from cli.overlay import load_overlay, apply_overlay
+
+    target = tmp_path / "project"
+    target.mkdir()
+    (target / "CLAUDE.md").write_text("# agent v1\n", encoding="utf-8")
+    overlay = load_overlay("test-stack")
+    assert overlay is not None, "test fixture overlay did not load"
+    apply_overlay(overlay, target)
+
+    (target / ".govkit").mkdir()
+    (target / ".govkit" / "marker.json").write_text(
+        json.dumps({
+            "version": "0.1.0",
+            "level": "4",
+            "agent": "test-agent",
+            "options": {"type": "api", "ci": "github", "stack": "test-stack"},
+            "stack": {"id": "test-stack", "version": "0.10.0"},
+            "applied_at": "2026-01-01T00:00:00+00:00",
+        }),
+        encoding="utf-8",
+    )
+    return target
+
+
+@pytest.fixture()
+def bundle(tmp_path, monkeypatch):
+    repo = _make_repo(tmp_path)
+    monkeypatch.setattr("cli.paths.AGENTS_DIR", repo / "agents")
+    monkeypatch.setattr("cli.paths.REPO_ROOT", repo)
+    monkeypatch.setattr("cli.overlay.STACKS_DIR", repo / "stacks")
+    monkeypatch.setattr("cli.version.GOVKIT_VERSION", "0.2.0")
+    return repo
+
+
+class TestUpgradePreservesTheStack:
+    def test_the_fixture_starts_on_the_stack_doc(self, bundle, tmp_path):
+        """Non-vacuous guard: if apply_overlay stopped installing, the assertions
+        below would be checking an empty file."""
+        target = _make_target(tmp_path, bundle)
+        text = (target / STACK_DOC).read_text(encoding="utf-8")
+        assert "STACK CONTENT" in text
+        assert parse_editable_header(text)["baseline"] == "test-stack@0.10.0"
+
+    def test_upgrade_keeps_the_stack_content(self, bundle, tmp_path):
+        """The severe half of #132: a Go/.NET/JVM/Node team's architecture
+        contracts silently became Python/FastAPI ones on upgrade."""
+        target = _make_target(tmp_path, bundle)
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        text = (target / STACK_DOC).read_text(encoding="utf-8")
+        assert "STACK CONTENT" in text, (
+            "upgrade reverted the stack doc to the stack-agnostic baseline"
+        )
+        assert "BASELINE CONTENT" not in text
+
+    def test_upgrade_keeps_the_stack_baseline_header(self, bundle, tmp_path):
+        """The half the issue actually observed. It also matters on its own:
+        doctor's D006 skips `govkit@` baselines, so a falsified key means stale
+        overlays stop being reported at all."""
+        target = _make_target(tmp_path, bundle)
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        header = parse_editable_header((target / STACK_DOC).read_text(encoding="utf-8"))
+        assert header["baseline"] == "test-stack@0.10.0", (
+            f"baseline became {header['baseline']!r} — doctor's D006 only checks "
+            "non-govkit baselines, so it would now skip this doc entirely"
+        )
+
+    def test_the_recorded_hash_still_describes_the_installed_body(
+        self, bundle, tmp_path,
+    ):
+        """Whatever upgrade leaves behind, the header must describe it — or the
+        next run's edit-protection compares against a body that was never there."""
+        from cli.headers import compute_body_hash
+
+        target = _make_target(tmp_path, bundle)
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        text = (target / STACK_DOC).read_text(encoding="utf-8")
+        assert parse_editable_header(text)["hash"] == compute_body_hash(text)
+
+    def test_a_user_edited_stack_doc_is_still_refused(self, bundle, tmp_path, capsys):
+        """Restoring the overlay must not become a second way to lose edits."""
+        target = _make_target(tmp_path, bundle)
+        doc = target / STACK_DOC
+        doc.write_text(
+            doc.read_text(encoding="utf-8") + "\n## Our own section\n", encoding="utf-8",
+        )
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        text = doc.read_text(encoding="utf-8")
+        assert "Our own section" in text, "upgrade destroyed a user edit"
+        assert "refused" in capsys.readouterr().err
+
+    def test_force_still_reinstates_the_stack_doc_not_the_baseline(
+        self, bundle, tmp_path,
+    ):
+        """--force means 'overwrite my edits with what govkit ships'. What
+        govkit ships for this repo is the stack's doc."""
+        target = _make_target(tmp_path, bundle)
+        doc = target / STACK_DOC
+        doc.write_text(
+            doc.read_text(encoding="utf-8") + "\n## Our own section\n", encoding="utf-8",
+        )
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=True))
+
+        text = doc.read_text(encoding="utf-8")
+        assert "STACK CONTENT" in text
+        assert "BASELINE CONTENT" not in text
+        assert "Our own section" not in text
+
+    def test_a_stackless_install_is_unaffected(self, bundle, tmp_path):
+        """Repos that never chose a stack must see no change in behavior."""
+        target = _make_target(tmp_path, bundle)
+        marker_path = target / ".govkit" / "marker.json"
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        del marker["stack"]
+        marker["options"].pop("stack", None)
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        text = (target / STACK_DOC).read_text(encoding="utf-8")
+        assert "BASELINE CONTENT" in text
+        assert parse_editable_header(text)["baseline"] == "govkit@0.2.0"
+
+    def test_an_unknown_stack_is_reported_rather_than_left_silent(
+        self, bundle, tmp_path, capsys,
+    ):
+        """Degrading to the baseline is the only thing upgrade can do, but doing
+        it quietly would swap a team's architecture contracts without telling
+        them."""
+        target = _make_target(tmp_path, bundle)
+        marker_path = target / ".govkit" / "marker.json"
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["stack"] = {"id": "stack-that-was-removed", "version": "9.9.9"}
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        err = capsys.readouterr().err
+        assert "stack-that-was-removed" in err and "does not bundle" in err, err
+
+    def test_an_unknown_stack_id_does_not_crash_the_upgrade(self, bundle, tmp_path):
+        """A marker naming a stack this govkit no longer bundles must degrade to
+        the baseline rather than raising."""
+        target = _make_target(tmp_path, bundle)
+        marker_path = target / ".govkit" / "marker.json"
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["stack"] = {"id": "stack-that-was-removed", "version": "9.9.9"}
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+        cmd_upgrade(argparse.Namespace(target=str(target), force=False))
+
+        assert (target / STACK_DOC).is_file()
+
+
+class TestWhyTheBaselineKeyMatters:
+    """D006 is the reason the falsified key was more than cosmetic.
+
+    `_check_baseline_staleness` skips any `govkit@<version>` baseline, because
+    that tracks the govkit version rather than an overlay version. So once
+    upgrade re-stamped every stack doc `govkit@…`, the stale-overlay check had
+    nothing left to inspect and reported nothing — permanently, for the life of
+    the repo. These tests run the real check both ways so that claim is
+    enforced rather than asserted in a comment.
+    """
+
+    def _target_with_baseline(self, tmp_path: Path, baseline: str) -> Path:
+        from cli.headers import format_editable_header
+
+        target = tmp_path / "proj"
+        doc = target / STACK_DOC
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            format_editable_header(baseline=baseline) + "# Tech Stack\n",
+            encoding="utf-8",
+        )
+        return target
+
+    def _findings(self, target: Path):
+        from cli.doctor import _check_baseline_staleness
+
+        return _check_baseline_staleness(target, {})
+
+    def test_a_stale_overlay_baseline_is_reported(self, tmp_path):
+        """Guard the premise: with the overlay's own key, D006 works."""
+        overlays = [o for o in list_overlays() if o.version != "0.0.0"]
+        assert overlays, "no bundled overlays to test against"
+        stack = overlays[0]
+        target = self._target_with_baseline(tmp_path, f"{stack.id}@0.0.1")
+        findings = self._findings(target)
+        assert [f.id for f in findings] == ["D006"], findings
+
+    def test_a_govkit_baseline_is_never_inspected(self, tmp_path):
+        """What upgrade used to write. Same stale doc, no finding."""
+        target = self._target_with_baseline(tmp_path, "govkit@0.15.0")
+        assert self._findings(target) == []


### PR DESCRIPTION
Closes #132.

## The reported diagnosis does not hold

The issue reports the `govkit:editable` guard missing local edits "after a baseline key rename". There is no rename, and **the guard is sound** — I reproduced a heavily edited doc through an upgrade and it was correctly refused, with the edits intact. A test now pins that.

The real defect is that **`cmd_upgrade` never knew about stacks.**

Six architecture docs vary by stack. They ship from `cli/stacks/<id>/` and are installed by `apply_overlay`, which stamps `baseline: <stack>@<version>`. But they *live* under `docs/<area>/architecture/` — a path every manifest declares as `governed` — and `upgrade` re-installs governed contracts with `skip_existing=False`. So upgrade overwrote each one with the stack-agnostic copy and re-stamped it `baseline: govkit@<version>`.

`apply` never had the problem: it copies governed paths with `skip_existing=True`, so the overlay it wrote moments earlier survives. Only upgrade overwrites, which is why the fix lives there.

## What was being lost

**The content — and this is worse than what was reported.** Every stack except `python-fastapi` ships genuinely different docs. Verified against the real CLI on a repo nobody had touched:

```
$ govkit apply --type api --level 4 --stack go-gin
  baseline: go-gin@0.10.0        go/gin mentions: 44

$ govkit upgrade                 # before this fix
  baseline: govkit@0.18.0        go/gin mentions: 13   python/fastapi mentions: 6
```

A Go, .NET, JVM or Node team's architecture contracts silently became Python/FastAPI ones.

**The baseline key, for every stack.** `doctor`'s D006 skips `govkit@` baselines, because those track the govkit version rather than an overlay version. Once upgrade stamped one on every stack doc, stale-overlay detection reported nothing for the life of the repo. Verified both ways rather than assumed:

| header baseline | D006 |
|---|---|
| `go-gin@0.9.0` (stale, correct key) | **reported** |
| `govkit@0.15.0` (what upgrade wrote) | silent — check is blind |

## Why the reporter saw "same hash, different baseline"

`python-fastapi` ships content identical to the baseline docs — it is the default stack, and its content was promoted into them. So clobbering those six files changes the baseline key while leaving the body hash untouched. That is exactly the header transition in the report, and it is a symptom of the clobber rather than of the guard.

## The fix

`upgrade` re-applies the marker's stack overlay after the governed refresh, through `apply_overlay`, so edit-protection still decides:

- a user-edited stack doc is **refused**, exactly as during the governed copy;
- `--force` reinstates **the stack's doc**, not the baseline;
- a marker naming a stack this govkit no longer bundles **warns and degrades** rather than aborting the upgrade.

`--migrate-levels` needed no change — it only rewrites the marker and stubs feature artifacts, and never touches governed docs.

## Tests

`tests/test_upgrade_stack_overlay.py`, 13 tests on a synthetic bundle so they stay fast and hermetic, plus premise guards against the real bundled overlays:

- the premise itself — that overlays *do* differ from the baseline, and that stack docs live under a governed path — so the behavioral tests cannot pass vacuously;
- content preserved, baseline key preserved, recorded hash still describing the installed body;
- edits still refused; `--force` reinstating the stack doc; stackless installs unaffected; unknown stack id warning and not crashing;
- the D006 relationship, running the real check both ways, so the justification is enforced rather than left in a comment.

2797 fast tests pass.

## Not chased here

The report's "554 lines of customization destroyed" I could not reproduce from a hashed header — the guard holds. The plausible remaining path is the pre-hash `mtime` fallback, where any govkit command re-stamps `applied_at` and protection silently lapses; `_copy_entry_should_refuse` already warns about that window. If the reporter's install predates content hashing, that deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
