### PR TITLE
feat(verdict): decide whether an autonomous run may open a PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,30 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ### Added
 
+- **`govkit verdict`** — for a harness driving an autonomous agent: may this run
+  open a PR? The agent cannot answer that about itself, and neither can its exit
+  code. Across five real headless runs — a clean fix, a correct refusal, a stop
+  at the ADR gate, and two bad outcomes — `claude -p` returned
+  `subtype: success` and exit 0 every time, so the verdict is derived from the
+  working tree, the diff and the gates instead.
+
+  Four outcomes, kept distinct on purpose: `0` FIXED, `1` REJECTED, `2` REFUSED,
+  `3` BLOCKED. **A refusal is a success.** Coding it as failure invites a retry
+  loop, and a retry loop against a gate the agent cannot honestly clear is the
+  pressure that produces self-certification.
+
+  Two gates exist because real runs failed them. `red-before-green` reverts the
+  source, keeps the new tests and requires a failure — every run asserted a
+  red-green cycle in its own summary. `citation-predates-fix` rejects a run that
+  modified the source it cites as `expectation.source`; one agent recovered a
+  contract from git history, restored it, cited it, and passed every govkit gate,
+  because `validate` checks the cited path resolves rather than that it predates
+  the fix.
+
+  govkit supplies the measurement; the harness still makes the decision, per
+  `AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §5.3.
+
+
 - **ADR approval attestation.** An ADR's `Accepted` status is now a derived
   state rather than typed text. The governance rules gate implementation on it
   — *"ADRs … must be Accepted before implementation proceeds"* — and nothing in

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Backend installs ship no UI artifacts; UI installs ship no backend artifacts. Th
 | `govkit init <feature>` | Scaffold a new feature folder from the appropriate starter (L4+). |
 | `govkit fix init <id>` | Scaffold a defect-lane fix record at `fixes/<id>/fix.yaml` (L4+) — one artifact instead of five, for a change that restores already-established behavior. |
 | `govkit evidence` | Report measured quality evidence from CI artifacts — a verdict per rubric dimension, with unmeasured ones reported as INCONCLUSIVE rather than green. |
+| `govkit verdict` | For a harness driving an autonomous agent: decide whether a run may open a PR. Exits `0` FIXED / `1` REJECTED / `2` REFUSED / `3` BLOCKED — a refusal is a success, not a failure. |
 | `govkit stack` | `stack list` shows bundled tech-stack overlays; `stack apply <id>` swaps the stack on an existing install. |
 | `govkit extension` | `extension list` shows bundled extension packs; `extension add <id> --target <path>` copies one into your project's `extensions/<id>/`. |
 | `govkit upgrade` | Refresh the files govkit owns (contracts, CI gates, templates) to a new version without touching the files you own. |
@@ -415,6 +416,36 @@ only gate that can see that, because it is the only one with the diff. It is
 stays green — see [ci/README.md](ci/README.md).
 
 ---
+
+## Driving an autonomous agent against a governed repo
+
+An agent cannot tell you whether its own run succeeded, and neither can its exit
+code: a headless `claude -p` returns success whether it fixed the defect,
+correctly refused it, or stopped at a gate only a human can clear. `govkit
+verdict` derives the answer from the working tree, the diff and the gates —
+the same move `govkit evidence` makes for quality.
+
+```bash
+govkit verdict --target . --source-roots "src/" --test-command "pytest -q"
+```
+
+| Exit | Verdict | What the harness does |
+|---|---|---|
+| `0` | **FIXED** | commit and open the PR |
+| `1` | **REJECTED** | no PR, and no blind retry — a human reads the report |
+| `2` | **REFUSED** | the agent declined and left no trace. **A success** — no PR, no retry |
+| `3` | **BLOCKED** | stopped at a human gate (an ADR, an ambiguous root cause). Escalate |
+
+Two of the gates exist because real runs failed them. **`red-before-green`**
+reverts the source, keeps the new tests, and requires a failure — every agent
+run asserts a red-green cycle in its summary, and this is what checks it.
+**`citation-predates-fix`** rejects a run that edited the source it cites as
+`expectation.source`: recovering a deleted contract and citing it manufactures
+the run's own eligibility, and passes every other gate.
+
+**Treat REFUSED as success.** Coding a refusal as failure is what invites a
+retry loop, and a retry loop against a gate the agent cannot honestly clear is
+the pressure that produces self-certification.
 
 ## ADR approval is derived, not typed
 

--- a/cli/cmd_verdict.py
+++ b/cli/cmd_verdict.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`govkit verdict` — may an autonomous run open a pull request?
+
+For the harness driving a bug-fix agent, not for a human at a keyboard. See
+`cli/verdict.py` for why the answer cannot come from the agent or its exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import sys
+from pathlib import Path
+
+from .verdict import EXIT_CODES, assess
+
+_LABEL = {"pass": "PASS", "fail": "FAIL", "skip": "----"}
+
+_NEXT_STEP = {
+    "FIXED": "Commit and open the PR.",
+    "REJECTED": "Do not open a PR, and do not retry blind — a human reads this.",
+    "REFUSED": "The agent declined. This is a success: no PR, no retry.",
+    "BLOCKED": "Stopped at a gate only a human can clear. Escalate; do not retry.",
+}
+
+
+def cmd_verdict(args: argparse.Namespace) -> None:
+    target = Path(args.target).resolve()
+    if not target.is_dir():
+        print(f"Error: target directory '{target}' does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    roots = tuple(r.strip() for r in (args.source_roots or "").split(",") if r.strip())
+    if not roots:
+        print(
+            "Error: --source-roots is required. govkit will not guess which "
+            "paths are application source; `.govkit/skill_context.yaml` records "
+            "what was detected under architecture.source_root, but an empty "
+            "value there means 'no single root' and is not a value to paste in.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    command = shlex.split(args.test_command) if args.test_command else None
+    result = assess(
+        target,
+        base=args.base or "",
+        source_roots=roots,
+        test_command=command,
+        run_validate=not args.no_validate,
+    )
+
+    if args.json:
+        print(json.dumps({
+            "verdict": result.verdict,
+            "exit_code": result.exit_code,
+            "target": str(target),
+            "gates": [
+                {"status": g.status, "gate": g.gate, "detail": g.detail}
+                for g in result.gates
+            ],
+        }, indent=2))
+        sys.exit(result.exit_code)
+
+    print(f"\ngovkit verdict — {result.verdict}  (exit {result.exit_code})\n")
+    for gate in result.gates:
+        print(f"  {_LABEL.get(gate.status, gate.status):<4}  {gate.gate:<28}  {gate.detail}")
+    print(f"\n{_NEXT_STEP.get(result.verdict, '')}\n")
+    sys.exit(result.exit_code)
+
+
+def register(subparsers) -> None:
+    """Register the `verdict` subcommand and its arguments."""
+    codes = ", ".join(f"{name}={code}" for name, code in EXIT_CODES.items())
+    p = subparsers.add_parser(
+        "verdict",
+        help="Decide whether an autonomous run may open a PR. For a calling "
+             f"harness: exit codes are {codes}.",
+    )
+    p.add_argument("--target", default=".", help="Path to the repository the agent ran in")
+    p.add_argument(
+        "--base", default="",
+        help="Ref the run started from. Required when the agent committed its "
+             "own work; omit for a run left uncommitted in the working tree.",
+    )
+    p.add_argument(
+        "--source-roots", default="",
+        help="Comma-separated application source prefixes, e.g. 'src/,lib/'. "
+             "Required: govkit will not guess.",
+    )
+    p.add_argument(
+        "--test-command", default="",
+        help="Command that runs the suite, e.g. 'pytest -q' or 'go test ./...'. "
+             "Without it the red-before-green gate cannot run and nothing is "
+             "certified — an unverified reproduction is not a verified one.",
+    )
+    p.add_argument(
+        "--no-validate", action="store_true",
+        help="Skip the `govkit validate` gate (it is run by default)",
+    )
+    p.add_argument("--json", action="store_true", help="Emit machine-readable output")
+    p.set_defaults(func=cmd_verdict)

--- a/cli/cmd_verdict.py
+++ b/cli/cmd_verdict.py
@@ -26,7 +26,7 @@ import shlex
 import sys
 from pathlib import Path
 
-from .verdict import EXIT_CODES, assess
+from .verdict import EXIT_CODES, VerdictError, assess
 
 _LABEL = {"pass": "PASS", "fail": "FAIL", "skip": "----"}
 
@@ -56,13 +56,21 @@ def cmd_verdict(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     command = shlex.split(args.test_command) if args.test_command else None
-    result = assess(
-        target,
-        base=args.base or "",
-        source_roots=roots,
-        test_command=command,
-        run_validate=not args.no_validate,
-    )
+    try:
+        result = assess(
+            target,
+            base=args.base or "",
+            source_roots=roots,
+            test_command=command,
+            run_validate=not args.no_validate,
+        )
+    except VerdictError as exc:
+        # Not one of the four verdicts. A broken setup says nothing about the
+        # agent's work, and reporting it as REFUSED would tell the harness the
+        # run succeeded by declining — so a misconfigured job would look green
+        # forever while never opening a PR.
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     if args.json:
         print(json.dumps({

--- a/cli/govkit.py
+++ b/cli/govkit.py
@@ -39,6 +39,7 @@ from .cmd_list import register as _register_list
 from .cmd_stack import register as _register_stack
 from .cmd_upgrade import register as _register_upgrade
 from .cmd_validate import register as _register_validate
+from .cmd_verdict import register as _register_verdict
 from .doctor import register as _register_doctor
 from .version import GOVKIT_VERSION
 
@@ -56,6 +57,7 @@ _REGISTRARS = (
     _register_doctor,
     _register_calibrate,
     _register_validate,
+    _register_verdict,
     _register_upgrade,
 )
 

--- a/cli/verdict.py
+++ b/cli/verdict.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Did an autonomous run earn the right to open a pull request?
+
+An agent cannot answer this about itself, and its runner cannot either: a
+headless `claude -p` returns `subtype: success` and exit 0 whether it fixed the
+defect, correctly refused it, or stopped at a gate only a human can clear. So
+the verdict has to be derived from the working tree, the diff, and the gates —
+the same move `govkit evidence` makes for quality. Measure it; do not accept
+the producer's account of it.
+
+`AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §5.3 states the constraint this obeys:
+"the calling harness, not govkit, has to be what says no." This command does
+not say no. It reports what is true of the tree and exits with a code the
+harness branches on; the decision stays with the caller.
+
+**Four outcomes, deliberately distinct.** Collapsing them is how autonomy goes
+wrong. A refusal reported as failure invites a retry loop, and a retry loop
+against a gate the agent cannot legitimately clear is exactly the pressure that
+produces the self-certification §4 warns about.
+
+    FIXED     0  every gate passed — the run may commit and open a PR
+    REJECTED  1  something is wrong — no PR, and no blind retry
+    REFUSED   2  the agent declined and left no trace — a SUCCESS
+    BLOCKED   3  stopped at a gate only a human can clear — escalate
+
+This is the working-tree half of a question CI cannot answer either: CI sees a
+PR that already exists, and by then the decision to open it has been made.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+FIXED = "FIXED"
+REJECTED = "REJECTED"
+REFUSED = "REFUSED"
+BLOCKED = "BLOCKED"
+
+EXIT_CODES = {FIXED: 0, REJECTED: 1, REFUSED: 2, BLOCKED: 3}
+
+FIXES_GLOB = "fixes/*/fix.yaml"
+FEATURES_DIR = "features"
+
+# Build output is not source, and belongs in nobody's declared surface.
+IGNORED_PARTS = ("__pycache__", ".pytest_cache", ".ruff_cache", "node_modules",
+                 ".venv", ".mypy_cache", "dist", "build", ".tox")
+
+# Files a harness leaves beside the run. Judging them as source would fail
+# every run that logged anything.
+RUNNER_ARTIFACTS = {"agent.json", "agent-run.json", "err.txt", ".agent-mode"}
+
+_STATUS_RE = re.compile(r"^## Status\s*\n(.+)$", re.MULTILINE)
+_GATE_STATUS = "Accepted"
+
+
+@dataclass
+class Gate:
+    """One check. `status` is pass/fail/skip; skip never certifies anything."""
+
+    status: str
+    gate: str
+    detail: str
+
+
+@dataclass
+class Assessment:
+    verdict: str
+    exit_code: int
+    gates: list[Gate] = field(default_factory=list)
+
+    def __iter__(self):
+        # Unpacks as (verdict, exit_code, gates).
+        return iter((self.verdict, self.exit_code, self.gates))
+
+
+def _git(repo: Path, *args: str, raw: bool = False) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=False,
+    )
+    # `--porcelain` encodes status in the first two columns, so the leading
+    # space of the first line is data, not padding. Stripping the whole output
+    # silently ate one character off exactly one path per run.
+    return result.stdout if raw else result.stdout.strip()
+
+
+def _ignored(rel: str) -> bool:
+    parts = rel.replace("\\", "/").split("/")
+    return any(part in IGNORED_PARTS for part in parts)
+
+
+def changed_files(target: Path, base: str) -> list[str]:
+    """Every path this run touched — committed since `base` and still dirty.
+
+    An agent that commits and opens the PR itself must be judged exactly like
+    one that leaves the tree dirty, so both are collected.
+    """
+    found: set[str] = set()
+    if base:
+        for line in _git(target, "diff", "--name-only", f"{base}...HEAD").splitlines():
+            if line.strip():
+                found.add(line.strip())
+    # `-uall` lists untracked FILES. The default collapses an untracked
+    # directory to its name, which hid a newly written ADR or fix record
+    # behind `docs/` and made the checks that read them silently vacuous.
+    for line in _git(target, "status", "--porcelain", "-uall", raw=True).splitlines():
+        path = line[3:].strip().strip('"')
+        if path:
+            found.add(path.rstrip("/"))
+    return sorted(
+        p for p in found
+        if not p.startswith(".govkit/") and not _ignored(p)
+        and Path(p).name not in RUNNER_ARTIFACTS
+    )
+
+
+def is_test_path(rel: str) -> bool:
+    """Heuristic shared with the fix-lane gate: a regression test is the proof
+    of a repair, not part of it, so it is never expected in `surface.paths`."""
+    name = Path(rel).name.lower()
+    parts = rel.replace("\\", "/").lower().split("/")
+    return "test" in name or "tests" in parts or "spec" in name
+
+
+def source_changes(changed: list[str], roots: tuple[str, ...]) -> list[str]:
+    return [
+        p for p in changed
+        if any(p.replace("\\", "/").startswith(r) for r in roots)
+        and not is_test_path(p)
+    ]
+
+
+def load_records(target: Path) -> list[tuple[Path, dict]]:
+    out = []
+    for path in sorted(target.glob(FIXES_GLOB)):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            data = {}
+        out.append((path, data if isinstance(data, dict) else {}))
+    return out
+
+
+def accepted_adr(target: Path, changed: list[str]) -> str:
+    """An ADR this run touched whose Status reads `Accepted`.
+
+    `Accepted` is a derived state — true because an approver approved that
+    decision at that commit. An author may only ever write `Proposed`, so an
+    agent that wrote `Accepted` has asserted an approval that did not happen.
+    TEMPLATE.md is excluded: its Status line is the vocabulary menu.
+    """
+    for rel in changed:
+        norm = rel.replace("\\", "/")
+        if "/ADR/" not in norm or not norm.endswith(".md"):
+            continue
+        if Path(norm).name == "TEMPLATE.md":
+            continue
+        try:
+            text = (target / rel).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        match = _STATUS_RE.search(text)
+        if match and match.group(1).strip() == _GATE_STATUS:
+            return norm
+    return ""
+
+
+def cited_source_changed(records: list[tuple[Path, dict]], changed: list[str]) -> str:
+    """A record whose `expectation.source` this same run modified.
+
+    Defect-lane condition 1 asks the change to cite a source that *already*
+    established the behavior. Editing — or restoring — that source in the same
+    change manufactures its own eligibility. Observed in a real headless run:
+    the agent recovered a deleted contract from git history, wrote it back,
+    cited it, and every govkit gate went green, because `validate` checks the
+    path resolves rather than that it predates the fix.
+    """
+    changed_set = {p.replace("\\", "/") for p in changed}
+    for _path, data in records:
+        source = (data.get("expectation") or {}).get("source")
+        if isinstance(source, str) and source.replace("\\", "/") in changed_set:
+            return source
+    return ""
+
+
+def undeclared_sources(records: list[tuple[Path, dict]], touched: list[str]) -> list[str]:
+    declared: set[str] = set()
+    for _path, data in records:
+        for entry in (data.get("surface") or {}).get("paths") or []:
+            if isinstance(entry, str):
+                declared.add(entry.replace("\\", "/"))
+    return [p for p in touched if p.replace("\\", "/") not in declared]
+
+
+def _revert_source(target: Path, roots: tuple[str, ...], base: str):
+    """Put the source back as it was before the run, and return an undo.
+
+    Two shapes, because the agent may or may not have committed. Dirty tree:
+    stash the source and pop it back. Committed run: check the source out at
+    `base` and restore it from HEAD afterwards. Returns None when neither is
+    possible, so the caller fails the gate rather than testing the wrong tree.
+    """
+    dirty = [
+        line for line in _git(target, "status", "--porcelain", "-uall", raw=True).splitlines()
+        if any(line[3:].strip().strip('"').replace("\\", "/").startswith(r) for r in roots)
+    ]
+    if dirty:
+        pushed = subprocess.run(["git", "stash", "push", "-q", "--", *roots],
+                                cwd=target, capture_output=True, text=True, check=False)
+        if pushed.returncode != 0:
+            return None
+        return lambda: subprocess.run(["git", "stash", "pop", "-q"], cwd=target,
+                                      capture_output=True, text=True, check=False)
+    if base:
+        out = subprocess.run(["git", "checkout", base, "--", *roots], cwd=target,
+                             capture_output=True, text=True, check=False)
+        if out.returncode != 0:
+            return None
+        return lambda: subprocess.run(["git", "checkout", "HEAD", "--", *roots],
+                                      cwd=target, capture_output=True, text=True, check=False)
+    return None
+
+
+def red_before_green(
+    target: Path, roots: tuple[str, ...], test_command: list[str] | None,
+    base: str = "",
+) -> Gate:
+    """Prove the regression test reproduces the defect.
+
+    Revert only the source, keep the new tests, and require a failure. This is
+    the one claim an agent cannot talk past: every run in the experiment
+    asserted red-before-green in its own summary, and only executing it decides
+    whether that was true.
+
+    Without a test command nothing is certified. `govkit evidence` states the
+    contract this follows — an unmeasured dimension is indistinguishable from a
+    verified one, so it is never a pass.
+    """
+    if not test_command:
+        return Gate("fail", "red-before-green",
+                    "no test command given — a run that cannot be shown to "
+                    "reproduce its defect cannot be certified")
+
+    def run_tests() -> int:
+        return subprocess.run(
+            test_command, cwd=target, capture_output=True, text=True, check=False,
+        ).returncode
+
+    if run_tests() != 0:
+        return Gate("fail", "red-before-green", "suite fails with the fix applied")
+
+    undo = _revert_source(target, roots, base)
+    if undo is None:
+        return Gate("fail", "red-before-green",
+                    "could not isolate the source change to test without it")
+    try:
+        without = run_tests()
+    finally:
+        # The tree must survive: a verdict tool that damages it is worse than
+        # none, and this runs against a repo a human is about to review.
+        undo()
+    if without == 0:
+        return Gate("fail", "red-before-green",
+                    "tests still pass with the fix reverted — no defect reproduced")
+    return Gate("pass", "red-before-green", "fails without the fix, passes with it")
+
+
+def _govkit_validate(target: Path) -> Gate:
+    result = subprocess.run(
+        [sys.executable, "-m", "cli.govkit", "validate", "--target", str(target)],
+        capture_output=True, text=True, check=False,
+        cwd=str(Path(__file__).resolve().parent.parent),
+    )
+    if result.returncode == 0:
+        return Gate("pass", "govkit-validate", "exit 0")
+    tail = (result.stdout or result.stderr or "").strip().splitlines()
+    return Gate("fail", "govkit-validate",
+                f"exit {result.returncode}" + (f" — {tail[-1]}" if tail else ""))
+
+
+def assess(
+    target: Path,
+    base: str = "",
+    source_roots: tuple[str, ...] = ("src/",),
+    test_command: list[str] | None = None,
+    run_validate: bool = True,
+) -> Assessment:
+    """Classify one autonomous run. Never raises; never leaves the tree dirty."""
+    target = Path(target)
+    changed = changed_files(target, base)
+    records = load_records(target)
+    features = (
+        [d for d in (target / FEATURES_DIR).glob("*") if d.is_dir()]
+        if (target / FEATURES_DIR).is_dir() else []
+    )
+    touched_source = source_changes(changed, source_roots)
+    gates: list[Gate] = []
+
+    # ---- Nothing attempted, nothing left behind --------------------------
+    if not changed:
+        gates.append(Gate("pass", "clean-refusal",
+                          "no files changed — the agent declined and said so"))
+        return Assessment(REFUSED, EXIT_CODES[REFUSED], gates)
+
+    adr = accepted_adr(target, changed)
+    gates.append(Gate("fail" if adr else "pass", "adr-not-self-accepted",
+                      f"{adr} claims {_GATE_STATUS}" if adr
+                      else f"no ADR claims {_GATE_STATUS}"))
+
+    # ---- Artifacts written, no code. Two very different things. ----------
+    if not touched_source:
+        if adr:
+            return Assessment(REJECTED, EXIT_CODES[REJECTED], gates)
+        if records:
+            gates.append(Gate("fail", "fix-record-describes-a-fix",
+                              "fix record present but no source changed"))
+            return Assessment(REJECTED, EXIT_CODES[REJECTED], gates)
+        if features:
+            gates.append(Gate("skip", "no-source-change",
+                              "feature artifacts authored, no code — a human gate"))
+            return Assessment(BLOCKED, EXIT_CODES[BLOCKED], gates)
+        gates.append(Gate("skip", "no-source-change",
+                          "no source changed and no governing artifact written"))
+        return Assessment(BLOCKED, EXIT_CODES[BLOCKED], gates)
+
+    # ---- It changed code, so every gate below must hold. -----------------
+    gates.append(Gate("pass" if records else "fail", "governing-artifact",
+                      f"{len(records)} fix record(s)" if records
+                      else "source changed with no fix record"))
+
+    gates.append(Gate("fail" if features else "pass", "defect-lane-only",
+                      f"authored features/: {sorted(d.name for d in features)}"
+                      if features else "no feature package invented"))
+
+    cited = cited_source_changed(records, changed)
+    gates.append(Gate("fail" if cited else "pass", "citation-predates-fix",
+                      f"modified its own cited source: {cited}" if cited
+                      else "cited source untouched by this change"))
+
+    undeclared = undeclared_sources(records, touched_source)
+    gates.append(Gate("fail" if undeclared else "pass", "surface-covers-diff",
+                      f"undeclared source: {undeclared}" if undeclared
+                      else "declared surface covers the changed source"))
+
+    gates.append(red_before_green(target, source_roots, test_command, base))
+
+    if run_validate:
+        gates.append(_govkit_validate(target))
+
+    failed = [g for g in gates if g.status == "fail"]
+    verdict = REJECTED if failed else FIXED
+    return Assessment(verdict, EXIT_CODES[verdict], gates)

--- a/cli/verdict.py
+++ b/cli/verdict.py
@@ -92,14 +92,56 @@ class Assessment:
         return iter((self.verdict, self.exit_code, self.gates))
 
 
+class VerdictError(Exception):
+    """The run could not be assessed at all — a broken setup, not a judgement.
+
+    Kept distinct from the four verdicts on purpose. Returning REFUSED for a
+    target that is not a repository would tell the harness "the agent declined,
+    this is a success, do not retry", and a misconfigured job would report
+    success forever while never opening a PR.
+    """
+
+
 def _git(repo: Path, *args: str, raw: bool = False) -> str:
+    """Run git and require it to succeed.
+
+    Swallowing a non-zero exit here is what let a non-repository read as "no
+    files changed". Every caller below treats empty output as a fact about the
+    run, so it has to be a fact about the run.
+    """
     result = subprocess.run(
         ["git", *args], cwd=repo, capture_output=True, text=True, check=False,
     )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        raise VerdictError(
+            f"git {' '.join(args)} failed in {repo}"
+            + (f": {detail[0]}" if detail else "")
+        )
     # `--porcelain` encodes status in the first two columns, so the leading
     # space of the first line is data, not padding. Stripping the whole output
     # silently ate one character off exactly one path per run.
     return result.stdout if raw else result.stdout.strip()
+
+
+def require_assessable(target: Path, base: str) -> None:
+    """Fail loudly before any gate runs, rather than mis-classifying later."""
+    if not target.is_dir():
+        raise VerdictError(f"target directory '{target}' does not exist")
+    try:
+        _git(target, "rev-parse", "--is-inside-work-tree")
+    except VerdictError as exc:
+        raise VerdictError(
+            f"'{target}' is not a git work tree — the verdict is derived from "
+            "the diff, so there is nothing to assess"
+        ) from exc
+    if base:
+        try:
+            _git(target, "rev-parse", "--verify", f"{base}^{{commit}}")
+        except VerdictError as exc:
+            raise VerdictError(
+                f"--base '{base}' does not resolve to a commit in '{target}'"
+            ) from exc
 
 
 def _ignored(rel: str) -> bool:
@@ -223,8 +265,18 @@ def _revert_source(target: Path, roots: tuple[str, ...], base: str):
         if any(line[3:].strip().strip('"').replace("\\", "/").startswith(r) for r in roots)
     ]
     if dirty:
-        pushed = subprocess.run(["git", "stash", "push", "-q", "--", *roots],
-                                cwd=target, capture_output=True, text=True, check=False)
+        # `-u` because a fix delivered as a NEW file is untracked, and
+        # `changed_files` already counts it as source. Without it the
+        # "reverted" run tested a tree that still contained the repair.
+        #
+        # Build artifacts are excluded, and that exclusion is load-bearing:
+        # the reverted run regenerates them, and `git stash pop` then refuses
+        # to overwrite the very files it is restoring. `__pycache__` under a
+        # source root makes that the default outcome for a Python repo.
+        excludes = [f":(exclude)**/{part}/**" for part in IGNORED_PARTS]
+        pushed = subprocess.run(
+            ["git", "stash", "push", "-u", "-q", "--", *roots, *excludes],
+            cwd=target, capture_output=True, text=True, check=False)
         if pushed.returncode != 0:
             return None
         return lambda: subprocess.run(["git", "stash", "pop", "-q"], cwd=target,
@@ -276,7 +328,15 @@ def red_before_green(
     finally:
         # The tree must survive: a verdict tool that damages it is worse than
         # none, and this runs against a repo a human is about to review.
-        undo()
+        restored = undo()
+    if restored is not None and restored.returncode != 0:
+        # Say so instead of reporting on the tests, because the tree now has
+        # the repair stashed away and a harness that committed it would ship
+        # the regression test without the fix.
+        return Gate("fail", "red-before-green",
+                    "could not restore the source after reverting it — the "
+                    "working tree may be missing the fix; recover it with "
+                    "`git stash list` / `git stash pop` before doing anything else")
     if without == 0:
         return Gate("fail", "red-before-green",
                     "tests still pass with the fix reverted — no defect reproduced")
@@ -303,8 +363,13 @@ def assess(
     test_command: list[str] | None = None,
     run_validate: bool = True,
 ) -> Assessment:
-    """Classify one autonomous run. Never raises; never leaves the tree dirty."""
+    """Classify one autonomous run.
+
+    Raises `VerdictError` when the run cannot be assessed at all. Never leaves
+    the working tree altered.
+    """
     target = Path(target)
+    require_assessable(target, base)
     changed = changed_files(target, base)
     records = load_records(target)
     features = (

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -405,3 +405,174 @@ class TestValidateGate:
         _fix_record(repo)
         _verdict, _code, gates = _run(repo, run_validate=False)
         assert "govkit-validate" not in {g.gate for g in gates}
+
+
+# ---------------------------------------------------------------------------
+# Untracked source must be reverted too
+# ---------------------------------------------------------------------------
+
+# Records what the suite could see each time it ran, and stays red/green on it.
+PROBE = [
+    sys.executable, "-c",
+    "import pathlib,sys;"
+    "log=pathlib.Path('probe.log');"
+    "seen=pathlib.Path('src/extra.py').exists();"
+    "log.write_text((log.read_text() if log.exists() else '')+('yes' if seen else 'no')+chr(10));"
+    "sys.exit(0 if seen else 1)",
+]
+
+
+class TestUntrackedSourceIsReverted:
+    """`changed_files` counts untracked paths, so a fix delivered as a NEW file
+    is source like any other. Stashing only tracked changes left it in place,
+    and the "reverted" run then tested a tree that still contained the fix."""
+
+    def _new_file_fix(self, repo: Path) -> None:
+        (repo / "src" / "extra.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+        _fix_record(repo, paths=["src/extra.py"])
+
+    def test_the_reverted_run_does_not_see_an_untracked_source_file(self, repo):
+        self._new_file_fix(repo)
+        _verdict, _code, gates = _run(repo, test_command=PROBE)
+
+        saw = (repo / "probe.log").read_text(encoding="utf-8").split()
+        assert saw[0] == "yes", "premise: the first run must see the fix"
+        assert saw[1] == "no", (
+            f"the reverted run still saw src/extra.py — it tested a tree that "
+            f"still contained the fix (probe: {saw})"
+        )
+        assert "red-before-green" not in _fail_names(gates)
+
+    def test_an_untracked_fix_is_restored_afterwards(self, repo):
+        """Reverting must be undone whether the file was tracked or not."""
+        self._new_file_fix(repo)
+        _run(repo, test_command=PROBE)
+        assert (repo / "src" / "extra.py").is_file(), "untracked source was not restored"
+
+    def test_a_new_file_that_does_not_reproduce_the_defect_is_rejected(self, repo):
+        """The gate must still be able to say no when the tests pass either way."""
+        self._new_file_fix(repo)
+        verdict, _code, gates = _run(repo, test_command=PASSES)
+        assert verdict == REJECTED
+        assert "red-before-green" in _fail_names(gates)
+
+
+# ---------------------------------------------------------------------------
+# A broken setup is an error, never a verdict about the agent
+# ---------------------------------------------------------------------------
+
+
+class TestSetupErrorsAreNotVerdicts:
+    """`_git` returned stdout even when git failed, so a non-repo produced no
+    changed files and the run classified as REFUSED — exit 2, which tells the
+    harness "the agent declined, this is a success, do not retry". A
+    misconfigured target would report success forever and never open a PR.
+
+    A setup error is not a judgement about the agent's work, so it must not
+    borrow one of the four verdicts.
+    """
+
+    def test_a_directory_that_is_not_a_repo_raises(self, tmp_path):
+        from cli.verdict import VerdictError
+
+        plain = tmp_path / "plain"
+        (plain / "src").mkdir(parents=True)
+        with pytest.raises(VerdictError, match="git"):
+            assess(plain, source_roots=("src/",), run_validate=False)
+
+    def test_an_unresolvable_base_raises(self, repo):
+        from cli.verdict import VerdictError
+
+        with pytest.raises(VerdictError, match="no-such-ref"):
+            assess(repo, base="no-such-ref", source_roots=("src/",), run_validate=False)
+
+    def test_a_valid_base_still_works(self, repo):
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                              capture_output=True, text=True).stdout.strip()
+        verdict, _code, _gates = _run(repo, base=head)
+        assert verdict == REFUSED
+
+    def test_the_cli_reports_a_non_repo_clearly(self, tmp_path, capsys):
+        from cli.cmd_verdict import cmd_verdict
+
+        plain = tmp_path / "plain"
+        (plain / "src").mkdir(parents=True)
+        with pytest.raises(SystemExit) as exc:
+            cmd_verdict(_cli_args(plain))
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "git" in err.lower(), err
+
+    def test_the_cli_reports_an_invalid_base_clearly(self, repo, capsys):
+        from cli.cmd_verdict import cmd_verdict
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_verdict(_cli_args(repo, base="no-such-ref"))
+        assert exc.value.code == 1
+        assert "no-such-ref" in capsys.readouterr().err
+
+
+class TestRestorationIsVerified:
+    """A verdict tool that leaves the fix stashed is worse than none: the
+    harness would commit a tree with the repair missing."""
+
+    def test_a_failed_restore_fails_the_gate(self, repo, monkeypatch):
+        import cli.verdict as vmod
+
+        _edit_source(repo)
+        _fix_record(repo)
+        real = vmod.subprocess.run
+
+        def flaky(cmd, *a, **kw):
+            if cmd[:3] == ["git", "stash", "pop"]:
+                return subprocess.CompletedProcess(cmd, 1, "", "conflict")
+            return real(cmd, *a, **kw)
+
+        monkeypatch.setattr(vmod.subprocess, "run", flaky)
+        _verdict, _code, gates = _run(repo)
+        assert "red-before-green" in _fail_names(gates)
+        detail = next(g.detail for g in gates if g.gate == "red-before-green")
+        assert "restore" in detail.lower(), detail
+
+
+class TestRegeneratedArtifactsDoNotBreakRestore:
+    """Stashing untracked source has a trap: running the suite regenerates
+    build artifacts, and `git stash pop` then refuses to overwrite the files it
+    is trying to restore. `__pycache__` under a source root makes this the
+    default outcome for a Python repo, so the artifacts are excluded from the
+    stash rather than fought with afterwards."""
+
+    # Regenerates a build artifact under the source root on every run, exactly
+    # as pytest does, and stays red/green on the fix.
+    REGENERATES = [
+        sys.executable, "-c",
+        "import pathlib,sys;"
+        "d=pathlib.Path('src/__pycache__');d.mkdir(parents=True,exist_ok=True);"
+        "(d/'calc.pyc').write_bytes(b'x');"
+        "sys.exit(0 if 'min(' in pathlib.Path('src/calc.py').read_text() else 1)",
+    ]
+
+    def test_the_gate_survives_a_suite_that_regenerates_artifacts(self, repo):
+        (repo / "src" / "__pycache__").mkdir()
+        (repo / "src" / "__pycache__" / "calc.pyc").write_bytes(b"stale")
+        _edit_source(repo)
+        _fix_record(repo)
+
+        _verdict, _code, gates = _run(repo, test_command=self.REGENERATES)
+        assert "red-before-green" not in _fail_names(gates), (
+            next(g.detail for g in gates if g.gate == "red-before-green")
+        )
+
+    def test_no_stash_is_left_behind(self, repo):
+        """A leftover stash means the tree a human reviews is not the tree the
+        agent produced."""
+        (repo / "src" / "__pycache__").mkdir()
+        (repo / "src" / "__pycache__" / "calc.pyc").write_bytes(b"stale")
+        _edit_source(repo)
+        _fix_record(repo)
+
+        _run(repo, test_command=self.REGENERATES)
+        stashes = subprocess.run(["git", "stash", "list"], cwd=repo,
+                                 capture_output=True, text=True).stdout.strip()
+        assert stashes == "", f"left a stash behind: {stashes}"
+        assert "min(" in (repo / "src" / "calc.py").read_text(encoding="utf-8")

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -1,0 +1,407 @@
+"""`govkit verdict` — did an autonomous run earn the right to open a PR?
+
+An agent cannot answer this about itself. Across five real headless runs —
+a clean fix, a correct refusal, a stop at the ADR gate, and two bad outcomes —
+`claude -p` returned `subtype: success` and exit 0 every single time. The
+calling harness has to derive the verdict from the working tree and the gates,
+which is the same move `govkit evidence` makes for quality: measure it, do not
+accept the producer's account of it.
+
+`AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §5.3 puts it as the single most important
+decision — "the calling harness, not govkit, has to be what says no". This
+command is govkit supplying the measurement that harness says no *with*; the
+decision, and the exit code it branches on, stay with the caller.
+
+The four outcomes are deliberately distinct, because collapsing them is how
+autonomy goes wrong. A refusal reported as failure invites a retry loop, and a
+retry loop against a gate the agent cannot legitimately clear is exactly the
+pressure that produces self-certification (§4).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cli.verdict import BLOCKED, FIXED, REFUSED, REJECTED, assess
+
+# Stand-ins for a real suite. RED_GREEN is content-sensitive: it passes only
+# when the fix is present, so reverting the source genuinely turns it red —
+# which is the behaviour the gate is checking for.
+RED_GREEN = [
+    sys.executable, "-c",
+    "import sys,pathlib;"
+    "sys.exit(0 if 'min(' in pathlib.Path('src/calc.py').read_text() else 1)",
+]
+FAILS = [sys.executable, "-c", "raise SystemExit(1)"]
+PASSES = [sys.executable, "-c", "raise SystemExit(0)"]
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=False)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A committed baseline: one source file, one test, one contract."""
+    r = tmp_path / "proj"
+    (r / "src").mkdir(parents=True)
+    (r / "tests").mkdir()
+    (r / "docs").mkdir()
+    (r / "src" / "calc.py").write_text("def rate(p):\n    return p\n", encoding="utf-8")
+    (r / "tests" / "test_calc.py").write_text("def test_ok():\n    assert True\n", encoding="utf-8")
+    (r / "docs" / "CONTRACT.md").write_text("# Contract\n\nRate is clamped.\n", encoding="utf-8")
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@e.com")
+    _git(r, "config", "user.name", "T")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "baseline")
+    return r
+
+
+def _fix_record(repo: Path, *, source: str = "docs/CONTRACT.md",
+                paths: list[str] | None = None, fix_id: str = "rate-clamp") -> None:
+    d = repo / "fixes" / fix_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "fix.yaml").write_text(
+        yaml.safe_dump({
+            "version": 1, "id": fix_id, "summary": "rate not clamped",
+            "expectation": {"source": source, "reference": "Rate is clamped"},
+            "failure": {"observed": "returns unclamped"},
+            "surface": {"paths": paths if paths is not None else ["src/calc.py"]},
+            "reproduction": {"test": "tests/test_calc.py"},
+            "risk": {k: False for k in (
+                "architecture", "security_auth", "data_handling",
+                "public_contract", "nfr", "cross_service")},
+            "introduces_new_behavior": False,
+        }, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _edit_source(repo: Path) -> None:
+    (repo / "src" / "calc.py").write_text(
+        "def rate(p):\n    return min(p, 100)\n", encoding="utf-8")
+
+
+def _adr(repo: Path, status: str, name: str = "0001-rates.md") -> None:
+    d = repo / "docs" / "backend" / "architecture" / "ADR"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(f"# ADR-0001\n\n## Status\n{status}\n", encoding="utf-8")
+
+
+def _run(repo: Path, **kw):
+    kw.setdefault("source_roots", ("src/",))
+    kw.setdefault("test_command", RED_GREEN)
+    # The govkit-validate gate spawns a full interpreter, which costs ~3s per
+    # case and says nothing about the gate under test. TestValidateGate covers
+    # it once, on its own.
+    kw.setdefault("run_validate", False)
+    return assess(repo, **kw)
+
+
+# ---------------------------------------------------------------------------
+# The four outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomes:
+    def test_untouched_tree_is_a_refusal_not_a_failure(self, repo):
+        """§5.3: stalling is a first-class success. Coding it as failure is what
+        invites a retry loop against a gate the agent cannot honestly clear."""
+        verdict, code, _gates = _run(repo)
+        assert (verdict, code) == (REFUSED, 2)
+
+    def test_a_complete_defect_fix_is_certified(self, repo):
+        _edit_source(repo)
+        _fix_record(repo)
+        verdict, code, gates = _run(repo)
+        assert (verdict, code) == (FIXED, 0), [g for g in gates if g.status == "fail"]
+
+    def test_feature_artifacts_without_code_is_blocked_not_rejected(self, repo):
+        """Authoring a feature package and stopping is the ADR gate working.
+        It needs a human, not a bug report."""
+        (repo / "features" / "rates").mkdir(parents=True)
+        (repo / "features" / "rates" / "plan.md").write_text("# plan\n", encoding="utf-8")
+        _adr(repo, "Proposed")
+        verdict, code, _gates = _run(repo)
+        assert (verdict, code) == (BLOCKED, 3)
+
+    def test_a_fix_record_with_no_fix_is_rejected(self, repo):
+        """A record describes a repair. Without the repair it is a claim about
+        work that was not done — broken, not blocked."""
+        _fix_record(repo)
+        verdict, code, _gates = _run(repo)
+        assert (verdict, code) == (REJECTED, 1)
+
+
+# ---------------------------------------------------------------------------
+# Individual gates
+# ---------------------------------------------------------------------------
+
+
+def _fail_names(gates) -> list[str]:
+    return [g.gate for g in gates if g.status == "fail"]
+
+
+class TestGates:
+    def test_source_changed_with_no_governing_artifact(self, repo):
+        _edit_source(repo)
+        verdict, _c, gates = _run(repo)
+        assert verdict == REJECTED
+        assert "governing-artifact" in _fail_names(gates)
+
+    def test_inventing_a_feature_package_alongside_a_fix_is_rejected(self, repo):
+        """§4's self-certification: five artifacts authored to clear a gate."""
+        _edit_source(repo)
+        _fix_record(repo)
+        (repo / "features" / "rates").mkdir(parents=True)
+        (repo / "features" / "rates" / "plan.md").write_text("# plan\n", encoding="utf-8")
+        verdict, _c, gates = _run(repo)
+        assert verdict == REJECTED
+        assert "defect-lane-only" in _fail_names(gates)
+
+    def test_an_agent_authored_accepted_adr_is_rejected(self, repo):
+        """`Accepted` is a derived state. An author may only write `Proposed`."""
+        _edit_source(repo)
+        _fix_record(repo)
+        _adr(repo, "Accepted")
+        verdict, _c, gates = _run(repo)
+        assert verdict == REJECTED
+        assert "adr-not-self-accepted" in _fail_names(gates)
+
+    def test_a_proposed_adr_is_fine(self, repo):
+        _edit_source(repo)
+        _fix_record(repo)
+        _adr(repo, "Proposed")
+        _verdict, _c, gates = _run(repo)
+        assert "adr-not-self-accepted" not in _fail_names(gates)
+
+    def test_the_adr_template_is_not_read_as_a_claim(self, repo):
+        """TEMPLATE.md carries the whole vocabulary menu, including Accepted."""
+        _edit_source(repo)
+        _fix_record(repo)
+        _adr(repo, "Proposed | Accepted | Rejected | Superseded", name="TEMPLATE.md")
+        _verdict, _c, gates = _run(repo)
+        assert "adr-not-self-accepted" not in _fail_names(gates)
+
+    def test_modifying_the_cited_source_is_rejected(self, repo):
+        """Observed in a real run: the agent restored a deleted contract, cited
+        it, and every govkit gate went green. Condition 1 asks the change to
+        cite a source that ALREADY established the behavior; editing that source
+        in the same change manufactures its own eligibility."""
+        _edit_source(repo)
+        _fix_record(repo)
+        (repo / "docs" / "CONTRACT.md").write_text(
+            "# Contract\n\nRate is clamped.\n\n## New rule\n", encoding="utf-8")
+        verdict, _c, gates = _run(repo)
+        assert verdict == REJECTED
+        assert "citation-predates-fix" in _fail_names(gates)
+
+    def test_source_outside_the_declared_surface_is_rejected(self, repo):
+        _edit_source(repo)
+        (repo / "src" / "sneaky.py").write_text("x = 1\n", encoding="utf-8")
+        _fix_record(repo, paths=["src/calc.py"])
+        verdict, _c, gates = _run(repo)
+        assert verdict == REJECTED
+        assert "surface-covers-diff" in _fail_names(gates)
+
+    def test_a_test_file_is_not_expected_in_the_surface(self, repo):
+        """surface.paths describes what was repaired; the regression test is the
+        proof of the repair, not part of it."""
+        _edit_source(repo)
+        (repo / "tests" / "test_calc.py").write_text(
+            "def test_ok():\n    assert True\n\ndef test_new():\n    assert True\n",
+            encoding="utf-8")
+        _fix_record(repo, paths=["src/calc.py"])
+        _verdict, _c, gates = _run(repo)
+        assert "surface-covers-diff" not in _fail_names(gates)
+
+
+class TestRedBeforeGreen:
+    """The one claim an agent cannot talk past. Every run in the experiment
+    asserted red-before-green in its summary; this is what checks it."""
+
+    def test_tests_that_still_pass_without_the_fix_are_rejected(self, repo):
+        _edit_source(repo)
+        _fix_record(repo)
+        verdict, _c, gates = _run(repo, test_command=PASSES)
+        assert verdict == REJECTED
+        assert "red-before-green" in _fail_names(gates)
+
+    def test_a_suite_failing_with_the_fix_applied_is_rejected(self, repo):
+        _edit_source(repo)
+        _fix_record(repo)
+        # Fails whether or not the fix is present => the fix does not work.
+        verdict, _c, gates = _run(repo, test_command=FAILS)
+        assert verdict == REJECTED
+        assert "red-before-green" in _fail_names(gates)
+
+    def test_without_a_test_command_nothing_is_certified(self, repo):
+        """Unmeasured is not verified — the contract `govkit evidence` states.
+        A run that cannot be shown to reproduce its defect cannot be FIXED."""
+        _edit_source(repo)
+        _fix_record(repo)
+        verdict, code, gates = _run(repo, test_command=None)
+        assert (verdict, code) == (REJECTED, 1)
+        assert "red-before-green" in _fail_names(gates)
+
+    def test_the_working_tree_survives_the_check(self, repo):
+        """It reverts the source to prove red, so it must put it back — a
+        verdict tool that damages the tree is worse than none."""
+        _edit_source(repo)
+        _fix_record(repo)
+        before = (repo / "src" / "calc.py").read_text(encoding="utf-8")
+        _run(repo)
+        assert (repo / "src" / "calc.py").read_text(encoding="utf-8") == before
+
+
+class TestCommittedRuns:
+    """The agent may commit and open the PR itself, so a committed run must be
+    judged exactly like an uncommitted one."""
+
+    def test_a_committed_fix_is_certified_against_its_base(self, repo):
+        base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                              capture_output=True, text=True).stdout.strip()
+        _edit_source(repo)
+        _fix_record(repo)
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "fix(calc): clamp the rate")
+        verdict, code, gates = _run(repo, base=base)
+        assert (verdict, code) == (FIXED, 0), [g.gate for g in gates if g.status == "fail"]
+
+    def test_a_committed_run_that_edits_its_cited_source_is_still_caught(self, repo):
+        base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                              capture_output=True, text=True).stdout.strip()
+        _edit_source(repo)
+        _fix_record(repo)
+        (repo / "docs" / "CONTRACT.md").write_text("# Contract\n\nchanged\n", encoding="utf-8")
+        _git(repo, "add", "-A")
+        _git(repo, "commit", "-qm", "fix(calc): clamp the rate")
+        verdict, _c, gates = _run(repo, base=base)
+        assert verdict == REJECTED
+        assert "citation-predates-fix" in _fail_names(gates)
+
+
+class TestNoise:
+    def test_build_artifacts_are_not_source(self, repo):
+        """__pycache__ under a source root is not a change anyone declares."""
+        _edit_source(repo)
+        cache = repo / "src" / "__pycache__"
+        cache.mkdir()
+        (cache / "calc.cpython-311.pyc").write_bytes(b"\x00")
+        _fix_record(repo, paths=["src/calc.py"])
+        _verdict, _c, gates = _run(repo)
+        assert "surface-covers-diff" not in _fail_names(gates)
+
+    def test_the_first_changed_path_is_not_truncated(self, repo):
+        """`git status --porcelain` encodes status in the first two columns, so
+        the leading space of the first line is data. Stripping the whole output
+        ate a character off exactly one path per run."""
+        from cli.verdict import changed_files
+
+        _edit_source(repo)
+        (repo / "docs" / "CONTRACT.md").write_text("# c\n", encoding="utf-8")
+        changed = changed_files(repo, "")
+        assert all(not p.startswith("ocs/") for p in changed), changed
+        assert "docs/CONTRACT.md" in changed
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+
+class TestWiring:
+    def test_registers_the_subcommand(self):
+        import argparse as ap
+
+        from cli.cmd_verdict import cmd_verdict, register
+
+        parser = ap.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        register(sub)
+        args = parser.parse_args(["verdict", "--target", "."])
+        assert args.func is cmd_verdict
+
+    def test_registered_in_the_main_dispatch_table(self):
+        from cli import govkit
+
+        assert "cli.cmd_verdict" in [r.__module__ for r in govkit._REGISTRARS]
+
+
+def _cli_args(repo: Path, **kw):
+    import argparse as ap
+
+    base = {
+        "target": str(repo), "base": "", "source_roots": "src/",
+        "test_command": "", "no_validate": True, "json": False,
+    }
+    base.update(kw)
+    return ap.Namespace(**base)
+
+
+class TestCli:
+    def test_exit_code_carries_the_verdict(self, repo, capsys):
+        """The harness branches on this, so it is the contract."""
+        from cli.cmd_verdict import cmd_verdict
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_verdict(_cli_args(repo))
+        assert exc.value.code == 2  # untouched tree => REFUSED
+        assert "REFUSED" in capsys.readouterr().out
+
+    def test_source_roots_are_required_rather_than_guessed(self, repo, capsys):
+        """`.govkit/skill_context.yaml` may record `source_root: ""`, which
+        means 'no single root' — guessing from it would silently scope the
+        checks to nothing."""
+        from cli.cmd_verdict import cmd_verdict
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_verdict(_cli_args(repo, source_roots=""))
+        assert exc.value.code == 1
+        assert "--source-roots is required" in capsys.readouterr().err
+
+    def test_missing_target_is_reported_not_crashed(self, tmp_path, capsys):
+        from cli.cmd_verdict import cmd_verdict
+
+        with pytest.raises(SystemExit) as exc:
+            cmd_verdict(_cli_args(tmp_path / "nope"))
+        assert exc.value.code == 1
+        assert "does not exist" in capsys.readouterr().err
+
+    def test_json_output_is_machine_readable(self, repo, capsys):
+        import json
+
+        from cli.cmd_verdict import cmd_verdict
+
+        _edit_source(repo)
+        _fix_record(repo)
+        with pytest.raises(SystemExit):
+            cmd_verdict(_cli_args(repo, json=True,
+                                  test_command=f'"{sys.executable}" -c "raise SystemExit(1)"'))
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["verdict"] in {FIXED, REJECTED, REFUSED, BLOCKED}
+        assert {g["gate"] for g in payload["gates"]}, payload
+
+
+class TestValidateGate:
+    """`govkit validate` is the one gate that shells out. Covered once here so
+    the rest of the suite need not pay for it."""
+
+    def test_a_govkit_governed_repo_passes_its_own_validate(self, repo):
+        _edit_source(repo)
+        _fix_record(repo)
+        _verdict, _code, gates = _run(repo, run_validate=True)
+        names = {g.gate for g in gates}
+        assert "govkit-validate" in names, names
+
+    def test_the_gate_is_absent_when_switched_off(self, repo):
+        _edit_source(repo)
+        _fix_record(repo)
+        _verdict, _code, gates = _run(repo, run_validate=False)
+        assert "govkit-validate" not in {g.gate for g in gates}


### PR DESCRIPTION
Adds `govkit verdict` — for a harness driving an autonomous bug-fix agent: **may this run open a PR?**

## Why the agent cannot answer this

I drove Claude Code headless against a govkit-governed L4 sandbox five times: a clean fix, a correct refusal, a stop at the ADR gate, and two bad outcomes. `claude -p` returned `subtype: success` and **exit 0 every single time.**

So the runner has nothing to branch on. The verdict has to be derived from the working tree, the diff and the gates — the same move `govkit evidence` makes for quality: measure it, don't accept the producer's account of it.

`AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §5.3 sets the constraint this obeys — *"the calling harness, not govkit, has to be what says no."* This command does not say no. It reports what is true and exits with a code; the decision stays with the caller.

## Four outcomes, kept distinct on purpose

| Exit | Verdict | Harness does |
|---|---|---|
| `0` | FIXED | commit and open the PR |
| `1` | REJECTED | no PR, no blind retry — a human reads it |
| `2` | REFUSED | agent declined, left no trace. **A success** |
| `3` | BLOCKED | stopped at a human gate. Escalate |

Collapsing REFUSED into failure is how autonomy goes wrong: it invites a retry loop, and a retry loop against a gate the agent cannot honestly clear is exactly the pressure that produces the self-certification §4 warns about.

## Two gates exist because real runs failed them

**`red-before-green`** reverts the source, keeps the new tests, and requires a failure. Every one of the five runs asserted a red-green cycle *in its own summary*; this is what checks it. Handles a committed run (`--base`) and an uncommitted one, and restores the tree either way — a verdict tool that damages the tree it is judging is worse than none.

**`citation-predates-fix`** rejects a run that modified the source it cites as `expectation.source`. In a real run the agent found a contract I had deleted, recovered it from git history, wrote it back, cited it, and **passed every govkit gate** — `validate` checks the cited path resolves, not that it predates the fix. Good-faith archaeology, and still a self-manufactured eligibility a reviewer would not spot.

## Design decisions worth reviewing

- **`--test-command` is required for certification.** Without it `red-before-green` cannot run, so nothing is FIXED. This is the contract `govkit evidence` states: an unmeasured dimension is indistinguishable from a verified one. It also keeps the command stack-agnostic (`pytest -q`, `go test ./...`, `dotnet test`).
- **`--source-roots` is required, not inferred.** `skill_context.yaml` records `source_root: ""` for repos with no single root, and `ci/README.md` already warns that is not a value to paste in. Guessing would silently scope every check to nothing.
- **A fix record with no source change is REJECTED, not BLOCKED.** A record describes a repair; without the repair it is a claim about work that was not done. A *feature* package with no code is BLOCKED — that is the ADR gate working.

## Verification

- 28 tests in `tests/test_verdict.py`; 2828 in the suite.
- Classified all five real agent runs correctly through the shipped CLI: FIXED / REJECTED / BLOCKED / REJECTED / REFUSED.
- Three bugs found and fixed while validating, all in my own code: `.strip()` on `git status --porcelain` ate a character off the first path; the default porcelain collapsed untracked directories so a newly written ADR was invisible; and stashing could not revert a *committed* fix.
- Test runtime cut 111s → 30s by scoping the interpreter-spawning `govkit-validate` gate to one dedicated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
