### PR TITLE
chore(release): 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-08-15
+
+Three things a governed repo could previously only assert about itself, it can
+now show: that a defect fix restores established behavior, that a quality score
+was measured rather than predicted, and that an ADR was approved by someone
+entitled to approve it. Plus `govkit verdict`, which asks the same question of
+an autonomous agent's own run.
+
 ### Fixed
 
 - **`govkit upgrade` no longer reverts your stack to the bundled baseline**
@@ -52,6 +60,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   contract from git history, restored it, cited it, and passed every govkit gate,
   because `validate` checks the cited path resolves rather than that it predates
   the fix.
+
+  govkit's own ADRs are carved out of the `Accepted` check, on the same
+  `govkit:editable` body hash `govkit validate` and the CI gate use: govkit
+  ships one that says `Accepted` because it is govkit's decision, and without
+  the carve-out the first run after adoption was rejected for an ADR the team
+  never wrote.
 
   govkit supplies the measurement; the harness still makes the decision, per
   `AUTONOMOUS_BUGFIX_AGENT_ANALYSIS.md` §5.3.

--- a/ci/azure/data-common-gate.yml
+++ b/ci/azure/data-common-gate.yml
@@ -54,7 +54,7 @@ stages:
               script: |
                 set -euo pipefail
                 python -m pip install --upgrade pip
-                python -m pip install govkit~=0.18.0
+                python -m pip install govkit~=0.19.0
 
           - task: Bash@3
             displayName: Run GovKit validation

--- a/ci/azure/evidence-gate.yml
+++ b/ci/azure/evidence-gate.yml
@@ -37,7 +37,7 @@ stages:
               versionSpec: '3.11'
             displayName: Set up Python
 
-          - script: pip install govkit~=0.18.0
+          - script: pip install govkit~=0.19.0
             displayName: Install GovKit
 
           # CONFIGURE THIS — replace with your own test command.

--- a/ci/azure/l3-ui-nextjs-quality-gate.yml
+++ b/ci/azure/l3-ui-nextjs-quality-gate.yml
@@ -30,7 +30,7 @@ stages:
               versionSpec: '3.11'
             displayName: Set up Python
 
-          - script: pip install govkit~=0.18.0
+          - script: pip install govkit~=0.19.0
             displayName: Install GovKit
 
           - script: govkit doctor --target .

--- a/ci/azure/ui-nextjs-quality-gate.yml
+++ b/ci/azure/ui-nextjs-quality-gate.yml
@@ -30,7 +30,7 @@ stages:
               versionSpec: '3.11'
             displayName: Set up Python
 
-          - script: pip install govkit~=0.18.0
+          - script: pip install govkit~=0.19.0
             displayName: Install GovKit
 
           - script: govkit doctor --target .

--- a/ci/github/data-common-gate.yml
+++ b/ci/github/data-common-gate.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install govkit~=0.18.0
+          python -m pip install govkit~=0.19.0
 
       - name: Run GovKit validation
         run: |

--- a/ci/github/evidence-gate.yml
+++ b/ci/github/evidence-gate.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install GovKit
-        run: pip install govkit~=0.18.0
+        run: pip install govkit~=0.19.0
 
       # CONFIGURE THIS — replace with your own test command.
       # It must leave JUnit XML (and, for UI, axe JSON) in the workspace.

--- a/ci/github/l3-ui-nextjs-quality-gate.yml
+++ b/ci/github/l3-ui-nextjs-quality-gate.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install GovKit
-        run: pip install govkit~=0.18.0
+        run: pip install govkit~=0.19.0
 
       - name: Enforce API and database boundary
         run: govkit doctor --target .

--- a/ci/github/ui-nextjs-quality-gate.yml
+++ b/ci/github/ui-nextjs-quality-gate.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install GovKit
-        run: pip install govkit~=0.18.0
+        run: pip install govkit~=0.19.0
 
       - name: Enforce API and database boundary
         run: govkit doctor --target .

--- a/cli/verdict.py
+++ b/cli/verdict.py
@@ -50,6 +50,8 @@ from pathlib import Path
 
 import yaml
 
+from .approval import is_govkit_authored
+
 FIXED = "FIXED"
 REJECTED = "REJECTED"
 REFUSED = "REFUSED"
@@ -207,7 +209,15 @@ def accepted_adr(target: Path, changed: list[str]) -> str:
     `Accepted` is a derived state — true because an approver approved that
     decision at that commit. An author may only ever write `Proposed`, so an
     agent that wrote `Accepted` has asserted an approval that did not happen.
-    TEMPLATE.md is excluded: its Status line is the vocabulary menu.
+
+    Two exclusions. TEMPLATE.md, because its Status line is the vocabulary
+    menu rather than a claim. And govkit's own ADRs: it ships one
+    (`docs/data/architecture/ADR/0001-…`) that says `Accepted` because it is
+    govkit's decision, and it lands in every `--type data` install — so any run
+    that happened to include a govkit install, the first one after adoption
+    most obviously, was rejected for an ADR the team never wrote. The
+    discriminator is the `govkit:editable` body hash `cli/approval.py` and both
+    CI gates already use; edit the file and it becomes the team's claim again.
     """
     for rel in changed:
         norm = rel.replace("\\", "/")
@@ -220,8 +230,11 @@ def accepted_adr(target: Path, changed: list[str]) -> str:
         except (OSError, UnicodeDecodeError):
             continue
         match = _STATUS_RE.search(text)
-        if match and match.group(1).strip() == _GATE_STATUS:
-            return norm
+        if not match or match.group(1).strip() != _GATE_STATUS:
+            continue
+        if is_govkit_authored(text):
+            continue
+        return norm
     return ""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.18.0"
+version = "0.19.0"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -576,3 +576,70 @@ class TestRegeneratedArtifactsDoNotBreakRestore:
                                  capture_output=True, text=True).stdout.strip()
         assert stashes == "", f"left a stash behind: {stashes}"
         assert "min(" in (repo / "src" / "calc.py").read_text(encoding="utf-8")
+
+
+class TestGovkitAuthoredAdrs:
+    """govkit ships one real ADR — `docs/data/architecture/ADR/0001-…` — and it
+    says `Accepted`, because it is govkit's decision and govkit's approvers
+    made it. It lands in every `--type data` install.
+
+    `cli/approval.py` and both CI gates already carve it out. This one did not,
+    so any run that happened to include a govkit install — the first run after
+    adoption, most obviously — was REJECTED for an ADR the team never wrote.
+    Requiring a customer's approver to attest a decision govkit made for them
+    is incoherent, and telling a human to investigate it is worse.
+    """
+
+    def _govkit_adr(self, repo: Path, *, tamper: bool = False) -> None:
+        from cli.headers import compute_body_hash, format_editable_header
+
+        body = "# ADR-0001: govkit's own decision\n\n## Status\nAccepted\n\n## 1. Context\n\nOurs.\n"
+        digest = compute_body_hash(body)
+        if tamper:
+            body += "\n## 2. Decision\n\nThe team edited this.\n"
+        d = repo / "docs" / "data" / "architecture" / "ADR"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "0001-data-features-skip-prediction-gate.md").write_text(
+            format_editable_header(baseline="0.19.0", body_hash=digest) + body,
+            encoding="utf-8",
+        )
+
+    def test_an_unmodified_govkit_adr_is_not_a_self_acceptance(self, repo):
+        self._govkit_adr(repo)
+        _edit_source(repo)
+        _fix_record(repo)
+        _verdict, _code, gates = _run(repo)
+        assert "adr-not-self-accepted" not in _fail_names(gates), (
+            next(g.detail for g in gates if g.gate == "adr-not-self-accepted")
+        )
+
+    def test_a_fresh_install_alone_is_not_rejected(self, repo):
+        """The shape the release smoke hit: govkit applied, nothing else."""
+        self._govkit_adr(repo)
+        verdict, _code, _gates = _run(repo)
+        assert verdict != REJECTED
+
+    def test_editing_a_govkit_adr_makes_it_the_teams_claim(self, repo):
+        """The carve-out keys on the body hash, so an edited copy is the
+        team's again — including its Accepted status."""
+        self._govkit_adr(repo, tamper=True)
+        _edit_source(repo)
+        _fix_record(repo)
+        _verdict, _code, gates = _run(repo)
+        assert "adr-not-self-accepted" in _fail_names(gates)
+
+    def test_a_hand_written_header_does_not_buy_silence(self, repo):
+        """A forged hash must not let a team-authored ADR claim Accepted."""
+        from cli.headers import format_editable_header
+
+        d = repo / "docs" / "backend" / "architecture" / "ADR"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "0002-ours.md").write_text(
+            format_editable_header(baseline="0.19.0", body_hash="0" * 64)
+            + "# ADR-0002\n\n## Status\nAccepted\n",
+            encoding="utf-8",
+        )
+        _edit_source(repo)
+        _fix_record(repo)
+        _verdict, _code, gates = _run(repo)
+        assert "adr-not-self-accepted" in _fail_names(gates)


### PR DESCRIPTION
Prepares the 0.19.0 release. **Publishing is triggered by a published GitHub Release**, so merging this does not ship anything — the release step stays with a human.

## What's in 0.19.0

| | |
|---|---|
| Added | `govkit verdict`, `govkit evidence`, ADR approval attestation, the defect lane |
| Changed | `adr-author` writes `Proposed` and stops; ADR templates request a decision rather than record one; FIRST/Virtue prediction is now an advisory forecast |
| Fixed | `govkit upgrade` no longer reverts a team's stack to the bundled baseline (#132) |

Minor rather than patch: two new subcommands and a merge-gate becoming advisory.

## The pin rule

`pyproject.toml` and the **eight** CI templates pinning `govkit~=0.18.0` move in this one commit, per CONTRIBUTING's *"gates that invoke govkit must install it at the shipping version"*. `tests/test_ci_govkit_dependency.py` asserts the pin equals the project version — this is the first release since that rule existed, and it passes.

## One real bug found by the release smoke

Not in packaging — in `verdict`. Installing govkit into a fresh repo and running `govkit verdict` returned:

```
FAIL  adr-not-self-accepted   docs/data/architecture/ADR/0001-…md claims Accepted
```

That is **govkit's own shipped ADR**. It says `Accepted` because it is govkit's decision, and it lands in every `--type data` install — so any repo where govkit had been applied near the agent run, most obviously the first run after adoption, was REJECTED for an ADR the team never wrote. Exactly the defect class the approval work called non-negotiable.

`cli/approval.py` and both CI gates already carve it out on the `govkit:editable` body hash. `verdict` now uses that same discriminator rather than inventing a second one: an edited copy is the team's claim again, and a forged hash buys nothing. Four regression tests.

## Verification

- 2843 tests pass at 0.19.0 (`GOVKIT_VERSION` reads package metadata, so the editable install was refreshed first).
- `python -m build` produces wheel + sdist; `twine check` **passes** on a fresh runner's toolchain.
  - It fails locally with `'2.5' is not a valid metadata version` — that is a stale `packaging` 24.2 in the dev env against hatchling's Metadata-Version 2.5, not a release blocker. Reproduced the CI toolchain in a clean venv (twine 7.0.0 / packaging 26.3) to confirm.
- Wheel carries every new bundled asset: `cli/governance/approval_policy.yaml`, its schema, both `adr-approval-gate.yml`, `cli/verdict.py`, `cli/approval.py`.
- Clean-venv install of the wheel: `apply --type data --level 4` ships the policy and gate, `validate` reports the attestation section and stays silent about ADR-0001, `verdict` classifies correctly.

## After merging

Create a GitHub Release tagged `v0.19.0` — that fires `publish.yml`, which builds and publishes via trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)