### PR TITLE
feat(extensions): packs can carry agent skills; vendor otter-skills; add --from-git

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,3 +194,24 @@ jobs:
           test -f "$tmp/docs/data/architecture/BOUNDARIES.md"       # baseline contracts
           test -f "$tmp/docs/data/architecture/TECH_STACK.md"       # python-dbt overlay
           grep -q "baseline: python-dbt@" "$tmp/docs/data/architecture/TECH_STACK.md"
+
+      - name: Extension list/add resolve from wheel layout
+        # Extension packs ship via the extensions/ -> cli/extension_packs/
+        # force-include; no other wheel-smoke step touches that mapping, so a
+        # broken or dropped include would only fail here. `add` also proves
+        # the skills-carrying path end-to-end from the wheel: the otter-skills
+        # pack lands with its license files and installs its skills into the
+        # applied agent's skills dir.
+        run: |
+          set -euxo pipefail
+          tmp="$(mktemp -d)"
+          /tmp/wheel-smoke-venv/bin/govkit apply --agent claude-code \
+              --target "$tmp" --level 4 --type api --ci github \
+              --stack python-fastapi
+          out="$(/tmp/wheel-smoke-venv/bin/govkit extension list)"
+          echo "$out"
+          echo "$out" | grep -q "otter-skills"
+          /tmp/wheel-smoke-venv/bin/govkit extension add otter-skills --target "$tmp"
+          test -f "$tmp/extensions/otter-skills/LICENSE"
+          test -f "$tmp/extensions/otter-skills/NOTICE"
+          test -f "$tmp/.claude/skills/otter-unit-testing/SKILL.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **Extension packs can carry agent skills.** A pack manifest may declare
+  `skills` (`{path, install_as}` entries) and an `origin` provenance block;
+  `govkit extension add` installs each declared skill into the applied
+  agent's skills directory, skipping any directory that already exists
+  (`--force` refreshes). Third-party content never clobbers team edits.
+- **`otter-skills` extension pack** — seven software-craft skills (unit
+  testing, atomic commits, story splitting, naming, legacy-code safety,
+  refactoring review) vendored from
+  [tottinge/otter-skills](https://github.com/tottinge/otter-skills) at a
+  pinned commit, Apache-2.0 with upstream LICENSE/NOTICE shipped in the
+  pack. Installs as `otter-<skill>`; refresh via
+  `scripts/sync_otter_skills.py` (dev-time only — installs stay offline).
+
 ## [0.19.0] — 2026-08-15
 
 Three things a governed repo could previously only assert about itself, it can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `govkit extension add` installs each declared skill into the applied
   agent's skills directory, skipping any directory that already exists
   (`--force` refreshes). Third-party content never clobbers team edits.
+- **`extension add --from-git <url> [--ref <sha>]`** — fetch an extension
+  pack from any git repository whose root carries a govkit `manifest.yaml`.
+  govkit's only network touch, on this explicit opt-in; the resolved commit
+  is pinned into the installed manifest's `origin.upstream_ref`, so the
+  committed project copy is the record and upstream updates arrive as
+  reviewable diffs on re-add.
 - **`otter-skills` extension pack** — seven software-craft skills (unit
   testing, atomic commits, story splitting, naming, legacy-code safety,
   refactoring review) vendored from

--- a/GOVKIT_TUTORIAL.md
+++ b/GOVKIT_TUTORIAL.md
@@ -648,6 +648,12 @@ seven third-party software-craft skills (vendored from tottinge/otter-skills
 at a pinned commit) into the applied agent's skills directory as
 `otter-<skill>`, skipping any skill directory that already exists.
 
+Packs need not be bundled. `govkit extension add --from-git <url>` fetches
+one from any git repository carrying a root `manifest.yaml`, pins the
+resolved commit into the installed manifest, and leaves the copy under
+`extensions/<id>/` for your repo to hold — updates arrive as reviewable
+diffs when you re-add with `--force`.
+
 ### Upgrades And Stack Changes
 
 Refresh files GovKit owns while preserving project-owned edits:

--- a/GOVKIT_TUTORIAL.md
+++ b/GOVKIT_TUTORIAL.md
@@ -643,6 +643,11 @@ provider-neutral LLM applications, vision inference, and skill-oriented agent
 architecture. Install them when the project needs those constraints; do not add
 them just to make a first adoption look complete.
 
+A pack can also carry agent skills: the bundled `otter-skills` pack installs
+seven third-party software-craft skills (vendored from tottinge/otter-skills
+at a pinned commit) into the applied agent's skills directory as
+`otter-<skill>`, skipping any skill directory that already exists.
+
 ### Upgrades And Stack Changes
 
 Refresh files GovKit owns while preserving project-owned edits:
@@ -712,7 +717,7 @@ needs to find the underlying files.
 | Worked examples | `features/schema_contract_example/`, `features/ui_task_dashboard/`, `features/example-jwt-unification/` | Example governed feature material. |
 | Stack overlays | `cli/stacks/` | Runtime/framework-specific contract overlays for backend and data project types. |
 | CI gates | `ci/github/`, `ci/azure/` | Type-, level-, stack-, and extension-aware workflow templates. |
-| Extensions | `extensions/` | Optional contract packs for LLM applications, vision inference, and skill-oriented agent architecture. |
+| Extensions | `extensions/` | Optional packs: contracts for LLM applications, vision inference, and skill-oriented agent architecture, plus the third-party otter-skills agent-skills pack. |
 | Tests | `tests/` | Regression coverage for CLI behavior, schema contracts, manifests, templates, stack selection, validation, and CI composition. |
 | Research/planning | `plans/`, `plans/research/` | Design plans, product positioning, page prototypes, and roadmap material. |
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,3 +2,13 @@ Governed AI Delivery (GovKit)
 Copyright 2026 Accelerated Innovation
 
 This product includes software developed by Accelerated Innovation.
+
+## Third-party components
+
+This distribution bundles the "otter-skills" extension pack
+(extensions/otter-skills/), vendored from
+https://github.com/tottinge/otter-skills (Copyright 2026 Tim Ottinger),
+licensed under the Apache License, Version 2.0. The upstream LICENSE and
+NOTICE files are included verbatim in the vendored pack and travel with every
+copy `govkit extension add` installs. The exact pinned upstream commit is
+recorded as `origin.upstream_ref` in extensions/otter-skills/manifest.yaml.

--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ See [`cli/stacks/README.md`](cli/stacks/README.md) for the complete guide, inclu
 
 ## Extensions
 
-Govkit ships **optional extension packs** that layer additional architecture contracts on top of the core kit — currently `llm-application`, `skill-oriented-agent-architecture`, and `vision-inference`. Add one with `govkit extension add`, or drop the folder in by hand; either way the folder under `extensions/<id>/` in your project *is* the install.
+Govkit ships **optional extension packs** that layer additional architecture contracts on top of the core kit — currently `llm-application`, `skill-oriented-agent-architecture`, `vision-inference`, and the third-party `otter-skills`. Add one with `govkit extension add`, or drop the folder in by hand; either way the folder under `extensions/<id>/` in your project *is* the install.
 
 ### How to add an extension
 
@@ -698,9 +698,14 @@ govkit extension list                              # see what's bundled
 govkit extension add llm-application --target .    # provider-neutral LLM contracts
 govkit extension add vision-inference --target .   # copy it into extensions/vision-inference/
 govkit extension add skill-oriented-agent-architecture --target .
+govkit extension add otter-skills --target .       # third-party software-craft skills
 ```
 
 `add` copies the pack into your project's `extensions/<id>/` and validates it in place. It **warns but proceeds** if the pack's `supported_levels` / `supported_project_types` don't match your `.govkit` marker, or if a core contract it `extends` isn't installed yet (e.g. a generative pack's L5 contracts in a non-L5 project). Pass `--force` to overwrite an existing folder.
+
+### Packs that carry agent skills
+
+A pack may declare `skills` in its manifest — agent skill directories that `extension add` installs into the applied agent's skills dir (`.claude/skills/`, `.agents/skills/`, or `.github/skills/`, per your marker). The bundled `otter-skills` pack works this way: seven software-craft skills (unit testing, atomic commits, story splitting, naming, legacy-code safety, refactoring review) vendored from the open-source [tottinge/otter-skills](https://github.com/tottinge/otter-skills) repository at a pinned commit, installing as `otter-<skill>`. A skill directory that already exists is **skipped, never overwritten** — refresh to the bundled version with `--force`. The upstream Apache-2.0 LICENSE and NOTICE travel with the pack; see [extensions/otter-skills/README.md](extensions/otter-skills/README.md) for provenance.
 
 **Or add one by hand** — the folder *is* the install, so you can vendor any extension, including ones not bundled with govkit:
 

--- a/README.md
+++ b/README.md
@@ -703,6 +703,15 @@ govkit extension add otter-skills --target .       # third-party software-craft 
 
 `add` copies the pack into your project's `extensions/<id>/` and validates it in place. It **warns but proceeds** if the pack's `supported_levels` / `supported_project_types` don't match your `.govkit` marker, or if a core contract it `extends` isn't installed yet (e.g. a generative pack's L5 contracts in a non-L5 project). Pass `--force` to overwrite an existing folder.
 
+**Or fetch a pack from any git repository** whose root carries a govkit `manifest.yaml`:
+
+```bash
+govkit extension add --from-git https://github.com/someone/their-pack --target .
+govkit extension add --from-git https://github.com/someone/their-pack --ref <sha> --target .
+```
+
+This is govkit's only network access, and only on this explicit opt-in — `apply` and the bundled packs stay offline. The resolved commit is recorded in the installed manifest's `origin.upstream_ref`, and the fetched copy under `extensions/<id>/` is what you commit — so your project holds the pin, teammates and CI never re-fetch, and pulling upstream updates later (`--from-git ... --force`) lands as an ordinary reviewable diff in your repo.
+
 ### Packs that carry agent skills
 
 A pack may declare `skills` in its manifest — agent skill directories that `extension add` installs into the applied agent's skills dir (`.claude/skills/`, `.agents/skills/`, or `.github/skills/`, per your marker). The bundled `otter-skills` pack works this way: seven software-craft skills (unit testing, atomic commits, story splitting, naming, legacy-code safety, refactoring review) vendored from the open-source [tottinge/otter-skills](https://github.com/tottinge/otter-skills) repository at a pinned commit, installing as `otter-<skill>`. A skill directory that already exists is **skipped, never overwritten** — refresh to the bundled version with `--force`. The upstream Apache-2.0 LICENSE and NOTICE travel with the pack; see [extensions/otter-skills/README.md](extensions/otter-skills/README.md) for provenance.

--- a/cli/cmd_extension.py
+++ b/cli/cmd_extension.py
@@ -9,22 +9,37 @@ Extension packs ship with the wheel (cli/extension_packs/, force-included from
 the repo's extensions/). `extension add` copies a pack into the target's
 extensions/<id>/ folder, where govkit's existing discovery/validate already
 operates. Mirrors the shape of `cmd_stack` (list + apply over a bundled set).
+
+`extension add --from-git <url>` fetches a pack from a git repository whose
+root carries a govkit manifest.yaml instead of using the bundled set. This is
+the one place govkit touches the network, and only on this explicit opt-in —
+`apply` and everything else stay offline. The fetched copy lands under the
+target's extensions/<id>/ with the resolved commit recorded in
+origin.upstream_ref, so the *project* holds the pin and later re-adds show
+upstream changes as reviewable diffs.
 """
 
 from __future__ import annotations
 
 import argparse
 import shutil
+import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+import yaml
 
 from . import paths
 from .agent_layout import AGENT_LAYOUTS
 from .extensions import (
     EXTENSIONS_DIR,
+    MANIFEST_FILE,
+    Extension,
     discover_extensions,
     discover_in,
     is_valid_extension_id,
+    load_manifest,
     validate_extension,
 )
 from .marker import read_govkit_marker
@@ -185,8 +200,121 @@ def _install_pack_skills(
         print(f"  installed: {layout.skills_dir}/{install_as}/")
 
 
+def _git(cmd: list[str], cwd: Path | None = None) -> str:
+    """Run a git command; exit with the stderr on failure, and with an
+    instruction to install git when the binary is absent."""
+    try:
+        return subprocess.run(
+            ["git", *cmd], cwd=cwd, check=True, capture_output=True, text=True
+        ).stdout.strip()
+    except FileNotFoundError:
+        print("Error: --from-git requires the `git` command on PATH.", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as exc:
+        print(f"Error: git {cmd[0]} failed: {exc.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _fetch_git_pack(url: str, ref: str | None, clone_dir: Path) -> tuple[Extension, str]:
+    """Clone `url` (checked out at `ref` when given) and read the govkit
+    manifest at its root. Returns the pack plus the resolved commit SHA —
+    the pin recorded into the installed copy."""
+    _git(["clone", "--quiet", url, str(clone_dir)])
+    if ref:
+        _git(["checkout", "--quiet", ref], cwd=clone_dir)
+    sha = _git(["rev-parse", "HEAD"], cwd=clone_dir)
+
+    manifest, err = load_manifest(clone_dir / MANIFEST_FILE)
+    if manifest is None:
+        print(
+            f"Error: {url} does not carry a govkit extension pack — "
+            f"expected {MANIFEST_FILE} at the repository root ({err}).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    ext_id = manifest.get("id")
+    if not is_valid_extension_id(ext_id):
+        print(
+            f"Error: the fetched manifest's id {ext_id!r} is not a valid "
+            "extension id; refusing to install.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return Extension(id=ext_id, root=clone_dir, manifest=manifest), sha
+
+
+def _ignore_git_and_symlinks(src: str, names: list[str]) -> set[str]:
+    """copytree ignore for fetched repos: drop .git, and drop symlinks —
+    dereferencing a hostile repo's symlink would copy files from the
+    maintainer's machine into a folder that gets committed."""
+    return {n for n in names if n == ".git" or (Path(src) / n).is_symlink()}
+
+
+def _record_git_origin(dest: Path, url: str, sha: str) -> None:
+    """Pin the fetch into the installed manifest's origin block. The project
+    copy is the record — a later re-add shows upstream changes as a diff
+    against exactly this commit."""
+    manifest_path = dest / MANIFEST_FILE
+    manifest, err = load_manifest(manifest_path)
+    if manifest is None:  # pragma: no cover — the fetch already loaded it
+        print(f"  WARN: could not record origin pin: {err}")
+        return
+    origin = dict(manifest.get("origin") or {})
+    origin["upstream_url"] = url
+    origin["upstream_ref"] = sha
+    origin.setdefault("license", "unknown")
+    manifest["origin"] = origin
+    manifest_path.write_text(
+        yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True), encoding="utf-8"
+    )
+
+
+def _add_pack(
+    pack: Extension,
+    target: Path,
+    force: bool,
+    copy_ignore=None,
+    git_origin: tuple[str, str] | None = None,
+) -> None:
+    """Shared tail of `extension add`: copy the pack into the target, warn on
+    marker mismatches, install declared skills, validate in place."""
+    dest = _resolve_dest(target, pack)
+
+    if dest.exists() and not force:
+        print(
+            f"Error: '{dest}' already exists. Re-run with --force to overwrite.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(pack.root, dest, ignore=copy_ignore)
+
+    print(f"\nAdding extension '{pack.id}' to {target}")
+    name = pack.manifest.get("name", pack.id)
+    if name != pack.id:
+        print(f"  {name}")
+    if git_origin is not None:
+        url, sha = git_origin
+        _record_git_origin(dest, url, sha)
+        print(f"  pinned: {url} @ {sha}")
+
+    marker = read_govkit_marker(target)
+    if marker:
+        for warning in _compat_warnings(pack.manifest, marker):
+            print(f"  WARN: {warning}")
+
+    _install_pack_skills(dest, pack.manifest, target, marker, force)
+
+    print(f"Done. Extension '{pack.id}' added to {dest}")
+    _print_validation_notes(target, pack.id)
+
+
 def cmd_extension_add(args: argparse.Namespace) -> None:
-    """Copy a bundled extension pack into <target>/extensions/<id>/.
+    """Copy an extension pack into <target>/extensions/<id>/ — a bundled pack
+    by id, or any git repository carrying a root manifest.yaml via --from-git.
 
     Refuses to clobber an existing folder without --force. After copying,
     validates the pack in place and surfaces any issues as non-fatal notes
@@ -198,6 +326,19 @@ def cmd_extension_add(args: argparse.Namespace) -> None:
         print(f"Error: target directory '{target}' does not exist.", file=sys.stderr)
         sys.exit(1)
 
+    from_git = getattr(args, "from_git", None)
+    if from_git:
+        with tempfile.TemporaryDirectory() as tmp:
+            pack, sha = _fetch_git_pack(
+                from_git, getattr(args, "ref", None), Path(tmp) / "pack"
+            )
+            _add_pack(
+                pack, target, args.force,
+                copy_ignore=_ignore_git_and_symlinks,
+                git_origin=(from_git, sha),
+            )
+        return
+
     pack = next((e for e in _bundled_packs() if e.id == args.extension_id), None)
     if pack is None:
         print(
@@ -206,35 +347,7 @@ def cmd_extension_add(args: argparse.Namespace) -> None:
             file=sys.stderr,
         )
         sys.exit(1)
-
-    dest = _resolve_dest(target, pack)
-
-    if dest.exists() and not args.force:
-        print(
-            f"Error: '{dest}' already exists. Re-run with --force to overwrite.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    if dest.exists():
-        shutil.rmtree(dest)
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(pack.root, dest)
-
-    print(f"\nAdding extension '{pack.id}' to {target}")
-    name = pack.manifest.get("name", pack.id)
-    if name != pack.id:
-        print(f"  {name}")
-
-    marker = read_govkit_marker(target)
-    if marker:
-        for warning in _compat_warnings(pack.manifest, marker):
-            print(f"  WARN: {warning}")
-
-    _install_pack_skills(dest, pack.manifest, target, marker, args.force)
-
-    print(f"Done. Extension '{pack.id}' added to {dest}")
-    _print_validation_notes(target, pack.id)
+    _add_pack(pack, target, args.force)
 
 
 def register(subparsers) -> None:
@@ -249,15 +362,43 @@ def register(subparsers) -> None:
     list_parser.set_defaults(func=cmd_extension_list)
 
     add_parser = ext_sub.add_parser(
-        "add", help="Add a bundled extension pack to a project"
+        "add", help="Add a bundled or remote extension pack to a project"
     )
     add_parser.add_argument(
         "extension_id",
-        help="Extension pack id (e.g. vision-inference). See `govkit extension list`.",
+        nargs="?",
+        help="Bundled extension pack id (e.g. vision-inference). "
+        "See `govkit extension list`. Omit when using --from-git.",
+    )
+    add_parser.add_argument(
+        "--from-git",
+        metavar="URL",
+        help="Fetch the pack from a git repository whose root carries a "
+        "govkit manifest.yaml, instead of the bundled set. The resolved "
+        "commit is recorded in the installed manifest's origin.upstream_ref.",
+    )
+    add_parser.add_argument(
+        "--ref",
+        help="Commit SHA, tag, or branch to check out with --from-git "
+        "(default: the repository's default branch head).",
     )
     add_parser.add_argument("--target", required=True, help=paths.TARGET_HELP)
     add_parser.add_argument(
         "--force", action="store_true",
         help="Overwrite an existing extensions/<id>/ folder",
     )
-    add_parser.set_defaults(func=cmd_extension_add)
+    add_parser.set_defaults(func=_cmd_extension_add_dispatch)
+
+
+def _cmd_extension_add_dispatch(args: argparse.Namespace) -> None:
+    """Argument cross-checks argparse can't express, then the real handler."""
+    if bool(args.extension_id) == bool(args.from_git):
+        print(
+            "Error: give exactly one of a bundled pack id or --from-git <url>.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    if args.ref and not args.from_git:
+        print("Error: --ref only applies with --from-git.", file=sys.stderr)
+        sys.exit(2)
+    cmd_extension_add(args)

--- a/cli/cmd_extension.py
+++ b/cli/cmd_extension.py
@@ -148,7 +148,12 @@ def _print_validation_notes(target: Path, ext_id: str) -> None:
 
 
 def _install_pack_skills(
-    pack_copy: Path, manifest: dict, target: Path, marker: dict | None, force: bool
+    pack_copy: Path,
+    manifest: dict,
+    target: Path,
+    marker: dict | None,
+    force: bool,
+    previously_declared: set[str] | None = None,
 ) -> None:
     """Install the pack's declared skills[] into the applied agent's skills dir.
 
@@ -158,20 +163,25 @@ def _install_pack_skills(
     own. An existing destination is skipped unless --force; re-add with
     --force is the refresh path. The copy source is the target's own pack
     copy — extensions/<id>/ stays the source of truth.
+
+    `previously_declared` carries the install_as names the replaced pack
+    version declared; names it dropped are reported (never deleted) so a
+    refresh cannot leave a removed skill active in silence.
     """
     skills = manifest.get("skills") or []
-    if not skills:
-        return
     agent = (marker or {}).get("agent")
     layout = AGENT_LAYOUTS.get(agent)
     if layout is None or layout.skills_dir is None:
-        print(
-            "  WARN: this pack declares agent skills, but no applied agent was "
-            "found in the target. Run `govkit apply` first, then re-run "
-            "`govkit extension add` with --force to install them."
-        )
+        if skills:
+            print(
+                "  WARN: this pack declares agent skills, but no applied agent was "
+                "found in the target. Run `govkit apply` first, then re-run "
+                "`govkit extension add` with --force to install them."
+            )
         return
-    skills_root = (target / layout.skills_dir).resolve()
+    skills_base = target / layout.skills_dir
+    skills_root = skills_base.resolve()
+    declared_now: set[str] = set()
     for entry in skills:
         if not isinstance(entry, dict):
             continue
@@ -182,13 +192,23 @@ def _install_pack_skills(
         if not isinstance(path, str) or not is_valid_extension_id(install_as):
             print(f"  WARN: skipping invalid skills entry {entry!r}")
             continue
+        declared_now.add(install_as)
         source = (pack_copy / path).resolve(strict=False)
         if not source.is_relative_to(pack_copy.resolve()) or not (source / "SKILL.md").is_file():
             print(f"  WARN: skipping skills entry with unsafe or empty path {path!r}")
             continue
-        dest = (skills_root / install_as).resolve(strict=False)
-        if not dest.is_relative_to(skills_root):
+        # fs ops use the UNRESOLVED dest: resolving first would follow a
+        # symlink and point rmtree at whatever the link targets. The resolved
+        # form is only the containment check.
+        dest = skills_base / install_as
+        if not dest.resolve(strict=False).is_relative_to(skills_root):
             print(f"  WARN: skipping skills entry {install_as!r} (unsafe destination)")
+            continue
+        if dest.is_symlink() or (dest.exists() and not dest.is_dir()):
+            print(
+                f"  WARN: {layout.skills_dir}/{install_as} exists but is not a "
+                "regular directory — refusing to touch it."
+            )
             continue
         if dest.exists():
             if not force:
@@ -196,8 +216,17 @@ def _install_pack_skills(
                 continue
             shutil.rmtree(dest)
         dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(source, dest)
+        # Same symlink rule as the git fetch: never dereference a pack's
+        # symlink into the project.
+        shutil.copytree(source, dest, ignore=_ignore_git_and_symlinks)
         print(f"  installed: {layout.skills_dir}/{install_as}/")
+    for stale in sorted((previously_declared or set()) - declared_now):
+        if is_valid_extension_id(stale) and (skills_base / stale).exists():
+            print(
+                f"  WARN: {layout.skills_dir}/{stale}/ was installed by the "
+                "previous pack version but is no longer declared — remove it "
+                "manually if it is unwanted."
+            )
 
 
 def _git(cmd: list[str], cwd: Path | None = None) -> str:
@@ -219,9 +248,16 @@ def _fetch_git_pack(url: str, ref: str | None, clone_dir: Path) -> tuple[Extensi
     """Clone `url` (checked out at `ref` when given) and read the govkit
     manifest at its root. Returns the pack plus the resolved commit SHA —
     the pin recorded into the installed copy."""
-    _git(["clone", "--quiet", url, str(clone_dir)])
+    # A value starting with "-" would be parsed by git as an option
+    # (e.g. --upload-pack=<cmd> executes a command); refuse it outright and
+    # terminate option parsing with "--" as a second layer.
+    for label, value in (("--from-git URL", url), ("--ref", ref)):
+        if value is not None and value.startswith("-"):
+            print(f"Error: {label} {value!r} must not start with '-'.", file=sys.stderr)
+            sys.exit(1)
+    _git(["clone", "--quiet", "--", url, str(clone_dir)])
     if ref:
-        _git(["checkout", "--quiet", ref], cwd=clone_dir)
+        _git(["checkout", "--quiet", ref, "--"], cwd=clone_dir)
     sha = _git(["rev-parse", "HEAD"], cwd=clone_dir)
 
     manifest, err = load_manifest(clone_dir / MANIFEST_FILE)
@@ -259,7 +295,11 @@ def _record_git_origin(dest: Path, url: str, sha: str) -> None:
     if manifest is None:  # pragma: no cover — the fetch already loaded it
         print(f"  WARN: could not record origin pin: {err}")
         return
-    origin = dict(manifest.get("origin") or {})
+    raw_origin = manifest.get("origin")
+    # A remote manifest is untrusted input: a non-mapping origin (e.g.
+    # `origin: hostile`) must degrade to an empty block, not crash the add
+    # after the previous pack copy was already replaced.
+    origin = dict(raw_origin) if isinstance(raw_origin, dict) else {}
     origin["upstream_url"] = url
     origin["upstream_ref"] = sha
     origin.setdefault("license", "unknown")
@@ -273,7 +313,6 @@ def _add_pack(
     pack: Extension,
     target: Path,
     force: bool,
-    copy_ignore=None,
     git_origin: tuple[str, str] | None = None,
 ) -> None:
     """Shared tail of `extension add`: copy the pack into the target, warn on
@@ -287,10 +326,20 @@ def _add_pack(
         )
         sys.exit(1)
 
+    previously_declared: set[str] = set()
     if dest.exists():
+        # Remember what the replaced pack version declared, so skills it
+        # dropped can be reported after the refresh (reported, not deleted).
+        old_manifest, _ = load_manifest(dest / MANIFEST_FILE)
+        for entry in (old_manifest or {}).get("skills") or []:
+            if isinstance(entry, dict) and isinstance(entry.get("install_as"), str):
+                previously_declared.add(entry["install_as"])
         shutil.rmtree(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(pack.root, dest, ignore=copy_ignore)
+    # Never dereference a pack's symlinks into the project — that would copy
+    # arbitrary files from the machine into a committed folder. Applies to
+    # bundled and hand-vendored packs the same as to git fetches.
+    shutil.copytree(pack.root, dest, ignore=_ignore_git_and_symlinks)
 
     print(f"\nAdding extension '{pack.id}' to {target}")
     name = pack.manifest.get("name", pack.id)
@@ -306,7 +355,10 @@ def _add_pack(
         for warning in _compat_warnings(pack.manifest, marker):
             print(f"  WARN: {warning}")
 
-    _install_pack_skills(dest, pack.manifest, target, marker, force)
+    _install_pack_skills(
+        dest, pack.manifest, target, marker, force,
+        previously_declared=previously_declared,
+    )
 
     print(f"Done. Extension '{pack.id}' added to {dest}")
     _print_validation_notes(target, pack.id)
@@ -332,11 +384,7 @@ def cmd_extension_add(args: argparse.Namespace) -> None:
             pack, sha = _fetch_git_pack(
                 from_git, getattr(args, "ref", None), Path(tmp) / "pack"
             )
-            _add_pack(
-                pack, target, args.force,
-                copy_ignore=_ignore_git_and_symlinks,
-                git_origin=(from_git, sha),
-            )
+            _add_pack(pack, target, args.force, git_origin=(from_git, sha))
         return
 
     pack = next((e for e in _bundled_packs() if e.id == args.extension_id), None)

--- a/cli/cmd_extension.py
+++ b/cli/cmd_extension.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 from . import paths
+from .agent_layout import AGENT_LAYOUTS
 from .extensions import (
     EXTENSIONS_DIR,
     discover_extensions,
@@ -131,6 +132,59 @@ def _print_validation_notes(target: Path, ext_id: str) -> None:
         print(f"  - {issue}")
 
 
+def _install_pack_skills(
+    pack_copy: Path, manifest: dict, target: Path, marker: dict | None, force: bool
+) -> None:
+    """Install the pack's declared skills[] into the applied agent's skills dir.
+
+    Third-party skill dirs are NOT govkit's "files" category (unconditional
+    overwrite): the team may have edited them or installed the same skill
+    another way, and govkit never destroys what it cannot regenerate as its
+    own. An existing destination is skipped unless --force; re-add with
+    --force is the refresh path. The copy source is the target's own pack
+    copy — extensions/<id>/ stays the source of truth.
+    """
+    skills = manifest.get("skills") or []
+    if not skills:
+        return
+    agent = (marker or {}).get("agent")
+    layout = AGENT_LAYOUTS.get(agent)
+    if layout is None or layout.skills_dir is None:
+        print(
+            "  WARN: this pack declares agent skills, but no applied agent was "
+            "found in the target. Run `govkit apply` first, then re-run "
+            "`govkit extension add` with --force to install them."
+        )
+        return
+    skills_root = (target / layout.skills_dir).resolve()
+    for entry in skills:
+        if not isinstance(entry, dict):
+            continue
+        path, install_as = entry.get("path"), entry.get("install_as")
+        # Defense in depth: validation reports these as notes, but nothing
+        # before this point refuses them — never let a bad manifest reach an
+        # rmtree/copytree outside the pack copy or the skills dir.
+        if not isinstance(path, str) or not is_valid_extension_id(install_as):
+            print(f"  WARN: skipping invalid skills entry {entry!r}")
+            continue
+        source = (pack_copy / path).resolve(strict=False)
+        if not source.is_relative_to(pack_copy.resolve()) or not (source / "SKILL.md").is_file():
+            print(f"  WARN: skipping skills entry with unsafe or empty path {path!r}")
+            continue
+        dest = (skills_root / install_as).resolve(strict=False)
+        if not dest.is_relative_to(skills_root):
+            print(f"  WARN: skipping skills entry {install_as!r} (unsafe destination)")
+            continue
+        if dest.exists():
+            if not force:
+                print(f"  skip: {layout.skills_dir}/{install_as}/ exists (use --force to refresh)")
+                continue
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(source, dest)
+        print(f"  installed: {layout.skills_dir}/{install_as}/")
+
+
 def cmd_extension_add(args: argparse.Namespace) -> None:
     """Copy a bundled extension pack into <target>/extensions/<id>/.
 
@@ -176,6 +230,8 @@ def cmd_extension_add(args: argparse.Namespace) -> None:
     if marker:
         for warning in _compat_warnings(pack.manifest, marker):
             print(f"  WARN: {warning}")
+
+    _install_pack_skills(dest, pack.manifest, target, marker, args.force)
 
     print(f"Done. Extension '{pack.id}' added to {dest}")
     _print_validation_notes(target, pack.id)

--- a/cli/extensions.py
+++ b/cli/extensions.py
@@ -167,11 +167,12 @@ def _check_id(manifest: dict, ext: Extension) -> list[str]:
 
 
 def _check_safe_file_path(
-    label: str, path: object, base: Path, base_label: str
+    label: str, path: object, base: Path, base_label: str, must_be_dir: bool = False
 ) -> list[str]:
     """Resolve `path` against `base` and verify it is a relative, contained,
-    existing file. Guards against absolute paths and `..` / symlink escape so
-    a malicious or sloppy manifest cannot reach outside the declared root."""
+    existing file (or directory, with `must_be_dir`). Guards against absolute
+    paths and `..` / symlink escape so a malicious or sloppy manifest cannot
+    reach outside the declared root."""
     if not isinstance(path, str):
         return [f"{label} must be a string"]
     # Cross-platform: Path.is_absolute() is host-OS-specific (e.g. "/foo" is
@@ -183,7 +184,10 @@ def _check_safe_file_path(
     candidate = (base / path).resolve(strict=False)
     if not candidate.is_relative_to(base_resolved):
         return [f"{label}: {path!r} resolves outside {base_label}"]
-    if not candidate.is_file():
+    if must_be_dir:
+        if not candidate.is_dir():
+            return [f"{label}: {path!r} does not exist under {base_label} (or is not a directory)"]
+    elif not candidate.is_file():
         return [f"{label}: {path!r} does not exist under {base_label} (or is not a file)"]
     return []
 
@@ -223,6 +227,48 @@ def _check_templates(manifest: dict, ext: Extension) -> list[str]:
         if path is None:
             continue
         issues.extend(_check_path_entry(f"templates[{i}].path", path, ext))
+    return issues
+
+
+def _check_skills(manifest: dict, ext: Extension) -> list[str]:
+    """Validate skills[] — agent skills the pack asks `extension add` to
+    install into the applied agent's skills directory. Each entry needs a
+    contained directory holding a SKILL.md, and an `install_as` name safe to
+    become a folder under the skills dir (same character rules as extension
+    ids — that pattern is the path-escape guard)."""
+    skills = manifest.get("skills")
+    if skills is None:
+        return []
+    if not isinstance(skills, list):
+        return ["skills must be a list"]
+    issues: list[str] = []
+    seen: set[str] = set()
+    for i, entry in enumerate(skills):
+        if not isinstance(entry, dict):
+            issues.append(f"skills[{i}] must be a mapping")
+            continue
+        path = entry.get("path")
+        if path is None:
+            issues.append(f"skills[{i}] missing required field: path")
+        else:
+            path_issues = _check_safe_file_path(
+                f"skills[{i}].path", path, ext.root,
+                f"{EXTENSIONS_DIR}/{ext.id}/", must_be_dir=True,
+            )
+            issues.extend(path_issues)
+            if not path_issues and not (ext.root / path / "SKILL.md").is_file():
+                issues.append(f"skills[{i}].path: {path!r} contains no SKILL.md")
+        install_as = entry.get("install_as")
+        if install_as is None:
+            issues.append(f"skills[{i}] missing required field: install_as")
+        elif not is_valid_extension_id(install_as):
+            issues.append(
+                f"skills[{i}].install_as: {install_as!r} must match ^[a-z0-9][a-z0-9-]*$"
+            )
+        elif install_as in seen:
+            issues.append(f"skills[{i}].install_as: duplicate name {install_as!r}")
+        else:
+            seen.add(install_as)
     return issues
 
 
@@ -375,6 +421,8 @@ def validate_extension(ext: Extension, target: Path) -> list[str]:
       - id format and folder-name match
       - contract_sets[].paths exist under ext.root
       - templates[].path exist under ext.root
+      - skills[] entries name contained SKILL.md directories and safe
+        install_as names
       - implementation_profiles[].path exist under ext.root (product-naming
         profiles; exempt from the neutrality/overlap heuristic by design)
 
@@ -389,6 +437,7 @@ def validate_extension(ext: Extension, target: Path) -> list[str]:
         *_check_id(m, ext),
         *_check_contract_sets(m, ext),
         *_check_templates(m, ext),
+        *_check_skills(m, ext),
         *_check_implementation_profiles(m, ext),
         *_check_relates_to(m, target),
         *_check_undeclared_overlap(m, target),

--- a/extensions/otter-skills/LICENSE
+++ b/extensions/otter-skills/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/extensions/otter-skills/NOTICE
+++ b/extensions/otter-skills/NOTICE
@@ -1,0 +1,21 @@
+otter-skills
+Copyright 2026 Tim Ottinger
+
+This product includes ideas distilled from publicly available writings and
+teaching by the following people. Their inclusion here is attribution, not a
+claim that they endorse this project or license its original source material:
+
+- Tim Ottinger: progressive admission, microtesting, the Eight Code Virtues,
+  naming, and related software-craft practices published through Agile Otter
+  and Industrial Logic.
+- Industrial Logic: Clean Start, Save Your Game, structure-shy tests, and its
+  body of software-craft teaching and practice.
+- Kent Beck: test-driven development, test lists, Tidy First?, and incremental
+  design practices.
+- Michael Feathers: legacy-code change mechanics, seams, and characterization.
+- Martin Fowler: the refactoring vocabulary and catalog.
+- Emily Bache and Llewellyn Falco: approval-testing and legacy-code practices.
+- GeePaw Hill: microtest rhythm and incremental switchover.
+
+Specific source links and narrower contribution notes are retained with the
+skills that use them.

--- a/extensions/otter-skills/README.md
+++ b/extensions/otter-skills/README.md
@@ -47,6 +47,19 @@ There is no `extension remove` command yet; removal is manual:
 rm -r extensions/otter-skills .claude/skills/otter-*   # adjust the skills dir per agent
 ```
 
+## Tracking upstream directly
+
+The bundled copy updates only when govkit re-vendors and releases. If the
+upstream repository gains a govkit `manifest.yaml` at its root, you can skip
+the bundled copy entirely and pull from source — pinned into your own repo:
+
+```bash
+govkit extension add --from-git https://github.com/tottinge/otter-skills --target .
+```
+
+Re-running with `--force` pulls upstream changes as a reviewable diff in your
+project.
+
 ## Re-vendoring (govkit maintainers)
 
 `scripts/sync_otter_skills.py` refreshes this pack from a new upstream commit;

--- a/extensions/otter-skills/README.md
+++ b/extensions/otter-skills/README.md
@@ -1,0 +1,55 @@
+# Otter Skills (third-party extension pack)
+
+Seven software-craft agent skills by Tim Ottinger, vendored from the open-source
+[otter-skills](https://github.com/tottinge/otter-skills) repository: unit
+testing (TDD/microtests), atomic commits, story splitting, user-POV story
+slicing, code and object naming, legacy-code safety, and representation
+refactoring review.
+
+This is **third-party content**. govkit vendors a pinned copy so installs stay
+deterministic and offline — nothing is fetched from the network at install
+time. The upstream LICENSE and NOTICE ship in this pack and travel with every
+copy `govkit extension add` makes.
+
+<!-- sync:provenance -->
+| Upstream | https://github.com/tottinge/otter-skills |
+|---|---|
+| Pinned commit | `c9acbd139d182211cbea9b8f6d22a47af15266df` |
+| Upstream version | 0.1.6 |
+| License | Apache-2.0 (LICENSE and NOTICE ship in this pack) |
+<!-- /sync:provenance -->
+
+## Install
+
+```bash
+govkit extension add otter-skills --target .
+```
+
+The pack lands at `extensions/otter-skills/`, and each skill installs into the
+applied agent's skills directory under an `otter-` prefix — for Claude Code,
+`.claude/skills/otter-unit-testing/` and so on (`.agents/skills/` for Codex,
+`.github/skills/` for Copilot). The prefix keeps these clearly third-party and
+collision-free next to your own skills and govkit's `govkit-*` skills.
+
+A skill directory that already exists is **skipped, never overwritten** — your
+edits and independently-installed copies survive. Refresh everything to the
+bundled version with:
+
+```bash
+govkit extension add otter-skills --target . --force
+```
+
+## Remove
+
+There is no `extension remove` command yet; removal is manual:
+
+```bash
+rm -r extensions/otter-skills .claude/skills/otter-*   # adjust the skills dir per agent
+```
+
+## Re-vendoring (govkit maintainers)
+
+`scripts/sync_otter_skills.py` refreshes this pack from a new upstream commit;
+it regenerates `manifest.yaml` and this file's provenance block. Each skill's
+upstream `agents/` subdir (OpenAI agent-builder config) is intentionally not
+vendored. See `origin` in [manifest.yaml](manifest.yaml) for the exact pin.

--- a/extensions/otter-skills/manifest.yaml
+++ b/extensions/otter-skills/manifest.yaml
@@ -1,0 +1,32 @@
+id: otter-skills
+name: Otter Skills (third-party)
+version: 0.1.6
+description: >-
+  Seven engineering-craft agent skills (unit testing, atomic commits, story
+  splitting, naming, legacy-code safety, refactoring review) vendored from
+  tottinge/otter-skills. Installs into your agent's skills directory as
+  otter-<skill>.
+govkit_min_version: 0.0.0
+extension_type: skills
+contract_sets: []
+origin:
+  upstream_url: https://github.com/tottinge/otter-skills
+  upstream_ref: c9acbd139d182211cbea9b8f6d22a47af15266df
+  upstream_version: 0.1.6
+  license: Apache-2.0
+  license_files: [LICENSE, NOTICE]
+skills:
+  - path: skills/atomic-commit
+    install_as: otter-atomic-commit
+  - path: skills/code-object-naming
+    install_as: otter-code-object-naming
+  - path: skills/legacy-code-safety
+    install_as: otter-legacy-code-safety
+  - path: skills/representation-refactor-review
+    install_as: otter-representation-refactor-review
+  - path: skills/story-splitting-for-delivery
+    install_as: otter-story-splitting-for-delivery
+  - path: skills/unit-testing
+    install_as: otter-unit-testing
+  - path: skills/user-pov-sliced-stories
+    install_as: otter-user-pov-sliced-stories

--- a/extensions/otter-skills/skills/atomic-commit/SKILL.md
+++ b/extensions/otter-skills/skills/atomic-commit/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: atomic-commit
+description: Create honest atomic Git commits by choosing one coherent work batch before editing, keeping the whole repository green, resolving every untracked file, staging the entire root with `git add .`, and pausing for human review before committing. Use when starting commit-sized work, completing a demonstrable implementation slice, running a series of refactorings, preparing or making a commit, or discussing atomic commits and trustworthy history. Do not use partial staging or retrospectively compose commits from an already mixed working tree.
+---
+
+# Atomic Commit
+
+Preserve historical truth: every commit must be a complete repository state that actually existed on disk, was tested in exactly that form, and was vetted by a human. A stranger must be able to check out any commit and encounter a coherent change with green tests.
+
+Atomicity begins when choosing the work, not when staging it. A small-looking commit assembled afterward from selected hunks is not atomic.
+
+## Non-negotiable invariants
+
+- Green before every commit is absolute. Never create a failing, WIP, checkpoint, or “fixed by the next commit” commit.
+- Incremental refactoring, tests, prescribed scans, and documentation are pre-commit work. Complete and verify them before presenting the feature commit for review.
+- Commit the entire working-directory state. Never use partial staging, path-limited staging, `git add -p`, or temporary reversal to manufacture commit boundaries.
+- Run all Git and verification commands from the repository root. Establish it with `git rev-parse --show-toplevel`; do not assume the current directory is the root.
+- Every untracked file receives an explicit disposition: add, ignore, or delete. Make evident decisions autonomously; ask the human only when the correct disposition is uncertain.
+- A human reviews the complete proposed commit after verification and before `git commit`.
+- Human review is part of the rapid local microcommit loop, not a reason to enlarge batches or postpone a completed green step. Many human-reviewed commits in a day are entirely consistent with this skill.
+- Use a Conventional Commits message that truthfully describes the whole state.
+
+## Choose the batch before editing
+
+Begin from a clean, green repository. If it is dirty, do not add another intention. Finish and commit the existing state through this protocol, or ask the human how to resolve it.
+
+Choose one meaningful, bounded change and state its intention. Then perform only that batch. Keep the batch small enough to understand, test, and review as a whole.
+
+A feature batch is coherent when it contains everything needed to leave that feature complete and trustworthy: its behavior change, incremental refactoring, tests, prescribed scans, and relevant documentation. These are supporting parts of one atomic feature commit, not separate intentions that must be split into preparatory or follow-up commits.
+
+If several logical changes nevertheless accumulate, acknowledge the broader batch and commit the complete state together. Do not split, selectively stage, or reconstruct it into cleaner-looking commits: those synthetic snapshots were not the states tested on disk. Describe the combined state honestly and improve batch discipline on the next change.
+
+## Recognize the commit point
+
+Completion of a demonstrable implementation slice, iteration, or story triggers the complete-state commit protocol only after its incremental refactoring, tests, prescribed scans, and documentation updates are complete. Demonstrable means the resulting behavior can be shown or verified as an end-to-end outcome, not merely that an internal task list is exhausted. Do not begin the next slice while the completed one remains uncommitted.
+
+Treat refactoring as a series of small experiments. After each refactoring run, execute the prescribed tests and return the whole repository to green before proceeding. Then show the human the result and ask whether the representation is sufficient or whether another refactoring run is warranted. The human decides when the refactoring is enough; the agent must not silently extend the series or declare completion on its own. When the human says it is enough, enter the complete-state commit protocol for the whole current state.
+
+If a refactoring run is not an improvement, undo that experiment while preserving unrelated work, restore green, and present the result again. Do not stack further refactorings onto an unverified or failing state.
+
+## Complete-state commit protocol
+
+Perform the protocol from the repository root.
+
+1. Confirm the intended batch is complete.
+2. List all untracked, non-ignored files, for example with `git ls-files --others --exclude-standard`.
+3. Inspect each file and decide: **add**, **ignore**, or **delete**. Ask only about genuinely uncertain cases.
+4. Apply every delete and `.gitignore` decision. Use safe, recoverable deletion where available and do not delete uncertain files.
+5. Inspect the complete working tree with `git status --short` and the relevant full diffs.
+6. Run the repository's complete prescribed test, scan, and verification suite against this resulting state. Every check must be green. If verification cannot complete or any check fails, do not commit.
+7. Re-list untracked files and inspect the complete status after verification. Tests and formatters sometimes create or modify files. Classify anything new; if cleanup or another action changes the repository state, repeat verification and this check until the green state is stable.
+8. Run `git add .` from the repository root, exactly—not from a subdirectory and not with narrower path arguments.
+9. Inspect `git status --short` and the complete staged diff (`git diff --cached`). Confirm that the staged snapshot contains the entire intended working state and no unexplained file.
+10. Present the human with:
+   - the complete status and reviewable staged change;
+   - every untracked-file disposition;
+   - the exact verification commands and green results;
+   - the proposed Conventional Commits message.
+11. Pause. Run `git commit -m "<type>[optional scope]: <description>"` only after explicit human approval.
+
+Staging and inspection must not change repository files. If human review or any later action changes a file, the reviewed and tested state is stale: restart the untracked-file check, verification, `git add .`, staged review, and approval.
+
+After committing, confirm the working tree is clean and report the commit identifier, message, and verification performed.
+
+## History rewriting and commit-producing Git operations
+
+Frown upon amend, rebase, squash, cherry-pick, and other history rewriting because they can manufacture commits that never independently existed and passed tests in their final context. Prefer a forward series of real, complete, vetted changes.
+
+When rewriting is explicitly required, the same invariants still apply to every final commit. Prevent the operation from auto-committing where possible, materialize the complete final tree on disk, resolve all untracked files, run the full prescribed verification, stage the whole root with `git add .`, present the exact result for human review, and only then create that commit. A sequence of rewritten commits must be checked and tested one final commit at a time; testing only the sequence endpoint is insufficient.
+
+Do not claim a rewritten commit was vetted merely because its source commit or aggregate result once passed. The exact final state is the evidence.
+
+## Stop conditions
+
+Do not commit when any of these is true:
+
+- the repository was not green in the exact state now staged;
+- verification was incomplete, skipped, or changed after it ran;
+- an untracked file lacks a disposition;
+- tracked or staged changes are unexplained;
+- the command is being run below the repository root;
+- the human has not reviewed and explicitly approved the complete state;
+- the proposed message conceals the actual breadth or intention of the batch.

--- a/extensions/otter-skills/skills/code-object-naming/SKILL.md
+++ b/extensions/otter-skills/skills/code-object-naming/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: code-object-naming
+description: >
+  Diagnose and improve names for code objects — variables, functions, methods,
+  classes, modules, and parameters — using Ottinger's naming guide. Use when
+  asked to review, choose, or rename identifiers; when names are vague, lying,
+  redundant, or noisy; when planning an incremental rename refactor; or when
+  extraction moments arise from hard-to-name code. Use
+  representation-refactor-review instead for a broad craft or knowledge-
+  representation review in which naming is only one concern.
+---
+
+# Code Object Naming
+
+## Why Names Matter
+Names are not for the compiler—they are for every human and AI that reads,
+debugs, extends, or maintains the code. Good names:
+- Speed defect location (~20% faster)
+- Reduce documentation and comments needed
+- Reduce misunderstanding-driven errors
+- Improve LLM comprehension efficiency (up to ~30% fewer tokens wasted)
+
+Names are a secondary concern only when the code is broken, untested, unsafe,
+or undeployable. Once those are true, naming matters.
+
+---
+
+## Diagnostic Workflow
+
+### Step 1 — Diagnose the Name
+
+Locate the name on Belshee's naming process scale:
+
+| Stage | What it looks like |
+|---|---|
+| **Missing / Nonsense** | No name, UUID-style, `tmp`, `data`, `info`, `obj` |
+| **Honest but Incomplete** | Names one use but the item has broader scope |
+| **Honest and Complete** | Lists all purposes but is long and unfocused |
+| **Intention-Revealing** | Clear about *purpose* and carries needed context |
+| **Domain Abstraction** | Single-purposed, domain-consistent, concerns separated |
+
+**Target**: Intention-Revealing or Domain Abstraction.
+**Acceptable temporary stop**: Honest but Incomplete (never Nonsense).
+
+> If you cannot name it well right now, give it an *obviously bad* name
+> (e.g., `applesauce`, `poop`, `doomed_X`) — easy to search, clearly
+> temporary, embarrassing enough to remove before commit.
+
+---
+
+### Step 2 — Assign the Right Part of Speech
+
+| Code object | Preferred grammar | Examples |
+|---|---|---|
+| Variables, parameters, fields | **Noun** | `customer`, `hourly_rate`, `invoice` |
+| Data structures, classes | **Noun** | `OrderQueue`, `PaymentRecord` |
+| Commands (mutations, actions) | **Verb phrase** | `dial()`, `submit_order()`, `cancel()` |
+| Queries / attribute getters | **Noun preferred** (not `get_`) | `customer.preferred_name()` not `get_preferred_name()` |
+| Interfaces, protocols, mixins | **Adjective / capability** | `Serializable`, `FileLike`, `Runnable` |
+| Abstract base / interface pair | **Qualified noun** | `Messenger` → `SMSMessenger`, `EmailMessenger` |
+
+**Decision rule**: Ask *"Is this a command (tell) or a query (ask)?"*
+Commands → verb. Queries → noun. Ambiguity → rename until it's clear.
+
+`as` conversion methods (e.g., `customer.date_as_ISO8601`) often signal a
+missing whole value object — consider extracting a type.
+
+---
+
+### Step 3 — Apply Context and Familiarity
+
+**Context hierarchy** (outer to inner): system → module → file → class →
+method → variable. Each layer provides context; names inside need not repeat
+what the layer already says.
+
+**Redundancy test**: Is the word present in the enclosing class/method name?
+Strip it from the member name.
+```
+# Bad — "employee" repeats class context
+class Employee:
+    employee_hourly_rate: Decimal
+
+# Good
+class Employee:
+    hourly_rate: Decimal
+```
+
+**Windshield naming**: Name by *purpose* (windshield = shields from wind),
+not *composition* (front glass). Ask "What is this *for*?" not "What is it
+*made of*?"
+
+**Domain terms**: Use the vocabulary domain experts use, even if it requires
+learning. `mrn` (Medical Record Number), `apy` (Annual Percentage Yield),
+`commit_hash` — profitable struggle. When developers learn the domain term,
+they gain vocabulary that appears everywhere: code, UI, conversations.
+
+**Familiarity check**: Readability is a *relationship* between code and its
+audience. Prefer team idioms and language conventions over universal rules.
+- **Profitable struggle**: unfamiliar but worth learning (new language feature,
+  domain term, idiomatic library pattern).
+- **Unprofitable struggle**: unfamiliar with no payoff — refactor this.
+
+---
+
+### Step 4 — Size to Scope
+
+Match name length to how far the name must travel.
+
+| Scope / travel | Appropriate length | Example |
+|---|---|---|
+| Single expression / lambda | Single letter or `x` | `lambda x: x > 0` |
+| Short loop, tiny function | Short | `rate`, `hours`, `order` |
+| Multi-use within a function | Descriptive | `git_repo`, `validated_data` |
+| Exported / used outside module | Carry full context | `git_repository`, `order_validator` |
+
+**Rules of thumb**:
+1. Length ~ scope. Short scope → shorter name.
+2. Clear in its context, not universally.
+3. Don't bury the lede — put the unique/meaningful part *first* (aids
+   autocomplete and searchability).
+4. Idiomatic names win: `df`, `G`, `fig`, `pd`, `nx` are unambiguous to
+   their community.
+
+---
+
+### Step 5 — Rename or Extract
+
+**Incremental rename protocol**:
+1. Pick the name up one level on Belshee's scale (don't try to leap from
+   Nonsense to Domain Abstraction in one shot).
+2. Use **IDE semantic rename** — never grep-and-replace (too blunt; misses
+   scope; cascades errors).
+3. Run tests after each rename, even tiny ones.
+4. Test the name with a teammate: does it feel natural? Do several people
+   agree?
+
+**Do NOT rename**:
+- Public API names (breaking change)
+- Names used by framework reflection
+- Names in separately-maintained documentation
+
+**Extraction moments** — when to extract rather than (only) rename:
+
+| Signal | Action |
+|---|---|
+| Block has a paragraph comment | Extract the block to a function; use comment text as name seed |
+| Complex boolean condition | Extract to `is_eligible_for_X()` predicate function |
+| Variable with long explanatory name | Extract to a named function returning the value |
+| Class is hard to name | Class likely has multiple responsibilities — split it |
+| Repeated `as_X()` conversion method | Signal for a whole value object type |
+| Name is fine in its file, confusing outside | Add context via import alias or rename |
+
+> Extraction builds vocabulary. Every extracted function is a named concept
+> that makes the codebase more browsable and its tests more focused.
+
+---
+
+## Quick Checklists
+
+### Name Audit (per identifier)
+- [ ] Does the name describe *purpose* (windshield) rather than composition?
+- [ ] Is the name's part of speech correct for its role (noun/verb/adjective)?
+- [ ] Does it avoid repeating context already provided by the enclosing scope?
+- [ ] Is the meaningful/unique segment at the *front* of the name?
+- [ ] Does the length match the scope (travel distance)?
+- [ ] Does it use domain or team vocabulary (not invented jargon)?
+- [ ] Is it distinguishable from nearby names?
+
+### Rename Readiness
+- [ ] Is this name safe to rename (not public API, not reflection-referenced)?
+- [ ] IDE semantic rename available?
+- [ ] Tests will run after rename?
+- [ ] Rename is one step on Belshee's scale, not a giant leap?
+
+---
+
+## Cross-links
+- **representation-refactor-review** owns broad review against all Eight Code
+  Virtues. Use this skill when identifier choice, diagnosis, or a safe rename is
+  the primary task; use the broader skill when naming is one symptom of a
+  larger representation problem.
+- **unit-testing** owns test-first behavior changes. Routine naming inside its
+  green refactor step stays there; use this skill for a deeper naming pass.
+
+---
+
+## References (progressive disclosure)
+Deeper chapter digests in `references/`:
+- `ch-nouns-and-verbs.md` — parts of speech, getter naming, framework idioms
+- `ch-context.md` — hierarchy, windshield naming, domain terms, over-contextualization
+- `ch-familiarity.md` — profitable struggle, team idioms, shared vocabulary
+- `ch-length.md` — scope-to-length matching, primacy, idiomatic nicknames
+- `ch-incrementalism.md` — Belshee's scale, obviously-bad names, safe rename
+- `ch-extraction.md` — paragraph markers, explanatory variables, class split signals

--- a/extensions/otter-skills/skills/code-object-naming/SOURCE_NOTES.md
+++ b/extensions/otter-skills/skills/code-object-naming/SOURCE_NOTES.md
@@ -1,0 +1,61 @@
+# SOURCE_NOTES — code-object-naming
+
+Author: naming-skill child agent
+Source: `vendor-sources/naming_shortguide/` (manuscript MD chapters)
+
+## Chapters read
+- `introduction.md` — context/priority framing only; not operational
+- `the_point.md` — key stats, Benner's 4 criteria, human+AI comprehension argument
+- `nouns_and_verbs.md` — parts-of-speech rules, getter noun preference, `as` conversion signal
+- `context.md` — hierarchy, windshield naming, domain terms, noise words, over-contextualization
+- `familiarity.md` — profitable/unprofitable struggle, audience question, idiom principle
+- `length.md` — scope-to-length matching, primacy, idiomatic nicknames (df/G/fig)
+- `incrementalism.md` — Belshee's scale, obviously-bad names, safe rename protocol, caveats
+- `extraction.md` — paragraph markers → functions, predicate extraction, class-split signal, browseability
+- `conclusion.md` — skimmed; no new operationalizable content
+- `foreword.md` — skimmed; framing only; dropped
+
+## What was taken
+- Belshee's naming-as-a-process 5-stage scale (core of Step 1 in workflow)
+- Noun/verb/adjective grammar rules for code objects (Step 2)
+- Context hierarchy + redundancy test + windshield naming + domain-term principle (Step 3)
+- Scope-to-length table + primacy rule + idiomatic nicknames (Step 4)
+- Incremental rename protocol + obviously-bad-name technique + rename caveats (Step 5)
+- Extraction moments decision table (Step 5)
+- Benner's 4 criteria (Understandability, Conciseness, Consistency, Distinguishability) — folded
+  into the Name Audit checklist (not called out by name; Ottinger's framing preferred)
+- Statistics from `the_point.md`: ~20% defect-location speedup, ~30% LLM token reduction
+
+## What was dropped
+- `introduction.md` prerequisites list (working code, tests, deploy pipeline) — acknowledged
+  in one sentence in SKILL.md "Why Names Matter" but not reprinted
+- Extended prose examples (FizzBuzz obfuscation demo, chocolate aisle analogy, bicycle tire
+  patch analogy) — summarized as principles, not quoted
+- `conclusion.md` — no operational content discovered; skipped
+- `foreword.md` — no operational content
+- `the_point.md` duplicate section (file contained apparent duplicate block starting line ~175)
+  — treated as artifact of manuscript draft format; content used from first occurrence only
+- Benner book citation (`Naming Things`, LeanPub 2025) and OOSC/Meyer citation — noted in
+  digests but not embedded in SKILL.md body (lean packaging preference)
+- Footnotes and bibliography — omitted from digests; Belshee URL retained in ch-incrementalism
+  as it points to a live reference useful to agents
+
+## Design choices
+1. **Progressive disclosure**: SKILL.md is the complete operational workflow; references/ provide
+   chapter-level depth without requiring agents to read all of them.
+2. **Tables over prose** for decision rules and checklists — easier for agents to process.
+3. **Belshee's scale** made explicit and central (Step 1) because it gives a shared vocabulary
+   for discussing naming quality incrementally.
+4. **Windshield naming** elevated to a named principle in SKILL.md body (not buried in references)
+   because it is the most concise heuristic for intent vs. composition.
+5. **Cross-link to representation-refactor-review** rather than duplicating Eight Virtues content.
+
+## Deferred publication consideration
+
+If the manuscript sources themselves are prepared for publication, clean the
+known layout artifacts in `the_point.md` and confirm that `conclusion.md` is
+complete. That source-publication work is outside this packaged skill.
+
+The Benner book (`Naming Things`, LeanPub 2025) remains a skill-local source
+note. A repository-wide bibliography is unnecessary unless more skills begin to
+share that source.

--- a/extensions/otter-skills/skills/code-object-naming/references/ch-context.md
+++ b/extensions/otter-skills/skills/code-object-naming/references/ch-context.md
@@ -1,0 +1,67 @@
+# Digest: Context Creates Clarity (ch: context)
+
+## The hierarchy
+Names do not exist alone. Every name lives inside:
+`system → module/package → file → class → method → variable`
+
+Each outer layer provides context. Inner names need not (should not) repeat it.
+
+## The redundancy test
+> Is this word already present in the enclosing class/method/module name?
+> If yes, drop it from the member name.
+
+```java
+// Over-specified — every name repeats "employee" and "payroll"
+class EmployeePayrollCalculator {
+    Money calculateEmployeeGrossPay(Employee employee, PayPeriod payPeriod) {
+        BigDecimal employeeHourlyRate = employee.getEmployeeHourlyRate();
+```
+
+```java
+// Context-aware — class name carries "employee" and "payroll"
+class EmployeePayrollCalculator {
+    Money calculateGrossPay(Employee employee, PayPeriod payPeriod) {
+        BigDecimal rate = employee.getHourlyRate();
+```
+
+## Windshield naming
+Name by **purpose** (what it is *for*), not composition (what it is *made of*).
+- "windshield" → shields from wind (purpose)
+- "front glass" → glass at the front (composition)
+
+Apply: `tail` in `bite_head_off()` could be `result`; ask what the caller will
+*do* with it, not what it structurally is.
+
+## Domain terms
+Use the vocabulary domain experts use. `mrn`, `apy`, `sku`, `commit_hash` —
+these are **profitable struggle** (see `ch-familiarity.md`). When developers
+learn the term, it pays dividends everywhere: source, UI, discussions.
+
+## Noise words to avoid
+`data`, `info`, `record`, `manager`, `processor` almost never add meaning.
+`CustomerData`, `CustomerInfo`, `CustomerRecord` in the same codebase = garbage.
+`ProcessingResult` on a financial enum that has `PAYMENT_FAILED` is too generic
+— it is probably `TransactionResult`.
+
+## When a name must travel
+A class or function used *outside* its defining module must carry enough context
+to be understood alone. Some redundancy is then justified.
+- Within `email` module: `Validator` is fine.
+- Outside: alias it: `from email import Validator as email_validator`.
+- If aliasing is frequent and consistent, that's a signal to rename the class.
+
+## Mathy vs. prosey
+In mathematical or algorithm contexts, conventional single-letter variables
+(`x`, `y`, `i`, `j`, `a`, `b`, `c` in quadratic formula) may be the
+clearest choice. Let the mathematical domain win.
+
+## Over-contextualization anti-pattern
+Pattern-combination names (`StrategyManagerFactory`, `DataProcessorHelper`) and
+noise-word hybrids impart little domain meaning. Strip them.
+
+## Practical guidelines (from manuscript)
+1. Trust your context — don't repeat what's already given.
+2. Consider the reader's journey through the hierarchy.
+3. Match domain vocabulary — use what domain experts say.
+4. Embrace minimal names in minimal contexts.
+5. Evolve names when code moves to a new context (refactoring/extraction).

--- a/extensions/otter-skills/skills/code-object-naming/references/ch-extraction.md
+++ b/extensions/otter-skills/skills/code-object-naming/references/ch-extraction.md
@@ -1,0 +1,108 @@
+# Digest: Extraction and Naming (ch: extraction)
+
+> "You have two important decisions to make: 1) what to name, and 2) what to
+> call it." — Eddie Bush
+
+Extraction and naming are two sides of the same coin. Every extraction
+requires a new name. Every good name suggests what might be worth extracting.
+
+## Paragraph comments → function names
+
+Paragraph comments inside a function are the code announcing what it's about
+to do:
+
+```python
+def export(output_filename, data_to_write):
+    # Ensure the data is not empty
+    ...
+    # Ensure the directory exists
+    ...
+    # Write data as CSV
+    ...
+```
+
+These markers say: "each section deserves a name." Extract each commented
+block to a function; use the comment text as the name seed. Delete the comment.
+
+```python
+def export(output_filename: str, data_to_write: DataSet):
+    if data_to_write.is_empty():
+        raise NoDataToWriteError()
+    with open_output(output_filename) as output_file:
+        write_csv(output_file, data_to_write)
+```
+
+## Complex boolean → predicate function
+
+A long compound condition signals an extraction:
+
+```python
+# Hard to parse inline
+if (order.total > 1000 and customer.membership_level == 'premium' and
+    customer.account_age_months > 12 and ...):
+    ...
+
+# Extract to a named predicate
+if is_eligible_for_express_processing(order, customer, inventory):
+    ...
+```
+
+Benefits of extraction over an explanatory variable:
+- **Browseability**: callers can skip the detail; readers scan without reading
+- **Testability**: the predicate can be unit-tested independently
+- **Reuse**: the condition can be called from multiple sites
+- **Single Point of Truth**: the boolean logic lives in one place
+
+When the expression is only used once and the function is short, an
+explanatory variable is an acceptable lighter alternative:
+```python
+eligible_for_express = order.total > 1000 and ...
+if eligible_for_express:
+    ...
+```
+The variable approach loses browseability and testability but gains
+debuggability and is easier to extract later.
+
+## Class naming difficulty → split signal
+
+> When you can't name a class because it seems to do multiple things,
+> you're probably looking at multiple classes sharing one definition.
+
+```python
+# Hard to name — it does: validation, pricing, payment, inventory, shipping, loyalty
+class CustomerOrderProcessor:
+    def validate_order(self, order): ...
+    def calculate_pricing(self, order, customer): ...
+    def process_payment(self, order): ...
+    def update_inventory(self, order): ...
+    def schedule_shipment(self, order): ...
+    def award_loyalty_points(self, customer, order): ...
+```
+
+When naming is difficult, ask: *"What is the ONE thing this class does?"* If
+the answer requires "and," split it.
+
+## Explanatory variable as a stepping stone
+
+Isolate a complex expression in a variable first, then extract the variable
+to a function. This two-step makes extraction safer and easier to verify.
+
+## Naming as vocabulary building
+
+> Extraction is not just moving text — it's building vocabulary.
+
+Every extracted function is a named concept. A codebase with good function
+names is **browseable**: readers can scan function calls without reading
+implementations, find what they need, and change it safely.
+
+## Extraction moments (decision table)
+
+| Signal in code | Recommended extraction |
+|---|---|
+| Inline comment describes a block | Extract block to function; comment → name |
+| Long boolean condition | Extract to `is_X()` / `can_X()` predicate |
+| Complex expression assigned to variable | Extract variable → then function |
+| Class is hard to name | Identify multiple responsibilities; split class |
+| `as_X()` conversion on a host object | Extract a whole value object type |
+| Same expression duplicated | Extract to a Single Point of Truth function |
+| Name is clear inside module, confusing outside | Add import alias; or rename class |

--- a/extensions/otter-skills/skills/code-object-naming/references/ch-familiarity.md
+++ b/extensions/otter-skills/skills/code-object-naming/references/ch-familiarity.md
@@ -1,0 +1,52 @@
+# Digest: Readability as Familiarity (ch: familiarity)
+
+## Core insight
+> Readability is not a property of code; it's a **relationship** between code
+> and its audience.
+
+Code is "unreadable" when parsing effort is felt to be unreasonably high by its
+intended readers. This is audience-relative, not absolute.
+
+## Profitable vs. unprofitable struggle
+
+| Type | Definition | Action |
+|---|---|---|
+| **Profitable** | Unfamiliar code that, once understood, adds a valuable tool to the reader's mental toolbox | Accept; teach it; it pays forward |
+| **Unprofitable** | Difficult code with no learning dividend — just friction | Refactor or rename |
+
+Examples:
+- Python list comprehension `[x.name for x in items if x.active]` — profitable
+  for any Python programmer to learn.
+- Arbitrary abbreviations or invented metaphors in a narrow codebase — unprofitable.
+
+## The audience question
+*Who is your primary audience?*
+- Your immediate team (current + future members)
+- A broader developer community (OSS, SDK)
+- Domain specialists (DSP engineers, financial quants, medical informatics)
+
+The readable choice aligns with how **that audience** already thinks and talks.
+`customer` or `user`? Whichever word your team uses in conversation.
+
+## Language and framework idioms
+Each language has conventions that its practitioners recognize instantly.
+Departing from them imposes cognitive cost even when the departure is
+"technically correct."
+
+- Rails `has_many :posts, dependent: :destroy` — immediately clear to Rails devs.
+- Pandas `df`, NetworkX `G`, Plotly `fig` — idiomatic; non-idiomatic replacements
+  confuse without helping.
+
+## Building shared familiarity
+1. **Co-create code** — pair, mob, or ensemble programming embeds shared idioms.
+2. **Live code review** — synchronous walkthrough beats async comment threads for
+   building vocabulary and resolving naming disagreements.
+3. **Shared coding standards** — focus on *naming, organization, and expression*,
+   not formatting (let `black`/`prettier` handle that).
+
+## Practical guidelines (from manuscript)
+1. Know your audience.
+2. Align with existing mental models — team vocab and domain vocab.
+3. Be consistent within your context.
+4. Invest in shared vocabulary — document and discuss conventions.
+5. Ensure cognitive effort teaches something valuable (profitable struggle test).

--- a/extensions/otter-skills/skills/code-object-naming/references/ch-incrementalism.md
+++ b/extensions/otter-skills/skills/code-object-naming/references/ch-incrementalism.md
@@ -1,0 +1,63 @@
+# Digest: Incrementalism (ch: incrementalism)
+
+## Naming is a process, not a moment
+
+Arlo Belshee's naming-as-a-process model (https://www.digdeeproots.com/articles/naming-process/):
+
+| Stage | Characteristics | OK to commit? |
+|---|---|---|
+| **Missing / Nonsense** | No name, UUID, `tmp`, `obj` | No — never leave this |
+| **Honest but Incomplete** | Names one use; broader scope exists | Acceptable temporary state |
+| **Honest and Complete** | Lists all purposes; long; unfocused | Acceptable; aim higher |
+| **Intention-Revealing** | Clear about *purpose*; carries needed context | Good — ship it |
+| **Domain Abstraction** | Single-purposed; domain-consistent; concerns separated | Best |
+
+Move names **one step at a time** up this scale. Leaping from Nonsense to
+Domain Abstraction in one step usually fails.
+
+## Obviously-bad names as placeholders
+> "If you can't give it a good name, give it a terrible one." — Ottinger & Belshee
+
+Criteria for an obviously-bad placeholder:
+1. **Easy to search** — unique enough to find with a grep/IDE search
+2. **Clearly temporary** — nobody will mistake it for a final name
+3. **Embarrassing enough to fix** — you will not commit this name
+
+Examples: `applesauce`, `poop`, `doomed_print_report`, `new_thing_being_built`
+
+Do NOT use `data`, `info`, `customerInfo` as temporaries — they look like
+real names and will be abandoned in the codebase.
+
+## Obviously-temporary names for in-flight refactors
+- Prefix with `doomed_` when deprecating: `doomed_print_report()`
+- Prefix with `new_` when introducing: `new_invoice_builder`
+- Add a `# TODO: rename` comment at the definition site
+- These signal to teammates that the item is transitional
+
+## Safe rename protocol
+1. **IDE semantic rename only** — rename via the IDE's refactoring support,
+   never grep-and-replace.
+   - Search-and-replace is too blunt (crosses scope boundaries, finds string literals)
+   - "Rename + compiler errors" is semantic rename the hard way — tedious and
+     prone to cascading errors
+2. **One rename at a time** — do not fix adjacent names while doing one rename.
+   Scope creep causes unrelated failures.
+3. **Run tests after each rename** — even tiny renames; catch breakage immediately.
+4. **Test the name with the team** — a name that feels natural to several people
+   is more stable than a solo invention.
+
+## What you cannot (safely) rename
+- **Public API names** — breaking change for downstream consumers
+- **Reflection-referenced names** — frameworks that look up names at runtime
+  (Spring, Rails conventions, some ORMs)
+- **Separately-maintained documentation** — names that appear in external specs,
+  contracts, or docs not under your control
+
+## Incremental improvement heuristics
+1. Extract the most obvious functions first — blocks with existing comments
+   are pre-labeled; use the comment as name seed.
+2. Let good names surface bad ones — once some names are clear, poor names
+   stand out more sharply.
+3. Refactor in small steps; test after each one.
+4. The goal is to become more correct over time, not to achieve perfection
+   before the first commit.

--- a/extensions/otter-skills/skills/code-object-naming/references/ch-length.md
+++ b/extensions/otter-skills/skills/code-object-naming/references/ch-length.md
@@ -1,0 +1,71 @@
+# Digest: Length of Names (ch: length)
+
+## The scope-length principle
+> A name only needs to carry its meaning as far as it must travel.
+
+| Scope / travel distance | Appropriate length | Rationale |
+|---|---|---|
+| Single expression, lambda body | Single letter (`x`) | Scope is one expression; context unambiguous |
+| Short loop body | Short (`rate`, `hours`) | Visible from declaration to last use |
+| Multi-use within a function | Descriptive (`git_repo`) | Disambiguation needed |
+| Used across functions in a module | Qualified (`order_validator`) | Travels; needs self-sufficiency |
+| Public API / exported name | Full context (`payment_gateway_client`) | Encountered alone in the wild |
+
+## Single-letter names: not forbidden
+Single letters work when:
+1. Scope is tiny (lambda, comprehension filter, short for-loop)
+2. Context is unambiguous (only one concept in scope)
+3. Convention supports it (`i`, `j` in matrix loops; `x`, `y` for coordinates;
+   `a`, `b`, `c` in quadratic formula; `e` in exception handlers)
+
+Problematic when the variable's declaration, initialization, and last use are
+too far apart to hold in one glance.
+
+## Redundant context adds noise, not meaning
+```python
+# Bad — "git" already in module name; "VersionControl" and "Repository" redundant
+git.GitVersionControlRepository(path)
+
+# Good
+git.Repository(path)
+```
+Redundant prefixes degrade autocomplete (all words share a prefix; meaningful
+part buried at the end) and add "deodorant formatting" pressure (line-wrapping
+to fit the long name).
+
+## Primacy of the unique segment
+In long names, put the **meaningful / unique part first** — it aids autocomplete
+and search. Burying the lede (unique part in the middle) means every user scans
+past the common prefix to find the differentiator.
+
+If you inherit a buried-lede name you can't rename: create a local alias in
+your function, work with it, then rename the original later.
+
+## Idiomatic nicknames
+Some short names are idiomatic within their community and should be honored:
+
+| Name | Community meaning |
+|---|---|
+| `pd` | Pandas (Python) |
+| `nx` | NetworkX (Python) |
+| `px` | Plotly Express (Python) |
+| `df` | DataFrame (Pandas / Databricks) |
+| `G` | Graph/DiGraph (NetworkX) |
+| `fig` | Figure/chart (Plotly) |
+| `e` | Exception (many languages) |
+| `i`, `j` | Loop indices |
+
+These are not "cryptic" — they are vocabulary. Using non-idiomatic replacements
+confuses practitioners without benefit.
+
+## Rules of thumb (from manuscript)
+1. Length ~ scope (shorter scope → shorter name).
+2. Clear in its context, not universally.
+3. Don't bury the lede — unique segment goes first.
+4. Idiomatic use trumps other rules.
+
+## Practical exercise (from manuscript)
+Commit your work first. Revise a function's names to follow these rules.
+Run `git diff` and compare with a teammate. Notice that the first reaction
+may be to the unfamiliarity of the style — ask whether it's easier to
+*understand at a glance* rather than whether it *looks familiar*.

--- a/extensions/otter-skills/skills/code-object-naming/references/ch-nouns-and-verbs.md
+++ b/extensions/otter-skills/skills/code-object-naming/references/ch-nouns-and-verbs.md
@@ -1,0 +1,32 @@
+# Digest: Nouns and Verbs (ch: nouns_and_verbs)
+
+## Core principle
+The point of noun/verb naming is to distinguish **commands** (tell the object
+to do something) from **queries** (ask the object what it knows). The split
+is semantic, not syntactic.
+
+## Rules of thumb (from manuscript)
+- **Objects and types** → noun names (`customer`, `PhoneDialer`, `Invoice`)
+- **Commands** → verb or verb phrase (`dial()`, `cancel()`, `submit_order()`)
+- **Attribute getters / queries** → **noun preferred** over `get_X()` verb form
+  - `customer.preferred_name()` reads as "name IS the customer's preferred name"
+  - `get_preferred_name()` adds noise without information
+  - Exception: when a framework requires `get_` or `set_` prefixes, comply
+- **Interfaces, protocols, mixins** → adjective-like (`Serializable`, `FileLike`)
+  or the abstract-type-as-noun pattern (`Messenger` → `SMSMessenger`,
+  `EmailMessenger`)
+- **IFoo / Foo splits** → considered inferior; use only when framework or team
+  insists
+
+## `as` conversions
+`customer.date_as_ISO8601` signals the *Customer* shouldn't own this
+conversion. It belongs on the date type: `customer.date.as_ISO8601()`.
+Repeated `as_X()` methods suggest a missing whole-value-object.
+
+## Framework override
+When a framework uses reflection and demands `get_`/`set_` warts or `_field`
+private prefixes, comply. Fighting your tools is not the point.
+
+## The real question
+*"Which of these calls is a command and which is a query?"*
+If it's not clear from reading the call site, the name is failing.

--- a/extensions/otter-skills/skills/legacy-code-safety/SKILL.md
+++ b/extensions/otter-skills/skills/legacy-code-safety/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: legacy-code-safety
+description: >
+  Establish trustworthy feedback around poorly understood or weakly tested
+  existing code before changing it. Use for characterization or approval tests,
+  test-harness access, seams, sensing and separation, dependency breaking, and
+  incremental replacement of risky live code. Once a fast trustworthy boundary
+  exists, use unit-testing to drive the requested new behavior.
+---
+
+# Legacy Code Safety
+
+Make one requested change safe without demanding a cleanup campaign or rewrite first.
+
+Legacy code is code for which the relevant behavior cannot be verified quickly and reliably. Existing tests may be absent, slow, flaky, too broad, or coupled to irrelevant structure. The immediate job is to establish enough trustworthy feedback for the change at hand.
+
+## Ownership and boundaries
+
+Use this skill when:
+
+- relevant behavior is undocumented, surprising, or poorly understood
+- existing tests do not protect the intended change
+- dependencies or side effects keep code out of a test harness
+- the task calls for characterization, pinning, approval tests, seams, sensing, separation, or safe legacy-code change
+- a large brownfield transformation needs an incremental path through live code
+
+Do not use it as the primary skill when:
+
+- a fast trustworthy test boundary already exists; use `unit-testing`
+- the request is review-only; use `representation-refactor-review`
+- the task is only to choose delivery slices; use `story-splitting-for-delivery`
+- the user requested a wholesale replacement; do not silently turn this skill into authorization for one
+
+This skill owns **establishing safety**. `unit-testing` owns specifying and implementing the new behavior after that boundary exists.
+
+## Safety invariants
+
+- Start from an intentional workspace and record relevant inherited failures before editing.
+- Characterization describes observed behavior, not desired behavior.
+- Separate observations, suspected defects, and requested changes.
+- Break only the dependencies that block sensing or separation for this change.
+- Production code must not branch on whether it is under test.
+- A test is not a safety net until it has demonstrated that it can fail for a relevant change.
+- Prefer small, reversible changes through live code over a parallel rewrite.
+- Preserve unrelated user work. Create commits or external changes only when authorized.
+
+## Workflow
+
+### 1. Frame the change and risk
+
+Before editing, state:
+
+```text
+Requested change:
+Likely change point:
+Relevant entry-to-exit path:
+Behavior that must remain stable:
+Dangerous or unavailable dependencies:
+Current feedback and inherited failures:
+```
+
+Ask three questions throughout: How will we know the requested change is correct? How will we know relevant existing behavior remains intact? How cheaply can we recover from a wrong step?
+
+### 2. Find the narrowest useful test point
+
+Prefer the cheapest boundary that protects the requested change:
+
+1. an existing focused public behavior
+2. an existing seam near the change point
+3. stable subsystem output suitable for approval testing
+4. a pinch point through which several relevant effects pass
+5. a minimal new seam
+
+Do not default to a full end-to-end harness or mock every collaborator. Read [references/seams-and-dependencies.md](references/seams-and-dependencies.md) when code cannot run or relevant effects cannot be observed.
+
+### 3. Characterize relevant behavior
+
+For one concrete input, run the current code and capture what it actually does. Establish that the test initially fails or that output is initially unapproved, inspect the observation, then record it with a behavioral name.
+
+Add cases for relevant branches, boundaries, failure paths, and known production examples—not indiscriminate coverage. Record suspected defects separately; do not fix or bless them silently.
+
+Use ordinary assertions for small focused results. Use approval testing for large structured output that is easier to review as a diff. Read [references/characterization-and-approvals.md](references/characterization-and-approvals.md) before creating approval artifacts.
+
+### 4. Prove the safety net
+
+Demonstrate at least one relevant failure by seeing the initial expectation fail, making and reverting a deliberate perturbation, or using a focused mutation. Coverage identifies unexercised code; it does not prove that assertions detect change.
+
+Restore the baseline immediately after any deliberate perturbation.
+
+### 5. Introduce only necessary seams
+
+For each blocking dependency, identify:
+
+```text
+Obstacle:
+Need: sensing | separation
+Seam and enabling point:
+Smallest production edit:
+Evidence behavior is preserved:
+```
+
+Keep preparatory edits structural and green. Prefer explicit parameters or small adapters when natural in the codebase, but use language and build-system seams when they are safer than broad redesign.
+
+### 6. Hand new behavior to TDD
+
+Once the boundary is fast, reliable, and capable of detecting relevant change, use `unit-testing`:
+
+1. write one failing test for the requested behavior
+2. make the minimum production change
+3. refactor while green
+4. retain characterization tests until focused tests safely supersede them
+
+Do not confuse a characterization expectation with a test-first specification.
+
+### 7. Switch incrementally when the change is large
+
+If the transformation cannot finish in a short safe cycle, keep old and new paths able to coexist, prove compatibility, and move one caller, case, or route at a time. Remove the old path only when evidence shows it is unused.
+
+Read [references/incremental-switchover.md](references/incremental-switchover.md) before a parallel implementation, broad API change, or rewrite proposal.
+
+### 8. Finish with evidence
+
+Report:
+
+```text
+Requested change:
+Observed legacy behavior:
+Characterization added:
+Seams used or introduced:
+Safety-net failure demonstrated:
+New behavior test and implementation:
+Verification:
+Temporary scaffolding:
+Remaining unprotected risks:
+```
+
+## Stop and report rather than guess
+
+Stop or narrow the work when characterization would:
+
+- execute destructive production effects
+- capture secrets, personal data, or environment-specific credentials
+- approve output nobody has inspected
+- depend on uncontrolled nondeterminism that obscures meaningful changes
+- require a public-contract change beyond the user's authorization
+- discard or overwrite unrelated work to regain a baseline
+
+When a unit remains unreachable, report the smallest seam that would unlock it and the risk of that edit. Do not fabricate confidence.
+
+## Related skills
+
+- `unit-testing` — owns test-first implementation after a trustworthy boundary exists.
+- `representation-refactor-review` — owns broad representation critique; this skill changes only enough representation to make the requested work safe.
+- `story-splitting-for-delivery` — owns delivery-slice selection. Use incremental switchover here to execute a chosen brownfield slice safely.
+- `code-object-naming` — owns focused naming analysis; routine names introduced by a seam should simply match the local dialect.
+
+For source attribution and further reading, see [references/sources.md](references/sources.md).

--- a/extensions/otter-skills/skills/legacy-code-safety/SOURCE_NOTES.md
+++ b/extensions/otter-skills/skills/legacy-code-safety/SOURCE_NOTES.md
@@ -1,0 +1,12 @@
+# SOURCE_NOTES — legacy-code-safety
+
+This skill synthesizes Michael Feathers' legacy-change mechanics, Emily Bache and Llewellyn Falco's approval-testing practice, GeePaw Hill's microtest rhythm and incremental switchover, and Tim Ottinger's clean-start, feedback, checkpoint, representation, integration, and delivery disciplines.
+
+## Design choices
+
+- The skill ends when a trustworthy boundary exists and the requested behavior can enter `unit-testing`; it does not create a competing TDD workflow.
+- Characterization, dependency breaking, and incremental switchover are separate references because each is loaded only for its corresponding obstacle.
+- The entrypoint emphasizes invariants and decisions rather than reproducing Feathers' full catalog of dependency-breaking techniques.
+- Approval artifacts require intentional inspection; the skill does not permit blind snapshot updates.
+- Incremental switchover permits named temporary duplication when it makes a large live-code transition safer, balancing SPOT against delivery risk.
+- Commit, integration, and external-release actions remain subject to user authorization and project practice.

--- a/extensions/otter-skills/skills/legacy-code-safety/references/characterization-and-approvals.md
+++ b/extensions/otter-skills/skills/legacy-code-safety/references/characterization-and-approvals.md
@@ -1,0 +1,65 @@
+# Characterization and Approval Testing
+
+Read this reference when existing behavior is poorly understood or the useful observable result is too large for a few focused assertions.
+
+## Characterization loop
+
+1. Choose one input relevant to the requested change.
+2. Invoke the current production path through the narrowest safe boundary.
+3. Begin with an expectation known to be wrong, or with unapproved output.
+4. Run the code and observe the actual result.
+5. Inspect whether the observation is meaningful, stable, and safe to retain.
+6. Record the observation and name the behavior it demonstrates.
+7. Repeat only for relevant partitions, boundaries, and failure paths.
+
+Expected values come from execution. Documentation, tickets, comments, and the agent's interpretation may explain an observation, but they do not replace it.
+
+If behavior appears defective, record:
+
+```text
+Observed behavior:
+Reason it may be defective:
+Known consumers or compatibility risk:
+Decision needed:
+```
+
+Do not silently repair it during baseline characterization.
+
+## When approval testing fits
+
+Prefer an approval artifact when the result is structured and broad enough that individual assertions would hide the whole:
+
+- reports and rendered documents
+- serializers, parsers, and transformations
+- command-line output
+- combinations of many business-rule cases
+- a stable event or call trace at a subsystem boundary
+
+Use focused assertions when the important result is small. Approval testing is not a reason to snapshot an entire application or object graph.
+
+## Approval loop
+
+1. Arrange representative input.
+2. Act through a safe boundary.
+3. Render only relevant results in a stable, human-readable form.
+4. Diff received output against the approved artifact.
+5. Inspect every meaningful difference.
+6. Approve intentionally and keep the artifact with the test.
+
+Before approval, control or remove timestamps, random identifiers, unstable ordering, machine paths, concurrency noise, secrets, personal data, and irrelevant bulk.
+
+Never update approved output merely to make a failing suite green. A changed artifact is evidence requiring a decision.
+
+## Demonstrate sensitivity
+
+Execution and coverage are not enough. Confirm that the test detects a relevant behavioral change by one of these means:
+
+- observe the initial incorrect expectation fail
+- temporarily perturb a protected value or branch, run the test, and revert
+- run a focused mutation tool and inspect surviving mutations
+
+Use coverage to find relevant branches not exercised, not as a quality target.
+
+## Retirement
+
+Keep broad characterization while it provides unique protection. As understanding improves, replace noisy approval output with focused behavioral tests where that makes failures faster and clearer. Retire an artifact only when equivalent protection is demonstrated.

--- a/extensions/otter-skills/skills/legacy-code-safety/references/incremental-switchover.md
+++ b/extensions/otter-skills/skills/legacy-code-safety/references/incremental-switchover.md
@@ -1,0 +1,48 @@
+# Incremental Switchover
+
+Read this reference before proposing a rewrite, broad API replacement, or transformation that cannot remain green in short steps.
+
+The goal is a path from the current live system to the desired system in which each intermediate state is usable, testable, recoverable, and no worse by the evidence available.
+
+## Switchover pattern
+
+1. Introduce the new representation, API, or path beside the old one.
+2. Preserve compatibility at their boundary.
+3. Test that old and new agree where they should.
+4. Move one caller, case, field group, route, or behavior.
+5. Run the relevant feedback and keep the system usable.
+6. Repeat in small authorized checkpoints.
+7. Remove the old path only when callers and runtime evidence show zero use.
+8. Remove compatibility scaffolding when it no longer protects a transition.
+
+Examples include an old API delegating through a new representation, mirror execution with comparison, one endpoint or caller switching at a time, and a UI flow replacing one field group at a time.
+
+## What “not worse” means
+
+Treat “not worse” as an evidence-based constraint, not a claim of perfection. Consider:
+
+- observable behavior and compatibility
+- safety, privacy, and security
+- performance and resource use
+- operational visibility and rollback
+- source clarity and temporary duplication
+
+Temporary duplication can be legitimate transition scaffolding when ownership and removal conditions are explicit. Do not misapply SPOT to force a big-bang cutover.
+
+## Avoid the rewrite trap
+
+A parallel rewrite defers integration, behavior discovery, and user feedback while preserving the process that produced the current problems. Prefer changing live code frequently. If no incremental route is visible, report the obstacle and search for a smaller admission boundary rather than assuming a rewrite is authorized.
+
+## Switchover plan
+
+```text
+Current live path:
+Target path:
+Compatibility mechanism:
+Agreement check:
+First caller/case to switch:
+Verification after each switch:
+Old-path removal condition:
+Temporary duplication and owner:
+Rollback or retreat point:
+```

--- a/extensions/otter-skills/skills/legacy-code-safety/references/seams-and-dependencies.md
+++ b/extensions/otter-skills/skills/legacy-code-safety/references/seams-and-dependencies.md
@@ -1,0 +1,70 @@
+# Seams and Dependency Breaking
+
+Read this reference when relevant code cannot enter a test harness or its important effects cannot be observed.
+
+## Diagnose before editing
+
+- **Sensing problem:** the code runs, but the test cannot observe a value, decision, or outgoing effect.
+- **Separation problem:** the code cannot run safely or repeatably because a collaborator is slow, destructive, unavailable, global, or uncontrollable.
+
+A dependency can create both problems. Name the immediate need so the production edit remains small.
+
+## Seam model
+
+A seam is a place where behavior can vary without editing the code at that place. Its **enabling point** is where the alternate behavior is selected.
+
+Look for existing seams before creating one:
+
+- function or constructor parameters
+- interfaces, callbacks, and overridable object behavior
+- dependency-injection registrations
+- imports, modules, package resolution, or link configuration
+- command, HTTP, messaging, and filesystem boundaries
+- configuration or environment values already designed to vary behavior
+- preprocessing or build configuration in languages where that is idiomatic
+
+The test should exercise production code. Do not add `if testing` branches.
+
+## Minimal dependency-breaking moves
+
+Choose the smallest move natural to the language and codebase:
+
+- parameterize a constructed dependency
+- extract a small adapter around an external API
+- expose a computed result rather than intercepting deep internals
+- make time, randomness, or identity an explicit input
+- replace a hard-coded call through an existing import or link seam
+- split pure decision logic from an effectful shell
+- subclass and override only when that is already a coherent local technique
+
+Preserve behavior during the move. Run available tests or characterization before and after each structural step.
+
+Avoid introducing a general architecture merely to test one path. A seam is successful when it unlocks trustworthy feedback with limited new knowledge and ownership.
+
+## Test doubles
+
+Use a double to control or observe a collaborator, not to reproduce its entire implementation.
+
+- A fake supplies a lightweight working implementation.
+- A stub supplies controlled answers.
+- A spy records relevant calls or effects.
+- A mock encodes an expected interaction.
+
+Prefer observable results over incidental call sequences. Extensive mocking, deep stubbing, or duplicated collaborator logic signals that the chosen boundary may be wrong.
+
+## Pinch points
+
+When many effects or callers converge, a pinch point can protect a larger relevant area with fewer tests. Use it only when its output is stable and meaningful. A broad pinch-point test may be slower or less diagnostic, so complement it with focused tests as the design becomes accessible.
+
+## Required seam note
+
+For every production edit made only to gain testability, record:
+
+```text
+Obstacle:
+Sensing or separation:
+Seam:
+Enabling point:
+Why this is the smallest coherent move:
+Behavior-preservation evidence:
+```

--- a/extensions/otter-skills/skills/legacy-code-safety/references/sources.md
+++ b/extensions/otter-skills/skills/legacy-code-safety/references/sources.md
@@ -1,0 +1,47 @@
+# Sources and Contributions
+
+## Michael Feathers
+
+- *Working Effectively with Legacy Code*: change mechanics, feedback, sensing and separation, seams and enabling points, test-harness access, characterization, and dependency-breaking techniques.
+  https://www.informit.com/store/working-effectively-with-legacy-code-9780132931779
+- “Testing Effectively With Legacy Code”: seam model and preprocessing, link, and object seams.
+  https://www.informit.com/articles/article.aspx?p=359417
+- “Changing Software and Legacy Code”: risk questions and the cost of avoiding change.
+  https://www.informit.com/articles/article.aspx?p=359418
+
+## Emily Bache and Llewellyn Falco
+
+- Emily Bache, “Approvals and Mutation Testing”: rapid characterization of poorly understood production behavior, branch-oriented examples, and mutation feedback.
+  https://coding-is-like-cooking.info/2019/08/approvals-and-mutation-testing/
+- Emily Bache, “Why We Should Be Saying Approval Testing”: approval as intentional review of captured output.
+  https://coding-is-like-cooking.info/2021/03/why-we-should-be-saying-approval-testing-instead-of-golden-master/
+- ApprovalTests legacy-code material: producing and verifying broad results.
+  https://approvaltests.com/legacycode/
+- Emily Bache's Gilded Rose Refactoring Kata, based on Terry Hughes' exercise and developed with approval/refactoring techniques learned in part from Llewellyn Falco.
+  https://github.com/emilybache/GildedRose-Refactoring-Kata
+
+## GeePaw Hill
+
+- “How I Work (Test-Driving Mix)”: one minimal path, one microtest/code-change pair, fast continuous feedback, and incremental testability work.
+  https://www.geepawhill.org/2020/02/11/how-i-work-test-driving-mix/
+- “Understanding Incremental Switchover”: transforming live code through small compatible intermediate states instead of a rewrite leap.
+  https://www.geepawhill.org/2020/07/21/understanding-incremental-switchover/
+
+## Tim Ottinger
+
+- “The Clean Start Protocol”: identify inherited state and establish a trustworthy beginning.
+  https://www.industriallogic.com/blog/clean-start-protocol/
+- “Save Your Game” and “What's This About Micro-commits?”: frequent recoverable green checkpoints.
+  https://www.industriallogic.com/blog/save-your-game/
+  https://www.industriallogic.com/blog/whats-this-about-micro-commits/
+- “Fast Feedback” and “Make Your Testing Affordable”: keep feedback timely, reliable, and economical.
+  https://www.industriallogic.com/blog/fast-feedback/
+  https://www.industriallogic.com/blog/make-your-testing-affordable/
+- “Structure-Shy Tests and Code”: keep tests from freezing internal object structure.
+  https://www.industriallogic.com/blog/structure-shy-tests-with-lod/
+- “SPOT and Coincidental Duplication”: distinguish duplicated knowledge from coincidentally similar code.
+  https://www.industriallogic.com/blog/spot-and-coincidental-duplication/
+- “Easy Integration,” “Safe Releases,” and “Work To Be Interruptible”: small integrated changes, working delivery, and recoverable work sessions.
+  https://www.industriallogic.com/blog/easy-integration/
+  https://www.industriallogic.com/blog/safe-release/
+  https://www.industriallogic.com/blog/work-to-be-interruptible/

--- a/extensions/otter-skills/skills/representation-refactor-review/SKILL.md
+++ b/extensions/otter-skills/skills/representation-refactor-review/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: representation-refactor-review
+description: Review code and propose evidence-based representation improvements using Tim Ottinger's Eight Code Virtues, SPOT, ZOM, and the improvement test. Use for broad craft, refactoring-readiness, clean-code, knowledge-representation critique, or discovering data clusters, data classes, and class-splitting boundaries. Do not use for bug/security-only review, implementing behavior test-first, or a focused identifier-naming task; those belong to the relevant specialist workflow.
+---
+
+# Ottinger-Style Code Review: Representation & Refactor
+
+This skill drives **concrete refactoring suggestions** — rename, extract, introduce type, replace conditional with table — grounded in Tim Ottinger's Eight Code Virtues and knowledge-representation lens. It is not an approval checklist or a style-only pass. Every finding must identify a representation problem and end in a specific mechanical move. If the evidence supports no objections, say so plainly.
+
+The deliverable is a **prioritized list of representation concerns and refactor recommendations**. Each item names the virtue(s) under pressure, shows the evidence, and prescribes the smallest change that improves the knowledge representation across multiple virtues together. Apply the ideas; do not impersonate Ottinger or claim he personally reviewed the code.
+
+## When this skill owns the task
+
+Use this skill for a broad review of how code represents domain knowledge, or when the user explicitly invokes the Eight Virtues, SPOT, ZOM, Coherent, the improvement test, or Ottinger-style review.
+
+Do not use it as the primary skill for:
+
+- correctness-, bug-, performance-, or security-only review without a requested representation lens
+- implementing new behavior or a bug fix test-first; use `unit-testing`
+- establishing test access and characterizing poorly understood existing behavior; use `legacy-code-safety`
+- choosing or sequencing delivery slices; use `story-splitting-for-delivery`
+- a focused request to choose, diagnose, or rename identifiers; use `code-object-naming`
+
+A broad representation review may still surface naming and test-design evidence. Keep the broad review here and use the sibling's specialized guidance only for the deeper sub-pass.
+
+## Progressive disclosure
+
+| Load | When |
+| --- | --- |
+| This file | Always when the skill is active |
+| [`references/virtues.md`](references/virtues.md) | Before writing findings — definitions, improvement test, Coherent, comments |
+| [`references/class-boundaries.md`](references/class-boundaries.md) | When data clusters, construction semantics, extracting a class/value object, or splitting a class are in scope |
+
+Keep the workflow here; put depth in the reference. Use the sibling `code-object-naming` skill when a review needs a dedicated naming pass.
+
+## Mindset
+
+Internalize these before reading a line:
+
+- **Code is written for an audience, most of whom are not the author.** Readability is a relationship between code and its maintainers—not author satisfaction.
+- **Good software is primarily a good representation of knowledge.** Working is table stakes. Prefer changes that give knowledge a clearer, more unique, simpler, more developed, briefer, more coherent home.
+- **Naming is among the most powerful tools available.** Difficulty naming is diagnostic; structure is often not crisp yet.
+- **Distinguish objective virtues from subjective ones.** Working, Unique, Simple, Developed, Brief, and Coherent can be evidenced. Clear and Easy are subjective relationships. Name which kind each finding is.
+- **Working is prime; the other seven virtues are peers in balance.** Do not apply a fixed ladder (Unique > Simple > …). Prefer multi-virtue representation wins. Use the **improvement test** for tradeoffs.
+- **Observation ≠ prescription.** Pressure on a virtue does not dictate the refactoring. Separate observation, inference, and action.
+- **A struggle to read code should be profitable, not needless.** Attack needless difficulty; respect difficulty that teaches the domain.
+- **Refactoring is the path, not the verdict.** Every objection should imply a concrete mechanical move (extract, rename, introduce type, replace conditional with table, etc.).
+- **Be relentless but not cruel.** Attack the artifact; respect the human.
+
+## Workflow
+
+1. **Establish Working first.** Inspect the project instructions and diff before choosing checks. Run the narrowest relevant existing tests when the user has asked for a review and local, non-mutating verification is available. If you cannot verify behaviour, state that limitation. Missing tests is a finding only when it creates a concrete regression risk for changed behaviour; absence alone is not automatically P1.
+2. **Read for the audience.** Flag every place you reverse-engineered intent.
+3. **Pass systematically against the Eight Virtues and naming.** Read [`references/virtues.md`](references/virtues.md). Use `code-object-naming` for a naming-heavy sub-pass. Go virtue by virtue (Working, then the seven peers), including boundaries and dependencies when they are in scope. Do not pattern-match a few smells and stop. **Within the Unique, Developed, and Coherent passes, run the ZOM Drift sub-pass (see below).**
+4. **For every concern capture:** (a) location, (b) virtue(s) under pressure, (c) concrete refactoring, (d) *why it matters* to audience/maintenance. No "why" → drop it.
+5. **Prioritize and assemble** the final report in the format below.
+
+## ZOM Drift Pass (Unique · Developed · Coherent)
+
+Run this pass while evaluating **Unique**, **Developed**, and **Coherent**. ZOM (Zero-One-Many) drift occurs when a representation fails to evolve as the codebase changes—staying at One when Many cases exist, staying scattered when a concept needs a single owner, or remaining when the concept is gone.
+
+**Always report evidence first. Infer second. Never lead with the redesign.**
+
+### Step 1 — Collect evidence
+
+Scan for these markers:
+
+- Repeated name stems (`name1`/`name2`, `primaryX`/`secondaryX`)
+- Repeated constants or enum values handled across multiple sites
+- Repeated parameter groups passed together in multiple call sites
+- Variables consistently manipulated together (traveling values)
+- Methods that all operate on the same data
+- Long conditional chains or large switch statements
+- Many boolean flags controlling unrelated variation
+- Duplicate private helpers or validation/parsing logic scattered across files
+- Tests that repeat the same setup for the same concept
+
+### Step 2 — Classify the ZOM state
+
+| State | Signal | Virtues under pressure |
+| --- | --- | --- |
+| **Zero pretending to be One** | Dead branches, obsolete parameters, unused abstractions, configuration for removed behaviour | Unique (false SPOT), Coherent (ghost dialect) |
+| **One pretending to be Many** | Numbered twins (`item1`/`item2`), parallel helpers, repeated parameter groups | Unique (latent duplication), Developed (missing collection or value object) |
+| **Many pretending to be One** | Long conditionals, large switch, flag piles, one class handling unrelated cases | Simple (path count), Developed (missing variation representation), Coherent (implicit dialect) |
+| **Many without Ownership** | Duplicate helpers, domain logic in utilities, same enum handled in many modules | Unique (SPOT violation), Coherent (scattered authoritative truth) |
+
+### Step 3 — Ask what multiplied
+
+When Many evidence appears, ask what the Many really is:
+
+- Values → collection
+- Parameter/field groups → value object
+- Behaviour on the same data → owning type
+- Same role in different places → strategy or table
+- States → state model
+- Rules → policy object or table
+- Scattered owners → one authoritative home
+
+### Step 4 — Produce ZOM findings
+
+For each concept identified, capture:
+
+```text
+Concept:
+Evidence (observations):
+Current representation:
+ZOM state (inference):
+Virtues under pressure:
+Smallest suggested representation improvement:
+```
+
+Integrate these findings into the main report at the appropriate P-level. ZOM-without-ownership and One-pretending-to-be-Many findings on shared facts are typically P1–P2 (Unique). Missing-type findings are typically P2–P3 (Developed). Dead representation is typically P2 unless it actively misleads (then P1 for Coherent/Unique).
+
+## Minimum evidence for class recommendations
+
+Clumping suggests a boundary; a meaningful name and independent rules confirm it. Do not recommend a class or split from size, field count, method count, or clumping alone.
+
+- **Introduce a class:** values repeatedly travel together **and** share construction rules, invariants, normalization, or behaviour worth owning.
+- **Split a class:** methods and fields form at least two distinct clusters; each cluster names a meaningful concept; and their necessary interaction fits through a small interface.
+
+When either recommendation is plausible, read [`references/class-boundaries.md`](references/class-boundaries.md) before reporting or changing code. Record evidence against the recommendation as well as evidence for it.
+
+## How to be exacting
+
+- **Go function by function, name by name.** Enumerate; do not only generalize. Group related names if needed, but account for all of them.
+- **Tie every objection to a principle.** "I don't like this" is not a finding. SPOT, path count, primitive cluster, dialect clash, ZOM state, etc. are findings.
+- **Prefer evidence where it exists.** Count ops/operands/paths; point at knowledge homes; show competing representations for Coherent; show co-change for Easy/Unique; enumerate stems for ZOM.
+- **Do not use a fixed peer-virtue ordering to win tradeoffs.** Working always wins. Among peers, argue the multi-virtue outcome and the real change being made.
+- **Name the refactoring, not just the smell.** End in a verb: *extract*, *rename*, *introduce*, *replace*, *inline*, *split*, *gather*, *invert*, *derive*.
+
+## Standing refactoring instruction: knowledge representation first
+
+Use when the task includes code changes, not only review comments.
+
+Act as if good software is primarily a good representation of knowledge. Passing tests is necessary, not sufficient. Refactor so the representation is more Unique, Simple, Clear, Easy, Developed, Brief, and Coherent while preserving behaviour.
+
+### Core rule
+
+- Do not refactor for style alone.
+- Refactor when evidence shows knowledge is poorly represented, duplicated, scattered, too primitive, dialect-split, or no longer matches what the code now reveals.
+
+### Method
+
+Before changing code, inspect nearby implementation and tests. Look for:
+
+- repeated names or stems
+- repeated parameter/field groups
+- values manipulated together
+- methods on the same data
+- duplicated helpers/policies/constants
+- growing conditionals/switches
+- enums/constants handled in many places
+- competing representations of one concept (Coherent pressure)
+- tests with the same setup repeatedly
+- functions/files that change together
+
+When you find these markers, apply the ZOM Drift Pass (above) before proposing any change.
+
+### Improvement test (required)
+
+Keep a change only if:
+
+1. Working is preserved (tests/evidence), and
+2. the overall representation is better across the peer virtues **together**.
+
+If not better overall, revert or choose a smaller experiment.
+
+### Working procedure
+
+1. State the concept under review.
+2. List concrete evidence (observations).
+3. Describe current representation.
+4. Identify ZOM / repetition / dialect signals (inferences).
+5. Propose the smallest representation improvement.
+6. Make the change.
+7. Preserve or add tests; run them.
+8. Re-evaluate with the improvement test.
+9. Revert or shrink if the result is not better.
+
+### Constraints
+
+- No speculative abstractions or named patterns without evidence.
+- Not "fewer lines alone," not "smaller files alone."
+- No behaviour change unless requested.
+- Always separate observations, inferences, and actions.
+
+### Required refactoring output
+
+Before changes:
+
+```text
+Concept:
+Evidence (observations):
+Current representation:
+ZOM/repetition/coherence signal (inference):
+Proposed representation improvement:
+Virtues under pressure / expected multi-virtue gain:
+Tradeoffs to watch:
+```
+
+After changes:
+
+```text
+Behaviour preserved:
+Tests:
+Representation improvement:
+Improvement test (Working + peers together):
+Tradeoffs:
+Remaining concerns:
+```
+
+## Priority indicators
+
+Assign exactly one per finding:
+
+- **P1 — Critical.** Threatens **Working** or **Unique** in a way that can corrupt behaviour or silently break under maintenance: demonstrated bugs, failing relevant tests, a concrete untested regression path in changed code, duplicated facts/algorithms (SPOT), competing executable truths, shared mutable assumptions. ZOM findings that create silent divergence of shared facts belong here.
+- **P2 — Major.** Serious pressure on **Simple**, **Clear**, **Developed**, or **Coherent** that will measurably slow or mislead maintainers: high path complexity, primitive obsession, disinformative/unsearchable names, not-logic, abstraction leaks, conflicting dialects for the same concept, pattern thrash. ZOM findings of One-pretending-to-be-Many and Many-without-Ownership belong here when they affect co-change.
+- **P3 — Minor.** Pressure on **Easy**, **Brief**, or milder Coherent/Developed issues: awkward-to-change structure for likely changes, missing helpful abstractions, chatty code, mild inconsistency, mild idiom drift. Zero-pretending-to-be-One (dead code) typically lands here unless it actively misleads.
+- **P4 — Polish.** Subjective preferences and team-negotiable conventions within an acceptable band. Flag as subjective; never inflate.
+
+Optional band markers when the medium renders them well: 🔴 P1 · 🟠 P2 · 🟡 P3 · 🔵 P4.
+
+Within a band, order by impact. Prefer multi-virtue representation fixes higher when severity is similar.
+
+## Review output
+
+Follow Codex's findings-first review convention. Present findings in descending severity, then unresolved assumptions or verification gaps, and finish with a short verdict. If there are no findings, say so directly and mention residual testing risk. Do not emit empty priority sections.
+
+Use this shape for each finding:
+
+```markdown
+### [P1–P4] [Imperative or concrete title]
+
+- **Location:** `[file:line]`
+- **Virtues under pressure:** [list]
+- **Observation:** [what the code demonstrates]
+- **Inference:** [why that evidence indicates a representation problem]
+- **Action:** [specific refactoring move]
+- **Why necessary:** [maintenance or behavioural consequence]
+```
+
+Report rules:
+
+- Make locations precise and use clickable local file links when Codex can provide them.
+- Every objection needs all six fields; **Why necessary** is non-negotiable.
+- Findings must be countable and auditable.
+- Do not pad P4 or starve P1.
+- Keep praise brief and only mention qualities that materially constrain a proposed change.
+- When several findings share one representation cause, group them if one fix resolves them; preserve distinct locations as evidence.
+
+## Codex operating notes
+
+- Read repository instructions such as `AGENTS.md` and preserve the user's unrelated work.
+- Prefer project scripts (`./run_tests`, `./tidy`, `./prepare`) when present.
+- Do not modify existing tests to bless broken behaviour without explicit user permission.
+- A review request authorizes inspection and non-mutating checks, not implementation. Only edit code when the user asks for fixes.
+- Do not create commits unless the user asks. When implementing fixes, keep structural and behavioural changes separable in the diff.
+- Load only the reference files needed for the current pass.
+
+## Related skills
+
+- `legacy-code-safety` owns characterization, seams, and dependency breaking needed before risky legacy changes. This skill may identify the risk but does not establish the safety boundary during a review.
+- `code-object-naming` owns focused identifier choice, diagnosis, and rename planning. This skill may identify naming as evidence inside a broader representation review.
+- `unit-testing` owns test-first implementation and focused FIRST/flakiness work. This skill may review test code as part of a broader representation critique, but does not replace the TDD loop.
+- `story-splitting-for-delivery` owns the choice and sequence of delivery slices; representation review does not turn design concerns into a backlog plan.
+
+## Diligence statement
+
+If the user asks for an AI-use disclosure in a saved review, adapt the template in `AI_DILIGENCE.md`. Do not add disclosure files to reviewed projects without that request.

--- a/extensions/otter-skills/skills/representation-refactor-review/references/class-boundaries.md
+++ b/extensions/otter-skills/skills/representation-refactor-review/references/class-boundaries.md
@@ -1,0 +1,129 @@
+# Data Clusters, Construction Semantics, and Class Boundaries
+
+Use this pass to decide whether a data cluster deserves a type or an existing class contains independently meaningful concepts. The goal is knowledge ownership, not more classes.
+
+## Core distinction
+
+> Introduce a class when related data and behaviour repeatedly travel together and have rules worth owning. Split a class when its data and methods form independently meaningful clusters joined by little shared behaviour.
+
+Method/field clumping discovers candidate boundaries. Construction, invariants, lifecycle, and the resulting interface confirm or reject them.
+
+## Trace construction semantics
+
+For a suspected concept, find every path that can create or assemble it:
+
+- constructors, named factories, builders, parsers, and conversion methods
+- deserializers, ORM/framework hydration, copying, and mutation after empty construction
+- test fixtures and object mothers that may reveal required preparation
+- callers that repeatedly validate, normalize, default, derive, or repair the same values
+
+Record:
+
+- canonical inputs and required/optional values
+- defaults and which boundary supplies them
+- rejected combinations and other invariants
+- normalization, canonicalization, and unit conversion
+- values derived from other inputs and any ordering dependency
+- whether partial or invalid states are representable
+- identity, equality, mutability, and lifecycle
+- construction effects such as IDs, timestamps, persistence, registration, or events
+- competing construction dialects or invariant-bypassing paths
+
+The language constructor is not necessarily the authoritative constructor. Repeated caller preparation may be the real construction policy scattered without an owner.
+
+## Decide what kind of representation exists
+
+| Evidence | Candidate representation |
+| --- | --- |
+| Values merely travel together | Parameter object or data record |
+| Values share validity or normalization rules | Value object with guarded construction |
+| Several input forms converge on one valid form | Named factories or parsers |
+| Optional groups accumulate over stages | Builder, draft, or explicit staged state |
+| Some fields are derived from canonical inputs | Factory that computes rather than accepts them |
+| Identity and independent lifecycle matter | Entity rather than value object |
+| Trusted storage must bypass ordinary creation | Explicit rehydration boundary |
+
+These are hypotheses, not automatic pattern prescriptions. Prefer local idioms and the smallest representation that gives the knowledge one authoritative home.
+
+## Find class partitions
+
+Treat fields and methods as a small dependency graph:
+
+- connect each method to the fields it reads or changes
+- connect methods that call one another or maintain the same invariant
+- identify dense groups with few cross-group connections
+
+Then test each candidate group:
+
+1. Can it be named as a domain or system concept without `Helper`, `Data`, `Part`, or an unexplained `Manager`?
+2. Does it own rules or behaviour, not merely occupy adjacent lines?
+3. Can it be constructed and remain valid through a coherent boundary?
+4. Can its relationship with the original class be expressed through a small intention-revealing interface?
+5. Does extraction avoid duplicated state, bidirectional synchronization, and chatty forwarding?
+
+Evidence becomes stronger when the groups also have separate construction sources, invariants, optionality, lifecycles, tests, uses, or change history.
+
+## Check counterevidence
+
+Do not recommend splitting merely because clumps exist. A single owner may remain better when:
+
+- an invariant genuinely spans the candidate groups
+- the groups are born, change, and die together
+- extraction creates constant back-and-forth calls or shared mutation
+- one group is only a serialization, persistence, or presentation view of the other
+- the class is intentionally a thin facade or application-service orchestrator
+- framework callbacks obscure an otherwise coherent responsibility
+
+Ask:
+
+1. Are the groups born together?
+2. Are they valid under shared rules?
+3. Do they change together?
+4. Do they die together?
+5. Is either meaningful and useful without the other?
+
+Mostly “no, no, no, no, yes” strongly supports a split. Mixed answers require judgment; report uncertainty rather than forcing extraction.
+
+## Minimum recommendation thresholds
+
+Recommend **introducing a class** only with both:
+
+- repeated grouping or travel of the same values; and
+- shared construction rules, invariants, normalization, or behaviour.
+
+Recommend **splitting a class** only with all three:
+
+- at least two distinct method/field clusters;
+- a meaningful concept name for each cluster; and
+- necessary cross-cluster interaction expressible through a small interface.
+
+Size and counts alone never meet either threshold. Clumping alone warrants investigation, not a recommendation.
+
+## Evidence record
+
+```text
+Concept or class:
+Data and method clusters:
+Construction sites and semantics:
+Shared and independent invariants:
+Lifecycle and co-change evidence:
+Cross-cluster interactions:
+Candidate names and ownership:
+Evidence against extraction:
+Smallest representation improvement:
+Unknowns requiring characterization:
+```
+
+## Incremental refactoring
+
+When implementation is authorized:
+
+1. Characterize current construction and invariant behaviour.
+2. Gather a repeated parameter cluster without changing semantics.
+3. Move one normalization, default, or invariant to the emerging owner.
+4. Redirect one creation path or method cluster at a time.
+5. Separate ordinary creation from parsing, rehydration, and fixture construction when their trust boundaries differ.
+6. Run relevant tests after every step and apply the improvement test.
+7. Remove bypasses only after all callers migrate.
+
+Keep an extraction only when Working is preserved and the resulting ownership and interface improve the peer virtues together.

--- a/extensions/otter-skills/skills/representation-refactor-review/references/virtues.md
+++ b/extensions/otter-skills/skills/representation-refactor-review/references/virtues.md
@@ -1,0 +1,188 @@
+# The Eight Code Virtues
+
+Tim Ottinger and Jeff Langr's positive vocabulary for code goodness (from *Agile in a Flash*, expanded over years, unified as the Eight Code Virtues). Where code smells name what is *bad*, the virtues name what is *good*—so a reviewer can say precisely what to preserve and what to pursue.
+
+Canonical write-up: [Eight Code Virtues (draft)](https://agileotter.blogspot.com/2026/08/eight-code-virtues-draft.html).
+
+## How the virtues relate
+
+**Working is non-negotiable.** The other seven are peers evaluated **in balance**, not a strict ladder:
+
+> **Working** (prime) · **Unique · Simple · Clear · Easy · Developed · Brief · Coherent** (peers)
+
+Never sacrifice Working for any other virtue. Among the peers, do not automatically rank one above another. Prefer changes that improve **several** virtues at once, usually by finding a better representation of knowledge. When peers pull against each other, use judgment and the improvement test—not a fixed ordering.
+
+### The improvement test
+
+Any proposed change must answer:
+
+1. Does it preserve **Working**?
+2. Given that it works, is the resulting code **really better** when Unique, Simple, Clear, Easy, Developed, Brief, and Coherent are considered **together**?
+
+If not, revert or try something smaller. Completing a refactoring that leaves the software worse is not virtuous.
+
+### Evidence, subjectivity, and judgment
+
+Not all virtues are subjective:
+
+| Virtue | Character |
+| --- | --- |
+| Working, Unique, Simple, Developed, Brief, Coherent | Observable; can be evidenced (with investigation) |
+| Clear, Easy | Subjective—relationships (readers; change + people/tools/system) |
+
+**Objective does not mean trivial to score.** Shared knowledge may be non-obvious; evidence can be incomplete; first interpretations can be wrong.
+
+An observation that a virtue is under pressure **does not prescribe the refactoring**. Several fixes may address the same pressure and affect other virtues differently. Separate:
+
+- **Observations** — what the code shows
+- **Inferences** — what that may mean (hypotheses)
+- **Actions** — the smallest representation change worth trying
+
+---
+
+## 1. Working — *as opposed to incomplete / unproven*
+
+The code has to work. Working is not design taste. We may accept a little duplication for clarity or extra lines for ease—we do **not** trade away Working.
+
+"Working" means more than looking plausible. Compilation yesterday, a single green test long ago, or author confidence is weak assurance.
+
+- Prefer fast, useful automated tests run **before and after** changes.
+- Also learn from demos, experiments, monitoring, and real use.
+- Without behavioural evidence, "refactoring" becomes wishful rewriting.
+- If tests are missing or thin: characterise behaviour, find a seam, or make careful preliminary changes so important behaviour can be observed—especially under agentic change.
+
+**Review implications:** Establish this first. Missing/failing tests for code under change, untested rewrites, and "it should work" are P1. Without Working, no other virtue is interesting.
+
+## 2. Unique — *as opposed to duplicated knowledge*
+
+**SPOT (Single Point of Truth):** each piece of knowledge should have **one authoritative representation**. Prefer SPOT over dry "don't repeat text," because the hazard is repeated *truth*, not identical characters.
+
+- Two identical values may be different facts that happen to match today—merging them would couple independent change.
+- Duplication is often non-textual: the same rule as calculation, conditional, comment, config, UI list, and test fixture.
+- Example: payment methods as enum + UI list + config strings + validation branches + serialisation maps + fixtures—different text, same knowledge.
+- Ask: would these have to change together because they express the same fact or rule? If yes, one authoritative home; derive the rest.
+- Heuristics: version history of co-change; text/dupe detectors (with known limits).
+
+**Review implications:** Duplicated facts/algorithms and implicit shared assumptions are P1 when they can silently corrupt behaviour under maintenance.
+
+## 3. Simple — *as opposed to complicated*
+
+Simple is a **structural** property: fewer **operands**, **operations**, and **execution paths** for the same behaviour at the same scope.
+
+- Not familiarity, fashion, or "only elementary features." Those may aid Clear or Coherent; Simple is literal machinery count.
+- A long procedural familiar solution can still be high in operands/ops/paths.
+- Tables can replace long conditional chains (one lookup vs many decision paths).
+- Collections replace `item1`/`item2`/`item3` coordination.
+- Named state replaces boolean soup and invalid-combination logic.
+- Named types replace primitive clusters passed and manipulated together.
+- Extracting a function may simplify **local** structure without reducing overall ops/paths—still useful locally; judge overall honestly.
+- Patterns/abstractions add their own structure; keep them only when what they remove exceeds what they add.
+
+**Review implications:** Count operands, operations, paths—make measurable claims. High path complexity is typically P2. Prefer reductions of real machinery, not ceremony for its own sake.
+
+## 4. Clear — *as opposed to puzzling*
+
+Clear code communicates with its **intended readers**. Maintainers are the real audience. Code is always clear to the author at write time; the virtue is clarity for **non-authors** in that audience—not imaginary beginners who know nothing of language, domain, or system.
+
+- Clarity is contextual and **subjective to the group**.
+- Idioms, domain terms, and local conventions reduce surprise.
+- Agents are often good at following local patterns—use that.
+- Clarity is more than restating mechanics in comments; better names/representations say *why* and *how it belongs*.
+
+**Review implications:** Name clarity findings as subjective but argue from audience and idioms. Disinformative names, not-logic, and reverse-engineering chores are usually P2.
+
+## 5. Easy — *as opposed to difficult to change*
+
+Easy is about **change**, not reading. Understandable code can still make an ordinary change hard.
+
+- Best moment to tend Easy: **just before** a known feature change—refactor so the change fits, then make the change (Beck). That is not speculative futures.
+- Speculative extension points for features that never arrive add structure without benefit and may block the real future.
+- Tables make "one more case" a row, not surgery on control flow.
+- Named/extracted policies and constants give change a home (e.g. limit `3` scattered vs one policy).
+- Dead branches and leftover feature flags force reasoning about decisions that no longer exist.
+- Co-change history, recurring repair commits, and scatter are evidence of awkward homes/boundaries.
+
+Improvements to Easy often improve Simple, Brief, Unique, Clear, or Coherent at the same time.
+
+**Review implications:** Ask what change is imminent and how hard it is. Structure that resists likely change is typically P3 (P2 if change is frequent/imminent). Prefer evidence-backed prep over speculative architecture.
+
+## 6. Developed — *as opposed to primitive*
+
+Programs start from language primitives. As understanding grows, the program should grow **concepts of its own**.
+
+- Variables that travel together in args, loops, and branches often hide an undeclared type.
+- Functions that only operate on that group are candidate operations of the type.
+- Goal is not "classes for classes' sake"—it is representing a concept the program already repeatedly assembles.
+- A better type often shortens arg lists, homes operations, speaks domain language, and reduces mishandling—improving Unique, Simple, Clear, Easy, Brief, and Coherent together.
+- When a concept keeps reassembling itself, the program is asking for a name.
+
+**Review implications:** Point at the primitive cluster and name the type/home. Usually P2–P3. Often a SPOT win.
+
+## 7. Brief — *as opposed to chatty / low signal*
+
+Brief means high **signal-to-noise** for the same behaviour and information—not fewest characters, not code golf.
+
+- Cryptic short code fails Clear/Easy and is not a win.
+- Denser idioms (filter, comprehension, map) can replace loops/collectors and be *easier* to grasp at a glance.
+- Small functions replace repeated explanation; better representations delete whole categories of plumbing.
+- Do not discount Brief or confuse it with golf.
+
+**Review implications:** On its own, often P3–P4. Over-terse cleverness is a **clarity** defect. Prefer representation that removes noise without hiding information.
+
+## 8. Coherent — *as opposed to contradictory dialects*
+
+**Coherence** is how far concepts, vocabulary, abstractions, architecture, patterns, and representations **reinforce** one another.
+
+- In a coherent system, learning compounds: understanding one part helps elsewhere.
+- Names stay consistent; similar relationships use similar forms; new work strengthens the system's language rather than inventing a local dialect.
+- Close partner of Developed: enum vs strings vs subclasses vs flag clusters for "the same" concept may be four dialects—or legitimately different models. Compare meanings/boundaries before forcing unity.
+- Flags may be unnamed state; primitive groups unnamed concepts; long conditionals knowledge better as table, rules, map, graph, or state machine.
+- Coherence is **not** "everything looks the same." One forced pattern can be consistent and still make little sense.
+- Before adding abstraction: how does this system already express similar ideas? Extend the language or invent another way to say the same thing?
+
+**Review implications:** Conflicting dialects for the same knowledge, pattern thrash, and vocabulary drift are typically P2–P3 (P1 when they encode competing truths that break Unique/Working). Prefer reinforcing existing good language over novel local styles.
+
+---
+
+## Comments and the virtues
+
+Comments are not executable. They can prime readers for hard algorithms, constraints, workarounds, or rationale the language cannot carry—and they can hide design problems.
+
+Three rules:
+
+1. Comments are for things that **cannot** be expressed in code.
+2. Comments that **restate** the code must be deleted.
+3. If a comment says what the code could say, **change the code** so the comment is redundant, then delete it.
+
+Moving comment knowledge into names/types/functions improves Unique, Clear, Simple, Developed, Brief, Coherent, and sometimes Easy. Do **not** strip comments from difficult code before improving representation—that leaves the same difficulty with less help. Temporary learning comments can guide refactoring, then go.
+
+---
+
+## From virtues to refactoring (review + change)
+
+1. Treat smells, metrics, awkward changes, and surprising search hits as **reasons to investigate**, not orders.
+2. Start from code involved in the **real** change. Search names/terms; find constants, enums, branches, structures, tests; look for traveling values; learn local vocabulary; use history when helpful.
+3. Inspect comments (restate? obsolete? promotable to code? indispensable rationale? temporary scaffolding?).
+4. Ask whether the concept has **one owner**. Prefer the smallest representation that gives it one.
+5. Separate observation / inference / proposed action; name virtues under pressure and tradeoffs.
+6. Small behaviour-preserving steps; tests green; structural commits separate from behavioural ones. Strengthen safety evidence before broad refactoring.
+7. Re-evaluate with the improvement test. If not better overall—revert.
+
+---
+
+## Using the virtues in a review
+
+- Confirm **Working** first; then evaluate the seven peers **together**.
+- Tag each finding with the virtue(s) under pressure.
+- For objective virtues, make evidence-backed claims (counts, clusters, co-change, competing representations).
+- For Clear and Easy, say they are subjective and argue from audience, idioms, and the actual change.
+- Prefer findings that point to a **representation** improvement affecting multiple virtues.
+- The virtues describe goodness; they complement SOLID and the 4 Rules of Simple Design (see `architecture.md`)—they do not replace them.
+
+## Further reading (selected)
+
+- Ottinger & Langr — How Virtuous Is Your Code? (original seven)
+- Ottinger — 7 Code Virtues Explained; Time for an 8th Virtue: Coherence
+- Sciamanna & Ottinger — SPOT and Coincidental Duplication
+- Ottinger — Simple v. Complicated; Rethinking Readability; Meaningful Names Revisited
+- Fowler — Refactoring; Feathers — Working Effectively with Legacy Code

--- a/extensions/otter-skills/skills/story-splitting-for-delivery/SKILL.md
+++ b/extensions/otter-skills/skills/story-splitting-for-delivery/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: story-splitting-for-delivery
+description: >
+  Split oversized features, epics, and stories into thin, demonstrable,
+  deployable slices
+  through progressive admission: start with a closed end-to-end skeleton, then
+  admit one case at a time. Use to choose or sequence delivery slices, including
+  message, schema, import, API, form, path, rule, persona, or channel rollouts.
+  Do not use merely to format an already-chosen split as user-visible outcomes;
+  that belongs to user-pov-sliced-stories.
+---
+
+# Story Splitting for Delivery (Progressive Admission)
+
+## Core idea
+This is the primary story-splitting skill.
+Build the end-to-end path first, fully closed. Then admit one safe case at a time.
+Everything not yet admitted stays rejected — invalid, unsupported, or not implemented.
+Each admission is a thin, testable, demonstrable, ideally deployable story.
+
+This is related to walking skeleton / tracer bullet thinking, but the distinctive move is **default-deny with progressive widening**.
+
+## When this skill fits
+Use it as the default whenever work is too big for one iteration or needs a delivery sequence.
+Progressive admission is especially natural when there is a clear cycle:
+- message queue / event processing
+- HTTP operations or API handlers
+- batch file / import processing
+- form fields and validation
+- UI controls that enable one action after another
+- schema or protocol versioning over time
+- multi-path user journeys, roles, channels, or rule variants
+
+If the admission boundary is not obvious, invent one from the variations in the work (paths, data shapes, rules, interfaces, roles). Do not fall back to component/task decomposition.
+Use `user-pov-sliced-stories` only when the main need is user-invoke / user-uses-result formatting.
+
+## Target shape of each admission slice
+A good admission slice:
+- keeps the full end-to-end path wired
+- admits exactly one new case, shape, type, field set, or rule
+- continues to reject all non-admitted cases with a stable response
+- is unit-testable and end-to-end testable
+- produces an observable result that can be demonstrated without later admissions
+- could be deployed without harming unhandled traffic
+- leaves room to TDD and refactor after green
+
+## Progressive admission workflow
+
+### 1) Name the admission boundary
+State what is being admitted:
+- message type / event type
+- request shape
+- file format or row shape
+- UI action / command
+- business rule variant
+- schema version
+
+Also name the default rejection:
+- not implemented
+- invalid input
+- unsupported operation
+- unknown type
+
+### 2) Start closed (Slice 0)
+Build the end-to-end skeleton that correctly does nothing useful yet:
+- reader/entry point exists
+- checker/guard exists
+- processor path exists but is not entered for real work
+- every input is rejected by the established pattern
+
+Value of Slice 0:
+- clients can integrate against rejection behavior
+- exception handling and reporting can be tested
+- deploy path and observability can be proven early
+
+### 3) First admissions (often non-business)
+Admit the simplest useful closed-world cases first:
+- health / ping / noop
+- deliberately ill-formed input rejected with a specific error
+- auth/identity failure if that is the front door
+
+These prove the admit/reject machinery before real business logic lands.
+
+### 4) Admit one real case
+Choose one case using bargain hunting:
+- simplest shape, or
+- most common shape, or
+- highest learning / risk-reduction shape
+
+Implement only that admitted case. All other cases remain rejected.
+
+### 5) Widen one admission at a time
+Each later slice admits exactly one more:
+- another message type
+- another field combination
+- another path branch
+- another rule
+- another output variation
+
+Do not bundle "the rest of the cases" into one catch-up story unless they are truly trivial and still independently testable.
+
+### 6) Finish planned admissions, keep the reject path
+When planned cases are done:
+- surprise inputs still hit the established reject path
+- the service may already be in production doing useful work
+- remaining edge cases stay optional backlog, not a launch blocker
+
+### 7) Continue admissions over the life of the system
+New messages, fields, schemas, and rules keep using the same pattern:
+admit one, test thoroughly, deploy, repeat.
+
+## Versioning guidance
+When interfaces are versioned:
+- adding a new admitted message/shape: minor bump
+- changing or removing an existing admitted contract: major bump
+- only changes to already-shipped contracts are breaking
+
+## Required output format
+Produce a short admission plan, not a component task list.
+
+```markdown
+# Progressive admission plan: <capability>
+
+## Admission boundary
+- **Admits:** <what varies: messages, shapes, ops, fields, rules>
+- **Default reject:** <stable not-implemented / invalid response>
+- **End-to-end path:** <entry -> guard -> process -> result>
+
+## Slice 0 — Start closed
+- **Admits:** nothing useful
+- **Behavior:** every input rejected by the established pattern
+- **Someone invokes:** <how a client, user, or stakeholder exercises the closed path>
+- **Observable result:** <stable rejection, error, status, or diagnostic they can see>
+- **Independent demonstration:** <how to show this result without later slices>
+- **User/stakeholder value:** clients, errors, deploy path, and tests work end to end
+- **Acceptance checks:**
+  - <check>
+  - <check>
+- **Still rejected:** everything
+
+## Slice 1 — <first admission title>
+- **Admits:** <exact case>
+- **Behavior:** <what happens for that case only>
+- **Someone invokes:** <the action, request, message, or input that exercises this case>
+- **Observable result:** <what the invoker can see or use>
+- **Independent demonstration:** <how to show this result without later admissions>
+- **User/stakeholder value:** <why this admission matters now>
+- **Acceptance checks:**
+  - admitted case works
+  - non-admitted cases still reject stably
+- **Still rejected:** <explicit remainder>
+
+## Slice 2 — <next admission title>
+...
+```
+
+For each slice after 0, keep both sides explicit:
+1. what is newly admitted
+2. what remains rejected
+
+## Sequencing heuristics
+Prefer this order when unsure:
+1. closed skeleton
+2. reject/health/guard behavior
+3. simplest valid admission (often hard-coded or minimal implementation)
+4. most common real case
+5. high-risk or high-learning variants
+6. polish, performance, and broad edge coverage
+
+Bargain-hunt each next admission:
+- high learning or value per unit effort
+- safe to deploy
+- easy to test in isolation from later admissions
+
+## Quality gate before accepting a slice
+Ask:
+- Is the end-to-end path still intact?
+- Does this admit only one new case?
+- Are non-admitted cases still rejected the same way?
+- Can someone invoke this slice and observe a meaningful result?
+- Can we demonstrate and deploy it without waiting for later admissions?
+- Is it clear why this result is worth admitting now?
+- Are unit and end-to-end checks obvious?
+- If we stopped after this slice, would the system remain coherent?
+
+If a proposed slice secretly requires many shapes, rules, or channels at once, split again.
+
+## Anti-patterns
+- Building all processors first, then wiring the entry point last
+- "Support all message types" as a single story
+- Horizontal splits: schema story → service story → UI story
+- Opening the guard to "pass everything" before implementations exist
+- Treating reject/not-implemented as temporary junk instead of a productized path
+- Over-specifying later admissions before slice 0 and slice 1 teach anything
+- Calling component tasks "admissions"
+
+## Facilitation script (20–30 minutes)
+1. **3 min**: Name capability, users/clients, and the input-process-output cycle.
+2. **5 min**: Define admission boundary and default reject behavior.
+3. **5 min**: Write slice 0 (start closed) and its checks.
+4. **7 min**: List candidate admissions; pick first 2–4 by simplicity/value/risk.
+5. **5 min**: Write exact admitted case + still-rejected remainder for the next slice only.
+6. **Optional 5 min**: Note versioning implications if contracts are external.
+
+## Worked micro-example
+Capability: process queue messages for account updates.
+
+1. **Start closed**: consume message, validate envelope, always respond `not_implemented`.
+2. **Admit ill-formed envelope**: reject with `invalid_message` and structured error.
+3. **Admit health ping**: hard-coded `ok` result.
+4. **Admit `AccountOpened` minimal shape**: create account with required fields only.
+5. **Admit optional display name on `AccountOpened`**.
+6. **Admit `AccountClosed`**.
+7. Keep unknown types on `not_implemented`.
+
+Demonstrate each step by submitting the newly admitted message and showing its
+observable response, then submitting an unadmitted message and showing that the
+stable rejection still holds. Each step is independently demonstrable,
+testable, and potentially releasable.
+
+## Relationship to nearby skills
+- `story-splitting-for-delivery` (this skill): primary splitter; progressive admission sequence.
+- `user-pov-sliced-stories`: optional formatter — restate each admission slice in user-invoke / user-uses-result language after the plan exists.
+
+After building the admission plan, optionally apply `user-pov-sliced-stories` to restate slices in user-POV format.
+
+## Sources
+- Agile Otter: Progressive Admission Pattern
+  https://agileotter.blogspot.com/2026/08/progressive-admission-pattern-for-data.html
+- Agile Otter: Splitting Stories resource list
+  https://agileotter.blogspot.com/2022/03/splitting-stories-resource-list.html
+- Related ideas: walking skeleton, tracer bullets, evolutionary design / primitive whole, bargain hunting, scatter-gather avoidance, whole stories, example-based splitting.
+
+For deeper pointers see `references/source-map.md`.

--- a/extensions/otter-skills/skills/story-splitting-for-delivery/SOURCE_NOTES.md
+++ b/extensions/otter-skills/skills/story-splitting-for-delivery/SOURCE_NOTES.md
@@ -1,0 +1,53 @@
+# SOURCE_NOTES — story-splitting-for-delivery skill pair
+
+Covers both skills in this family:
+- `skills/story-splitting-for-delivery/`
+- `skills/user-pov-sliced-stories/`
+
+## What was taken
+
+### From `vendor-sources/iterative-story-split/SKILL.md` (priority source)
+- Full progressive admission workflow: start closed → first admissions → admit one → widen → keep reject path → forever.
+- Admission boundary naming, default-rejection framing, slice quality gate.
+- Versioning guidance (minor/major semantics for admitted contracts).
+- Required output format (progressive admission plan template) — kept verbatim.
+- Sequencing heuristics and bargain-hunting framing.
+- Anti-patterns list.
+- Facilitation script (20–30 min).
+- Worked micro-example (account update queue).
+- Cross-link to `user-pov-sliced-stories` as optional formatter.
+- Source URLs: progressive admission article + splitting resource list.
+
+### From `vendor-sources/iterative-story-split/references/source-map.md` (priority source)
+- Full content adapted into `references/source-map.md`, with one addition: a note about the old listicle source so lead integrators know why it was deprioritized.
+
+### From `vendor-sources/user-pov-sliced-stories/SKILL.md` (priority source)
+- Formatter-only role clarified up front.
+- Workflow (create admission plan first, then restate in user POV).
+- Required output format (User invokes / User uses result / Acceptance checks / Not yet in slice).
+- Sequencing rules, quality gate, response style.
+- Cross-link to `story-splitting-for-delivery` as the primary splitter.
+
+## What was dropped
+
+### From `vendor-sources/STORY_SPLITTING_SKILL.md` (lower priority, old listicle)
+- **Dropped entirely from skill bodies**: SPIDR-first primary workflow, hamburger method full procedure, 8-step facilitation script, split pattern menu (26+ sub-bullets), worked "pay bills online" example.
+- **Vocabulary preserved** (in `references/source-map.md` only): walking skeleton, tracer bullet, bargain hunting, scatter-gather avoidance, SPIDR as backup prompt vocabulary, hamburger method name-only pointer.
+- Source links from the listicle (Gojko, Dinwiddie, Cohn, Wake, Killick, etc.) were not added to the package. They are available in the original vendor file for anyone who needs them.
+
+## Design choices
+
+- Two skills remain separate by design: triggers and outputs differ. `story-splitting-for-delivery` outputs an admission plan; `user-pov-sliced-stories` outputs formatted slice descriptions for stakeholders.
+- Progressive admission is the **only** primary workflow in `story-splitting-for-delivery`. SPIDR and other pattern menus are demoted to vocabulary in `references/source-map.md`, used only to name the next admission boundary when it is unclear.
+- `user-pov-sliced-stories` sets `allow_implicit_invocation: false` in its Codex config — it should only trigger when the user explicitly wants user-POV formatting, not when they ask for a split.
+- Family framing: **story-splitting-for-delivery** (progressive admission for delivery-ready thin vertical slices), not generic story writing.
+- The canonical installable copies are the skill directories in this repository. Older user-level Warp copies are source history and may be replaced manually using the root installation guidance.
+
+## Deferred evaluations (not release blockers)
+
+- Keep `user-pov-sliced-stories` explicit-only unless routing evaluations show
+  that prompts such as “how do we describe these slices?” reliably intend that
+  formatter rather than the primary splitter.
+- Add a condensed bibliography from the old listicle to
+  `references/source-map.md` only if users demonstrate a recurring need to cite
+  those outside authors.

--- a/extensions/otter-skills/skills/story-splitting-for-delivery/references/source-map.md
+++ b/extensions/otter-skills/skills/story-splitting-for-delivery/references/source-map.md
@@ -1,0 +1,39 @@
+# Source map
+
+Use this file when you need deeper provenance or alternate phrasing.
+Prefer the progressive admission article first. Use the resource list only when the admission boundary is unclear and broader splitting ideas would help identify the next case.
+
+## Primary sources
+
+- **Progressive Admission Pattern** (Agile Otter)
+  https://agileotter.blogspot.com/2026/08/progressive-admission-pattern-for-data.html
+  Core sequence: start closed → first admissions → additional admissions → keep reject path → continue forever.
+  Applies beyond queues to any input-process-output cycle, including UI controls and form fields.
+  Also covers interface versioning (minor for new admissions, major for changes to shipped contracts).
+
+- **Splitting Stories resource list** (Agile Otter)
+  https://agileotter.blogspot.com/2022/03/splitting-stories-resource-list.html
+  Framing: end-to-end slices beat top-down design / bottom-up implementation.
+  Always prefer N% of the system 100% done over 100% of the system N% done.
+
+## Supporting ideas from the resource list
+Use these as supporting vocabulary, not as a second competing workflow.
+
+- **Walking skeleton / tracer bullet**: prove the end-to-end path exists early; this is slice 0.
+- **Evolutionary design / primitive whole**: grow a working whole instead of assembling finished parts late.
+- **Whole stories for whole teams**: keep product and engineering in one conversation around the split.
+- **Bargain hunting**: choose the next slice by value and learning per effort, not by completeness.
+- **Scatter-gather avoidance**: avoid splits where value appears only after late integration.
+- **Example/test-based splitting**: when stuck, split by concrete examples. Each example that requires different code is a candidate admission boundary.
+- **SPIDR and other pattern menus** (Spike, Path, Interface, Data, Rules): useful prompts for finding the next admission case, not a separate primary workflow.
+
+## How this skill does story splitting
+Many splitting guides ask: "What thin vertical slices deliver value?"
+This skill answers through progressive admission: "What is closed by default, and which single case do we open next?"
+
+That second question is the default operating mode here.
+Supporting pattern menus (SPIDR, hamburger, paths/data/rules) are prompts for finding the next admission — not an alternative primary workflow.
+
+## Lower-priority pointers from STORY_SPLITTING_SKILL.md (old listicle)
+The vendor file `STORY_SPLITTING_SKILL.md` contains a richer SPIDR-first menu, the hamburger method, and a 30-minute facilitation script.
+Those are useful as backup vocabulary if the team is stuck in technical decomposition. Do not resurrect that workflow as a primary path; fold only the vocabulary into `source-map.md` (done above).

--- a/extensions/otter-skills/skills/unit-testing/SKILL.md
+++ b/extensions/otter-skills/skills/unit-testing/SKILL.md
@@ -1,0 +1,411 @@
+---
+name: unit-testing
+description: Implement or extend production behavior test-first, or diagnose focused unit-test quality and flakiness, using red-green-refactor, ZOMBIES, Tidy First?, FIRST microtests, and Save Your Game checkpoints. Use for TDD, microtests, test-first bug fixes, flaky tests, and refactoring within an active green cycle. Do not use to choose delivery slices, format user stories, conduct a broad representation review, or perform a focused identifier-naming analysis; those belong to the corresponding sibling skills.
+---
+
+# Unit Testing (TDD · Microtests · ZOMBIES · Tidy First? · Eight Virtues)
+
+## When to use this skill
+
+**Use `unit-testing` when:**
+- Implementing new behavior or extending existing behavior with production code
+- Bug fixes that require new logic (characterize with a failing test first)
+- Choosing the next test to write (ZOMBIES ordering)
+- Deciding whether to tidy before writing the next test (Tidy First?)
+- Refactoring production or test code toward the Eight Code Virtues within an active TDD cycle
+- Diagnosing flaky, slow, or poorly-structured tests using FIRST
+- Any session where you would otherwise "code then sprinkle tests"
+
+**Do NOT use `unit-testing` for:**
+- Establishing initial test access or characterizing poorly understood existing behavior → use `legacy-code-safety`, then return here
+- Choosing which delivery slice to build next → use `story-splitting-for-delivery`
+- Formatting an already-split story as user-visible outcomes → use `user-pov-sliced-stories`
+- Reviewing code broadly for representation or virtue violations without an active TDD cycle → use `representation-refactor-review`
+- Performing a focused identifier diagnosis or rename plan → use `code-object-naming`
+- Trunk-landing strategies, feature toggles, or branch-by-abstraction (out of scope for this package)
+
+---
+
+## Purpose and scope
+
+TDD is programming hygiene. Its job is not "prove the whole system" or "raise coverage." Its job is to keep code orderly and **safe to change in tiny steps** so you can refactor, integrate, and deliver without fear.
+
+- **Timely, not Thorough:** test-first keeps code testable and orderly; component, contract, E2E, and human testing are still required and not replaced by microtests.
+- **Test-after is not TDD:** writing tests after a production pile recreates legacy conditions — hard-to-test shapes, fear of breaking "what already works," and joyless test-after work.
+- **Review is not a substitute for tests:** `representation-refactor-review` catches representation drift and virtue violations but does not replace the microtest hygiene loop this skill owns.
+
+---
+
+## What requires test evidence
+
+Before changing production behavior, make a short **Beck-style test list** of
+behavioral examples and concerns. This is not a manual test plan or a scripted
+series of human actions and observations. It is a revisable list of tests that
+might be needed; implement only one test at a time and update the list as the
+code teaches you more.
+
+A test list is required when work creates or changes:
+
+- decisions or alternatives: `if`/`else`, conditional expressions, pattern
+  matching, `switch`/`case`
+- repetition, selection, grouping, ordering, or aggregation:
+  `for`/`while`, filters, folds, queries
+- calculations, conversions, parsing, formatting, or validation
+- documents, classes, records, messages, entities, or other data
+- persistence, retrieval semantics, state transitions, or side effects
+- error handling, retries, fallbacks, authorization, or boundary enforcement
+- any behavior where different inputs, states, or circumstances should produce
+  meaningfully different results
+
+At minimum, consider and list:
+
+- ordinary successful examples
+- anticipated errors and rejected inputs
+- boundary conditions and transitions
+
+The test list is inventory, not a batch to write in advance. Select the next
+test with ZOMBIES, make it pass, refactor, and then reconsider the list.
+
+### Choose the test level
+
+Decision and transformation logic normally belongs under FIRST microtests.
+Behavior that depends on a real boundary needs the smallest faithful automated
+test capable of establishing it:
+
+- persistence semantics may require an integration test against the real store
+- document creation may require a component, approval, schema, or round-trip test
+- messages and public interfaces may require contract or serialization tests
+- user workflows may require story, component, or end-to-end tests
+
+Extract decision or transformation logic into microtestable units when that
+improves the design. Do not replace necessary high-fidelity evidence with mocks
+that cannot establish the real behavior.
+
+Dedicated microtests are usually unnecessary for simple wiring or delegation,
+read-only accessors that merely return stored state, generated code, trivial
+data carriers, or declarative framework configuration. These may be exercised
+indirectly by a faithful higher-level test. Add focused tests when apparently
+simple code acquires a decision, transformation, contract, or meaningful
+failure mode.
+
+---
+
+## Preconditions: Clean Start
+
+Before the first production edit of a task:
+
+1. Working tree intentional and tidy — no mystery untracked junk, no unrelated half-work.
+2. Current with the integration branch when project practice and the user's authorization allow the required fetch/pull.
+3. Dependencies updated the repo's way.
+4. Clean build if the stack needs one.
+5. **All relevant tests green** — use `./prepare` or `./run_tests` when present.
+
+If anything is red before your changes, stop. That is an inherited problem; do not pile new work on a broken baseline.
+
+Run the fast suite after each small step. Testing never needs permission.
+
+---
+
+## The cycle (do not skip steps)
+
+Work one behavior at a time. Keep cycles short enough that retreat is cheap.
+
+```text
+clean/green baseline
+  → update the Beck-style test list; pick ONE next behavior (ZOMBIES order)
+  → Tidy First? (First / After / Later / Never)
+  → write the next failing test at the chosen level (normally a microtest)
+  → write minimum production code to pass (green)
+  → refactor toward the Virtues (stay green)
+  → authorized atomic microcommit (Save Your Game)
+  → integrate: combine, verify, publish when authorized
+  → repeat from a clean, current baseline
+```
+
+### Red
+
+- Name the behavior in domain language (situation + expectation).
+- Exercise a realistic public API you wish existed; let the test design the call site.
+- Fail because the behavior is missing or wrong — **not** from `fail()` hacks or compile errors as placeholders.
+- Only enough test to fail meaningfully. One primary reason to fail; clear assertion message.
+
+### Green
+
+- Only enough production code to make the suite pass.
+- No speculative features; no extra branches "while you're here."
+- You may change design for testability; that is expected.
+- When anything is red, your only job is restoring green — including **graceful retreat** to the last good commit if the step went sideways.
+
+### Refactor
+
+- Required, not optional. Skipping refactor is how suites and designs rot.
+- Remove duplication; clarify names; improve structure **while green**.
+- Refactor tests too; treat them as production-grade code.
+- Prefer automated IDE/LSP refactor tools over manual cut/paste.
+- Stay structure-shy (see below) so tests do not freeze internals.
+
+### Atomic microcommit / Save Your Game
+
+- When the intentional step is complete and green, use `atomic-commit` to prepare the whole repository state, obtain human review, and commit only when authorized.
+- The atomic microcommit is the local **Save Your Game** point: coherent, tested, recoverable, and distinct from publishing to collaborators. Human review belongs inside this rapid loop; do not enlarge the step merely to reduce review frequency.
+- Park side quests instead of mixing them. Before tricky attempts, use an authorized recoverable checkpoint. If confused, retreat without discarding unrelated user work, then redo smaller.
+- If a commit is not authorized, preserve and report the green diff without committing.
+- Task is not complete while tests fail.
+
+### Integrate
+
+- Integration is a separate step after the local Save Your Game point: obtain current shared changes, combine them with the completed change, and rerun the prescribed checks on that newly combined state.
+- Publish only when project practice calls for it and the user has authorized the external action.
+- Any integration operation that creates or rewrites commits remains subject to the complete-state review and verification rules in `atomic-commit`.
+- Do not call a local commit "integrated" when collaborators cannot yet obtain it. Do not publish a combined state that has not been tested.
+
+---
+
+## ZOMBIES: ordered test selection
+
+Maintain the Beck-style test list. Pick the next test using ZOMBIES, not arbitrarily:
+
+1. **Zero** — the null/empty/trivial case first.
+2. **One** — a single simple instance.
+3. **Many (More complex)** — the general case, once Zero and One both pass.
+4. At each of those stages, separately attend to:
+   - **Boundary** — edge values at that complexity level.
+   - **Interface** — does the shape of the call still make sense as scenarios accumulate?
+   - **Exception** — the failure/error path for that stage.
+5. **Simple scenarios, Simple solutions** — resist writing a Many-complexity test while Zero/One are unproven. Resist over-engineering the implementation ahead of what the current test demands.
+
+**One test at a time.** Never write a batch of tests and fill them in after — batching commits to interface decisions before the first implementation has taught you anything. Canon TDD names this a failure mode (rework, "test #6 depression") for a concrete reason.
+
+---
+
+## Tidy First? (before each next test)
+
+Before writing each next test, ask explicitly: **First, After, Later, or Never?**
+
+- **First** — current structure would make the upcoming test awkward or impossible to add cleanly. Do the structural change now, as its own step: tests green before and after, no behavior change, separate commit from the behavior that follows. This is "make the change easy, then make the easy change."
+- **After** — structure is fine for this test; land the behavior now, clean up in the refactor step once green.
+- **Later** — worth doing eventually, not blocking right now. Note it (comment, ticket, journal — whatever the project already uses) and proceed.
+- **Never** — the cost of tidying exceeds the benefit. Say so and move on; don't tidy reflexively.
+
+Prefer LSP-backed rename/extract tools or `ast-grep` structural rewrite over hand-editing for any First or post-green structural change — mechanical and deterministic beats agent-reasoned-and-regenerated for moves a tool can do exactly. Reserve model reasoning for the judgment call (which option, and why), not for typing out a rename across a dozen call sites.
+
+---
+
+## Microtests (FIRST)
+
+TDD's inner loop uses **microtests** (unit tests that meet FIRST):
+
+| Letter | Meaning |
+|--------|---------|
+| **F**ast | Milliseconds preferred; no real network/DB/filesystem/clock/services |
+| **I**solated | No shared mutable state; any order; one behavior |
+| **R**epeatable | Same result every run; control time/randomness/threads |
+| **S**elf-verifying | Assert automatically; no manual log inspection |
+| **T**imely | Written before/with the code, not after a big bang |
+
+Rules of thumb:
+
+- Test the unit in an **artificial** context, not full app context.
+- If you need DB/HTTP/clock, fake or inject them — or move this test to a slower suite.
+- Do not grow a heavyweight test framework to compensate; shrink the test and the unit boundary.
+- Microtests do not replace component, contract, story/BDD, E2E, or human checks. They make those affordable by keeping units honest.
+- **High-fidelity rule:** production code must not branch on "am I being tested?"
+
+### Make Isolated and Repeatable observable
+
+FIRST is an acceptance criterion, not merely a description. Before accepting a
+new or changed test as green, inspect every input that can affect its assertion:
+time and timezone, randomness, threads and scheduling, iteration order, process
+environment, locale, shared mutable state, files, ports, databases, networks,
+credentials, permissions, and pre-existing records. The test must control each
+relevant input or provide an isolated, test-specific environment that does.
+
+Use evidence proportional to the risk:
+
+- Run the new test alone and in its containing suite.
+- When the runner supports it, vary test order to expose contamination and
+  retain the reported seed so a failure can be reproduced. Ordering tests to
+  hide contamination is not a repair.
+- For a concurrency, timing, order-dependence, or prior-flake repair, repeat the
+  focused test enough to investigate likely intermittency. Repetition supplies
+  evidence; it does not prove that no flake remains and must never become
+  rerun-until-green acceptance.
+
+Whatever a test requires, it provides. Prefer fresh fixtures and unique,
+test-owned resources. For higher-level tests that need real infrastructure,
+provision known configuration and curated data in a pristine or otherwise
+isolated environment; do not share mutable services with people or unrelated
+test runs.
+
+Assert only the behavior that matters. Do not depend on incidental order from
+unordered collections, queries, messages, or concurrent completion: either make
+ordering part of the production contract or compare without regard to order.
+Prefer explicit deterministic inputs; when randomness is itself relevant, use
+a reproducible seed and report it on failure. Use one injected clock reading for
+one logical operation and deliberately cover relevant calendar, timezone, DST,
+and expiry boundaries. Synchronize on observable events, conditions, futures,
+or barriers rather than guessed delays; assert elapsed time only when timing is
+the behavior under test.
+
+### Outside-in option
+
+A failing higher-level example/story test may hang red while you drive the interior with microtests. Still do not bulk-write production code without microtest guidance for decisions and transformations.
+
+---
+
+## Write tests that enable refactoring (structure-shy)
+
+Bad tests block the purpose of TDD.
+
+**Behavior over structure**
+
+- Read tests to understand code; never require reading production code to understand tests.
+- Assert observable results and meaningful outcomes, not incidental private structure.
+- Prefer scenario-oriented organization (shared arrange = shared situation) over rigid "one test class per production class" when clarity suffers.
+
+**Resilient under routine change**
+
+Existing tests should normally survive implementation edits and refactorings
+that preserve observable behavior. Do not mechanically edit tests to mirror each
+production edit or merely restore green. When an existing test breaks, classify
+the reason before changing either side:
+
+- The observable behavior or contract intentionally changed: update or replace
+  the test deliberately so it states the new behavior.
+- Production behavior regressed: repair the production code.
+- Only implementation structure, incidental formatting or ordering,
+  collaborator calls, snapshots, or fixture details changed: repair the
+  over-specified test so it observes the meaningful outcome instead.
+- The reason is unclear: investigate before editing both test and production
+  code; making both agree can conceal the defect.
+
+If routine work requires edits to several existing tests, stop treating those
+edits as maintenance. This is evidence of shared structural coupling or
+over-specification. Locate and remove that source of maintenance pressure before
+continuing. Adding a test for genuinely new behavior is expected; repeatedly
+rewriting existing tests to track code movement is not.
+
+**Structure-shy (Law of Demeter / "one dot")**
+
+- Do not reach through deep graphs in tests or production (`a.b.c.d`).
+- Talk to immediate collaborators; push knowledge behind intention-revealing methods.
+- Deep coupling in tests makes refactors fail everywhere and teaches teams to fear improvement.
+
+**Assertions and names**
+
+- Use assertions that print useful expected/actual values.
+- Test name + assertion should diagnose the mistake without reading the whole test body.
+- Avoid magic values; name domain-meaningful constants.
+
+**Side effects**
+
+- Prefer testing direct results over obscure global/file/DB side effects.
+- Side-effect-heavy tests usually signal low-cohesion design — improve the design.
+
+---
+
+## Refactor toward the Eight Virtues
+
+When refactoring (optionally after each green; required in CLEANUP), target named virtues rather than vague "cleanup":
+
+**Working** is non-negotiable. **Unique, Simple, Clear, Easy, Developed, Brief, and Coherent are peers in balance**; no peer has a fixed rank. Never pursue Brief at the expense of Working or overall representation quality.
+
+- **Unique / SPOT** — is this fact stated in exactly one place? Duplication hints at a Unique violation. Do not abstract ahead of a real second instance.
+- **Simple** — fewer operators/operands/paths, independent of naming.
+- **Clear** — would multiple readers agree on what this does, independent of Simple.
+- **Easy** — is the right next change actually easy to make, or would it require touching many places?
+- **Developed** — still using raw primitives where a real type/abstraction has emerged? (Watch for Primitive Obsession, Feature Envy.)
+- **Coherent** — does this vocabulary, pattern, and structure agree with the rest of the system, not just read well in isolation? Especially useful for keeping agent-written code from drifting into locally-sound-but-globally-inconsistent vocabulary.
+- **Brief** — remove excess that adds no value, while balancing it with Clear, Easy, Developed, and the other peers.
+
+Use LSP rename / `ast-grep` for mechanical moves (Extract Method, Rename, Replace Temp with Query — Fowler's catalog); use model judgment only to decide *which* virtue is violated and what the target shape should be.
+
+---
+
+## Affordable feedback
+
+Defect cost tracks how long bugs sit undetected. Slow suites make people run tests less, which makes debugging worse.
+
+- Keep the coding suite fast enough to run after nearly every edit.
+- Segregate slow tests; do not pretend UI/API tests are microtests.
+- Replace slow broad tests of pure logic with microtests of that logic.
+- Flaky tests destroy trust — fix causes (over-specification, shared state, time, external services, order dependence). Do not normalize "rerun until green."
+
+---
+
+## Diagnosing FIRST violations
+
+| Symptom | Likely violation | Common root causes |
+|---------|-----------------|-------------------|
+| Fails intermittently | Repeatable | Clock, threads, randomness, env difference |
+| Passes alone, fails in suite | Isolated | Shared state, static caches, DB residue |
+| Fails only in CI | Repeatable | Env config, concurrency, race conditions |
+| Slow and unstable | Fast | Real network/DB calls, large fixtures |
+| Unclear failure signal | SelfVerifying | Missing/weak assertions, log-inspection reliance |
+
+Repair approaches: inject clock abstractions; seed RNG; use synchronization primitives (remove `sleep()`); reset state in setup/teardown; eliminate globals; replace real services with in-memory fakes or doubles.
+
+Do not assume the test is defective. A consistent test can reveal intermittent
+production behavior such as races, lost updates, nondeterministic ordering,
+overflow, clock-boundary defects, or latency sensitivity. Reproduce while
+varying one relevant dimension at a time (order, seed, load, timezone/locale,
+parallelism, or environment), locate the uncontrolled input, and repair the
+cause. Do not weaken, ignore, quarantine, or rerun past the assertion merely
+because the failure is intermittent.
+
+---
+
+## What TDD is not (avoid cargo cult)
+
+| Misunderstanding | Reality |
+|-----------------|---------|
+| TDD = QA / system validation | TDD enables safe change; other testing still required |
+| TDD = maximize coverage % | Coverage is a side effect; goal is safe change |
+| Write all tests first in a batch | One failing test at a time, in cycle |
+| Testers hand devs unit tests | Developers own the microtest cycle and refactor |
+| Skip green/refactor because "trivial" | Small skips accumulate into untestable mess |
+| Integration is "not TDD" | Save locally, then integrate continuously; verify the combined state |
+| Tests must mirror class structure | Tests must document behavior and survive refactor |
+| Timely means Thorough | Write tests when writing the code; exhaustive coverage is not the goal |
+
+---
+
+## Session algorithm
+
+1. **Clean start** — baseline green (`./prepare` / `./run_tests` as available).
+2. **Test list** — inventory likely successes, errors, and boundaries; do not write the tests as a batch.
+3. **Tidy First?** — ask First/After/Later/Never before each next test.
+4. **Pick one** behavior; optionally draft the commit message (intentional commit).
+5. **Red** — write the next test at the chosen level (normally a FIRST microtest); confirm its failure reason is correct.
+6. **Green** — minimal code; run tests (full fast suite or project norm).
+7. **Refactor** — tidy prod + tests toward named virtues; run tests again. If behavior-preserving production edits break existing tests, classify the cause and remove over-specification rather than synchronizing tests mechanically.
+8. **Atomic microcommit / Save Your Game** — when authorized, use `atomic-commit` to review and preserve the complete green state; otherwise report the green diff.
+9. **Integrate** — when authorized, incorporate shared changes, verify the combined state, and publish; do not conflate this with the local commit.
+10. If stuck more than one small step of confusion → **retreat** to the last green saved state and choose a smaller behavior.
+11. Repeat from a clean, current baseline. Never end a coding session on red you introduced.
+
+---
+
+## Anti-patterns to refuse
+
+See `references/anti-patterns.md` for the quick-reference list. Key ones:
+
+**Process:** production code before a failing test; big-bang implementation then tests; skipping refactor; batching tests before implementing any; leaving suite red while starting another concern; huge uncommitted WIP; normalizing "rerun until green."
+
+**Test design:** tests coupled to private structure or deep-graph navigation; routinely editing existing tests to mirror production changes; one test asserting many unrelated behaviors; shared mutable fixtures leaking across tests; real time/network/DB/filesystem/sleep in microtests; production code that detects test mode; test names that restate technical methods instead of domain situations.
+
+**Refactor:** vague "cleanup" without targeting a named virtue; hand-editing renames across many files when LSP/`ast-grep` can do it exactly; pursuing Brief at the cost of Clear or Working.
+
+**Scope confusion:** expecting microtests alone to prove product fitness; treating coverage % as the goal; weakening or rewriting existing tests to accept broken behavior without explicit human approval.
+
+---
+
+## Interaction with other skills
+
+- `legacy-code-safety` — establishes a trustworthy boundary around poorly understood or weakly tested existing code. Once that boundary can detect relevant change, this skill owns the new behavior cycle.
+- `story-splitting-for-delivery` — choose and sequence thin vertical delivery slices; `unit-testing` implements each admitted slice with TDD discipline. Do not use `unit-testing` to choose the split.
+- `user-pov-sliced-stories` — formats an already-split story as explicit User-invokes / User-uses-result outcomes. `unit-testing` does not own that formatting.
+- `representation-refactor-review` — owns broad representation critique, including ZOM drift. The Eight Virtues vocabulary is shared: `unit-testing` applies it inside the active green cycle; the review skill applies it when review itself is the task.
+- `code-object-naming` — owns focused identifier diagnosis and rename planning. Routine naming improvements inside the green refactor step remain part of `unit-testing`; defer only a deeper naming pass.
+- `atomic-commit` — owns preparation, whole-repository verification, human review, and creation of the local Save Your Game microcommit. `unit-testing` keeps that commit distinct from subsequent shared integration.
+- **Existing tests are contracts:** do not weaken or rewrite existing tests to accept broken behavior unless the user explicitly approves and reviews the shown change.

--- a/extensions/otter-skills/skills/unit-testing/SOURCE_NOTES.md
+++ b/extensions/otter-skills/skills/unit-testing/SOURCE_NOTES.md
@@ -1,0 +1,46 @@
+# SOURCE_NOTES — unit-testing skill
+
+## Sources consulted
+
+1. `vendor-sources/canonical-tdd/canonical-tdd-skill.md` — **highest priority**
+   - Frontmatter name was `split-tidy-ship`; this is the canonical Tim Ottinger / IL skill covering ZOMBIES, Tidy First?, Eight Virtues, and Canon TDD discipline.
+2. `vendor-sources/tdd/SKILL.md` — Warp `tdd` skill (previously installed at `~/.agents/skills/tdd`)
+3. `vendor-sources/tdd/sources/CORPUS_SUMMARY.md` — distilled Clean Start series + TDD corpus notes
+4. `vendor-sources/tdd/references/anti-patterns.md` — TDD anti-patterns quick list
+5. `vendor-sources/tdd-skill/SKILL.md` — near-identical to `vendor-sources/tdd/SKILL.md` (same content; tdd-skill is an older copy)
+6. `vendor-sources/unit_test_engineering/SKILL.md` — FIRST diagnostics, flaky-test triage, test design guidelines
+7. Tim Ottinger, ["Why Are My Tests Flakey?"](https://www.industriallogic.com/blog/why-are-my-tests-flakey/) — over-specification, cross-contamination, global state, unreliable inputs and environments, date/time errors, and intermittent production behavior; vendored at `vendor-sources/tdd-skill/sources/why-are-my-tests-flakey.md`
+
+## What was taken
+
+- **From canonical-tdd:** Phase 2 (Tidy First? / First-After-Later-Never), Phase 3 (ZOMBIES ordering + one-test-at-a-time canon), Phase 4 (Eight Virtues refactor target with full virtue definitions and LSP/ast-grep tool preference). These are the core TDD/microtest/tidy/ZOMBIES/virtue-refactor sections per PLAN.md instructions.
+- **From tdd:** Clean Start preconditions, red-green-refactor-integrate cycle, FIRST microtest table, structure-shy / LoD guidance, high-fidelity rule, affordable feedback section, cargo-cult avoidance table, session algorithm, graceful retreat / Save Your Game discipline.
+- **From unit_test_engineering:** FIRST violation diagnostic table (symptom → violation → root causes → repair), flaky-test repair approaches, test design anti-patterns (god test, shared fixture mutation, sleep-based sync), "one behavior per test" rule.
+- **From "Why Are My Tests Flakey?":** operational evidence for Isolated and Repeatable tests; order randomization as a diagnostic rather than a repair; controlled, test-specific environments; unordered-result handling; calendar-boundary and synchronization guidance; and the distinction between a flaky test and a reliable test exposing flaky production code.
+- **Resilience interpretation:** frequent edits to existing tests during behavior-preserving production work are treated as evidence of over-specification or structural coupling. The skill requires classifying a break as an intentional contract change, production regression, brittle test, or unresolved cause before editing the test.
+- **From tdd/references/anti-patterns.md:** supplemented and deduplicated into `references/anti-patterns.md`.
+
+## What was dropped
+
+- **Phase 1 (story splitting / INVEST/SPIDR)** — belongs to `story-splitting-for-delivery` per PLAN.md.
+- **Phase 5 (trunk landing, feature toggles, Branch by Abstraction, MMMSS gates)** — out of scope for this package per PLAN.md.
+- **Full article dumps** from `vendor-sources/tdd/sources/` (Clean Start series text, full URI corpus) — too bulky; CORPUS_SUMMARY.md content was distilled into skill body instead.
+- **`tdd-skill/sources/` directory** — identical to `tdd/sources/`; not duplicated.
+- **BDD/examples section** from CORPUS_SUMMARY — kept only the "BDD complements TDD; does not replace microtesting" note within the cargo-cult table; full BDD treatment belongs elsewhere.
+- **MMMSS shipping gate logic** from canonical-tdd Phase 5.
+
+## Key design choices
+
+- Merged all three source skills into ONE `SKILL.md` body (no sibling skills); PLAN.md rule "one concept, one skill."
+- ZOMBIES section is now a first-class section (not buried), matching canonical-tdd priority.
+- Tidy First? is integrated into the cycle diagram and has its own section, with explicit First/After/Later/Never choices.
+- The Industrial Logic Red-Green-Refactor-Integrate loop is expanded operationally as Clean Start → test list → Tidy First? → Red → Green → Refactor → authorized atomic Save Your Game microcommit → separately verified shared integration. Human review participates in the rapid microcommit loop; the local commit and integration are intentionally not conflated.
+- Eight Virtues doctrine matches the review skill: Working is non-negotiable; the other seven are peers in balance.
+- FIRST diagnostic table from `unit_test_engineering` is kept as a quick triage reference within the skill body.
+- `agents/openai.yaml` default_prompt is an ordered operational checklist usable directly by Codex.
+- `references/anti-patterns.md` is lean; points back from SKILL.md with one line rather than duplicating all items.
+
+## Deferred evaluations and design options (not release blockers)
+
+1. **Eight Virtues canonical source** — the virtue definitions come from canonical-tdd-skill.md (Ottinger & Langr); if a dedicated shared reference is later useful, both `unit-testing` and `representation-refactor-review` could link to it rather than duplicate it.
+2. **Description trigger wording** — the current `description:` frontmatter uses a concise capability boundary. Validate it against real routing prompts before expanding it.

--- a/extensions/otter-skills/skills/unit-testing/references/anti-patterns.md
+++ b/extensions/otter-skills/skills/unit-testing/references/anti-patterns.md
@@ -1,0 +1,47 @@
+# Unit Testing Anti-Patterns (stop these)
+
+## Process
+
+- Production code before a failing test for that behavior
+- Big-bang implementation, tests afterward ("new legacy")
+- Writing a batch of tests before implementing any of them
+- Skipping refactor because "it works"
+- Leaving the suite red while starting another concern
+- Huge uncommitted WIP — cannot retreat cheaply
+- Mixing unrelated changes in one commit
+- Ignoring failures / rerunning until flake passes
+- Configuring automatic reruns as a substitute for diagnosing a flake
+- Quarantining or ignoring a flaky test without an owner and repair path
+- Treating CI as a substitute for local continuous testing
+- Using bare `fail()` or compile errors as the intended red without asserting behavior
+
+## Test design
+
+- Tests coupled to private structure, call graphs, or train-wreck navigation (`a.b.c.d`)
+- Editing existing tests alongside routine production edits merely to preserve green
+- Treating widespread test maintenance after a behavior-preserving refactor as normal
+- One test asserting many unrelated behaviors (god test)
+- Shared mutable fixtures that leak across tests
+- Real time, network, DB, filesystem, or sleep in microtests
+- Depending on incidental order from an unordered or concurrently-produced result
+- Sharing mutable environments, records, ports, credentials, or services across test runs
+- Ordering tests alphabetically or otherwise to conceal cross-contamination
+- Over-specified snapshots of entire HTML/JSON/DOM when one fact matters
+- Assertions that only check `true`/`false` without useful expected/actual output
+- Production code that detects test mode (high-fidelity violation)
+- Test names that restate technical method names instead of domain situations
+
+## Refactor
+
+- Vague "cleanup" without targeting a named virtue
+- Hand-editing renames or extracts across many files when LSP/`ast-grep` can do it exactly
+- Pursuing Brief at the cost of Clear or Working
+- Abstracting at first duplication hint without a second real instance (Unique violation)
+
+## Scope confusion
+
+- Expecting microtests alone to prove product fitness
+- Treating coverage % as the goal rather than safe change
+- Replacing BDD/example collaboration with guesswork microtests for unclear rules
+- Expanding coverage metrics with empty tests that never assert
+- Weakening or rewriting existing tests to accept broken behavior without explicit human approval

--- a/extensions/otter-skills/skills/user-pov-sliced-stories/SKILL.md
+++ b/extensions/otter-skills/skills/user-pov-sliced-stories/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: user-pov-sliced-stories
+description: Format thin vertical slices as explicit "User invokes" and "User uses result" outcomes. Use when the split already exists or the user specifically wants user-observable wording for slices. For choosing the split sequence itself, prefer `story-splitting-for-delivery` (progressive admission). Also use when reframing a technical plan into user-visible slices after admission planning is complete.
+---
+
+# User POV Sliced Stories
+
+## Role of this skill
+This skill is a **formatter**, not a splitter.
+It translates an existing admission plan into user-visible invoke/result language.
+
+Primary splitting — choosing the admission boundary, sequencing slices, writing Slice 0, bargain-hunting the next case — belongs in `story-splitting-for-delivery`.
+Apply this skill after that plan exists, or when the user specifically asks for user-observable wording.
+
+## Build slices as user-visible behavior
+Define each slice as an end-to-end behavior a user can trigger and benefit from immediately.
+Avoid component-only splits (UI-only, API-only, DB-only).
+Each slice must be independently demoable.
+
+## Workflow
+1. If no admission plan exists yet, create one with `story-splitting-for-delivery` first.
+2. Restate the capability in customer terms: who, behavior change, value now.
+3. For each admission slice, write the user-visible invoke/result pair (see format below).
+4. Keep slices small — typically 1–3 days.
+5. Define concrete acceptance examples before implementation.
+6. Re-split after each delivered slice based on feedback.
+
+## Required output format
+For each slice, always produce:
+
+### Slice N — \<short user-facing title\>
+- **User invokes:** \<exact command, UI action, API call, or trigger\>
+- **User uses result:** \<observable value/output the user consumes immediately\>
+- **Acceptance checks:** \<2–4 testable checks\>
+- **Not yet in this slice:** \<explicitly deferred scope\>
+
+## Sequencing rules
+- Deliver 2–5 slices at a time.
+- Put the safest value slice first.
+- Put highest uncertainty reduction in slice 1 or 2.
+- Keep later slices negotiable; do not over-specify implementation.
+
+## Quality gate before finalizing slices
+Confirm each slice:
+- is demoable to a stakeholder
+- provides value or learning even if work stops afterward
+- is testable independently
+- remains vertical and user-observable
+- is small enough for fast feedback
+
+## Response style
+- Write from user POV, not component POV.
+- Prefer concrete invocation language: command name, button label, menu path, API endpoint.
+- Keep each slice concise and high signal.
+- If the plan uses technical admission language, translate it — do not copy paste implementation details.
+
+## Relationship to nearby skills
+- `story-splitting-for-delivery`: primary splitter — defines admission boundary, Slice 0, and admission sequence.
+- `user-pov-sliced-stories` (this skill): formatter — restates the output of that plan in user-visible language.
+
+Invoke `story-splitting-for-delivery` when the question is "how do we cut this work?"
+Invoke this skill when the question is "how do we describe these slices to stakeholders?"

--- a/governance/schemas/extension-manifest.schema.json
+++ b/governance/schemas/extension-manifest.schema.json
@@ -14,7 +14,7 @@
     "version": { "type": "string" },
     "description": { "type": "string" },
     "govkit_min_version": { "type": "string" },
-    "extension_type": { "type": "string", "enum": ["architecture"] },
+    "extension_type": { "type": "string", "enum": ["architecture", "skills"] },
     "supported_levels": {
       "type": "array",
       "items": { "type": "integer" }
@@ -63,6 +63,44 @@
             },
             "additionalProperties": false
           }
+        }
+      }
+    },
+    "skills": {
+      "type": "array",
+      "description": "Agent skills this pack carries. `govkit extension add` installs each into the applied agent's skills directory (e.g. .claude/skills/<install_as>/), skipping any destination that already exists unless --force is given.",
+      "items": {
+        "type": "object",
+        "required": ["path", "install_as"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Extension-folder-relative path to a directory containing SKILL.md."
+          },
+          "install_as": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]*$",
+            "description": "Directory name under the agent's skills dir. Convention: <pack-prefix>-<skill-name>."
+          }
+        }
+      }
+    },
+    "origin": {
+      "type": "object",
+      "description": "Provenance for vendored third-party content. Records where the pack's content was copied from and under what license, so attribution and re-vendoring stay auditable.",
+      "required": ["upstream_url", "upstream_ref", "license"],
+      "properties": {
+        "upstream_url": { "type": "string" },
+        "upstream_ref": {
+          "type": "string",
+          "description": "Pinned upstream commit SHA the vendored copy was taken from."
+        },
+        "upstream_version": { "type": "string" },
+        "license": { "type": "string" },
+        "license_files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extension-folder-relative paths to the upstream license/notice files shipped with the pack."
         }
       }
     },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,6 +10,7 @@ PowerShell scripts that exercise `govkit apply` and `govkit validate` across the
 | `smoke-ui.ps1` | 3 agents × 3 standalone UI shapes × 3 levels (`ui-react`, `ui-angular`, `ui-nextjs`) | `scripts/projects-ui/` |
 | `smoke-dotnet.ps1` | 3 agents × 3 levels (`--type api`, .NET-realistic feature content) | `scripts/projects-dotnet/` |
 | `smoke-inspect.ps1` | Visual inspection helper (no apply/validate) | Reads from `scripts/projects*/` |
+| `sync_otter_skills.py` | Re-vendors the `extensions/otter-skills/` pack from a pinned upstream commit (dev-time only — never runs at install time) | Rewrites `extensions/otter-skills/` in place |
 
 Output dirs and the bootstrapped `.venv/` are gitignored — running the scripts won't dirty your working tree.
 

--- a/scripts/sync_otter_skills.py
+++ b/scripts/sync_otter_skills.py
@@ -88,6 +88,24 @@ def sync(sha: str, upstream_version: str) -> None:
             sys.exit(f"Error: checkout resolved to {head}, not the requested {sha}.")
 
         plugin = clone / UPSTREAM_PLUGIN
+        # Validate the upstream layout BEFORE deleting anything vendored —
+        # a reshaped upstream must fail with the working tree intact, not
+        # half-erased.
+        upstream_skills = [
+            p for p in sorted((plugin / "skills").glob("*")) if (p / "SKILL.md").is_file()
+        ] if (plugin / "skills").is_dir() else []
+        missing = [
+            str(p.relative_to(clone))
+            for p in (plugin / "LICENSE", plugin / "NOTICE")
+            if not p.is_file()
+        ]
+        if not upstream_skills or missing:
+            sys.exit(
+                f"Error: upstream layout at {sha} is not what this script "
+                f"expects ({UPSTREAM_PLUGIN}/skills/*/SKILL.md plus LICENSE and "
+                f"NOTICE; missing: {missing or 'skills'}). Nothing was deleted."
+            )
+
         pack_skills = PACK_DIR / "skills"
         if pack_skills.exists():
             shutil.rmtree(pack_skills)

--- a/scripts/sync_otter_skills.py
+++ b/scripts/sync_otter_skills.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# Copyright 2026 Accelerated Innovation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+"""Re-vendor the otter-skills extension pack from a pinned upstream commit.
+
+DEV-TIME ONLY. govkit has no network access at install time and must keep
+none — this script runs on a maintainer's machine to refresh
+extensions/otter-skills/ from https://github.com/tottinge/otter-skills,
+then the result ships in the wheel like any other bundled pack.
+
+    python scripts/sync_otter_skills.py --sha <40-hex> --upstream-version <v>
+
+What it does:
+  1. Clones upstream into a temp dir and checks out the given SHA (verified
+     against `git rev-parse HEAD` — a branch name or short SHA is refused).
+  2. Replaces the pack's skills/ with plugins/otter-skills/skills/*,
+     excluding each skill's agents/ subdir (OpenAI agent-builder config no
+     govkit-supported agent consumes).
+  3. Copies the plugin-level LICENSE and NOTICE to the pack root so the
+     Apache-2.0 attribution travels with every copy `extension add` makes.
+  4. Regenerates manifest.yaml (this script owns that file: provenance,
+     version, and the skills list are derived, so a re-run at the same SHA
+     is a no-op) and rewrites the provenance block in the pack README.
+
+Idempotence check: running at the currently-pinned SHA must leave
+`git diff` empty.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACK_DIR = REPO_ROOT / "extensions" / "otter-skills"
+UPSTREAM_URL = "https://github.com/tottinge/otter-skills"
+UPSTREAM_PLUGIN = "plugins/otter-skills"
+INSTALL_PREFIX = "otter-"
+
+MANIFEST_TEMPLATE = """\
+id: otter-skills
+name: Otter Skills (third-party)
+version: {version}
+description: >-
+  Seven engineering-craft agent skills (unit testing, atomic commits, story
+  splitting, naming, legacy-code safety, refactoring review) vendored from
+  tottinge/otter-skills. Installs into your agent's skills directory as
+  otter-<skill>.
+govkit_min_version: 0.0.0
+extension_type: skills
+contract_sets: []
+origin:
+  upstream_url: {url}
+  upstream_ref: {sha}
+  upstream_version: {version}
+  license: Apache-2.0
+  license_files: [LICENSE, NOTICE]
+skills:
+{skills}"""
+
+PROVENANCE_START = "<!-- sync:provenance -->"
+PROVENANCE_END = "<!-- /sync:provenance -->"
+
+
+def _run(args: list[str], cwd: Path | None = None) -> str:
+    return subprocess.run(
+        args, cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def sync(sha: str, upstream_version: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        sys.exit("Error: --sha must be a full 40-hex commit SHA (the pin must be exact).")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone = Path(tmp) / "otter-skills"
+        _run(["git", "clone", "--quiet", UPSTREAM_URL, str(clone)])
+        _run(["git", "checkout", "--quiet", sha], cwd=clone)
+        head = _run(["git", "rev-parse", "HEAD"], cwd=clone)
+        if head != sha:
+            sys.exit(f"Error: checkout resolved to {head}, not the requested {sha}.")
+
+        plugin = clone / UPSTREAM_PLUGIN
+        pack_skills = PACK_DIR / "skills"
+        if pack_skills.exists():
+            shutil.rmtree(pack_skills)
+        for skill_dir in sorted((plugin / "skills").iterdir()):
+            if not skill_dir.is_dir():
+                continue
+            shutil.copytree(
+                skill_dir,
+                pack_skills / skill_dir.name,
+                ignore=shutil.ignore_patterns("agents"),
+            )
+        for name in ("LICENSE", "NOTICE"):
+            shutil.copyfile(plugin / name, PACK_DIR / name)
+
+    skill_names = sorted(p.name for p in pack_skills.iterdir() if p.is_dir())
+    skills_yaml = "".join(
+        f"  - path: skills/{name}\n    install_as: {INSTALL_PREFIX}{name}\n"
+        for name in skill_names
+    )
+    (PACK_DIR / "manifest.yaml").write_text(
+        MANIFEST_TEMPLATE.format(
+            version=upstream_version, url=UPSTREAM_URL, sha=sha, skills=skills_yaml
+        ),
+        encoding="utf-8",
+    )
+
+    readme = PACK_DIR / "README.md"
+    provenance = (
+        f"{PROVENANCE_START}\n"
+        f"| Upstream | {UPSTREAM_URL} |\n"
+        f"|---|---|\n"
+        f"| Pinned commit | `{sha}` |\n"
+        f"| Upstream version | {upstream_version} |\n"
+        f"| License | Apache-2.0 (LICENSE and NOTICE ship in this pack) |\n"
+        f"{PROVENANCE_END}"
+    )
+    text = readme.read_text(encoding="utf-8")
+    pattern = re.compile(
+        re.escape(PROVENANCE_START) + ".*?" + re.escape(PROVENANCE_END), re.DOTALL
+    )
+    if not pattern.search(text):
+        sys.exit(f"Error: {readme} has no {PROVENANCE_START} block to rewrite.")
+    readme.write_text(pattern.sub(provenance, text), encoding="utf-8")
+
+    print(f"Vendored {len(skill_names)} skills at {sha}.")
+    print(
+        "Now: review `git diff`, update the pinned SHA in NOTICE.md if it "
+        "changed, add a CHANGELOG entry, and run the test suite."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--sha", required=True, help="Full upstream commit SHA to vendor.")
+    parser.add_argument(
+        "--upstream-version", required=True,
+        help="Upstream plugin version (plugins/otter-skills/.claude-plugin/plugin.json).",
+    )
+    args = parser.parse_args()
+    sync(args.sha, args.upstream_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cmd_extension.py
+++ b/tests/test_cmd_extension.py
@@ -162,3 +162,128 @@ class TestExtensionAddSafety:
 
         cmd_extension_add(_add_args("okay-ext", target))
         assert (target / "extensions" / "okay-ext" / "manifest.yaml").exists()
+
+
+class TestExtensionAddSkills:
+    """A pack may declare skills[]; `add` installs each into the applied
+    agent's skills dir. Third-party content is skip-not-clobber: an existing
+    destination survives unless --force, and govkit never installs skills
+    into a target with no applied agent."""
+
+    SKILL_BODY = "---\nname: unit-testing\ndescription: d\n---\nbody v1\n"
+
+    @classmethod
+    def _bundle_skills_pack(cls, packs_dir, manifest_extra=""):
+        pack = packs_dir / "craft-pack"
+        skill = pack / "skills" / "unit-testing"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(cls.SKILL_BODY, encoding="utf-8")
+        (skill / "references").mkdir()
+        (skill / "references" / "notes.md").write_text("ref", encoding="utf-8")
+        (pack / "manifest.yaml").write_text(
+            "id: craft-pack\nname: Craft Pack\nversion: 0.1.0\n"
+            "extension_type: skills\ncontract_sets: []\n"
+            "skills:\n"
+            "  - path: skills/unit-testing\n"
+            "    install_as: craft-unit-testing\n" + manifest_extra,
+            encoding="utf-8",
+        )
+        return pack
+
+    def _target_with_marker(self, tmp_path, agent="claude-code"):
+        from cli.marker import write_govkit_marker
+
+        target = tmp_path / "proj"
+        target.mkdir()
+        write_govkit_marker(target, agent, "4", {"type": "api", "ci": "github"})
+        return target
+
+    @pytest.mark.parametrize(
+        "agent, skills_dir",
+        [
+            ("claude-code", ".claude/skills"),
+            ("codex", ".agents/skills"),
+            ("copilot", ".github/skills"),
+        ],
+    )
+    def test_installs_skills_into_the_applied_agents_dir(
+        self, tmp_path, monkeypatch, agent, skills_dir
+    ):
+        monkeypatch.setattr(paths, "EXTENSION_PACKS_DIR", tmp_path / "packs")
+        self._bundle_skills_pack(tmp_path / "packs")
+        target = self._target_with_marker(tmp_path, agent)
+
+        cmd_extension_add(_add_args("craft-pack", target))
+
+        installed = target / skills_dir / "craft-unit-testing"
+        assert (installed / "SKILL.md").read_text(encoding="utf-8") == self.SKILL_BODY
+        assert (installed / "references" / "notes.md").is_file()
+
+    def test_existing_skill_dir_is_skipped_not_clobbered(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(paths, "EXTENSION_PACKS_DIR", tmp_path / "packs")
+        self._bundle_skills_pack(tmp_path / "packs")
+        target = self._target_with_marker(tmp_path)
+        team_copy = target / ".claude" / "skills" / "craft-unit-testing"
+        team_copy.mkdir(parents=True)
+        (team_copy / "SKILL.md").write_text("team-edited", encoding="utf-8")
+
+        cmd_extension_add(_add_args("craft-pack", target))
+
+        assert (team_copy / "SKILL.md").read_text(encoding="utf-8") == "team-edited"
+        assert "skip: .claude/skills/craft-unit-testing/" in capsys.readouterr().out
+
+    def test_force_refreshes_the_skill_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(paths, "EXTENSION_PACKS_DIR", tmp_path / "packs")
+        self._bundle_skills_pack(tmp_path / "packs")
+        target = self._target_with_marker(tmp_path)
+        team_copy = target / ".claude" / "skills" / "craft-unit-testing"
+        team_copy.mkdir(parents=True)
+        (team_copy / "SKILL.md").write_text("team-edited", encoding="utf-8")
+
+        cmd_extension_add(_add_args("craft-pack", target, force=True))
+
+        assert (team_copy / "SKILL.md").read_text(encoding="utf-8") == self.SKILL_BODY
+
+    def test_no_marker_warns_and_installs_pack_but_not_skills(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(paths, "EXTENSION_PACKS_DIR", tmp_path / "packs")
+        self._bundle_skills_pack(tmp_path / "packs")
+        target = tmp_path / "proj"
+        target.mkdir()
+
+        cmd_extension_add(_add_args("craft-pack", target))
+
+        out = capsys.readouterr().out
+        assert (target / "extensions" / "craft-pack" / "manifest.yaml").exists()
+        assert not (target / ".claude" / "skills").exists()
+        assert "no applied agent" in out
+
+    def test_traversal_path_and_install_as_are_skipped(self, tmp_path, monkeypatch, capsys):
+        """Validation only reports; the installer itself must refuse to copy
+        from outside the pack or to a name that escapes the skills dir."""
+        monkeypatch.setattr(paths, "EXTENSION_PACKS_DIR", tmp_path / "packs")
+        self._bundle_skills_pack(
+            tmp_path / "packs",
+            manifest_extra=(
+                "  - path: ../../outside\n    install_as: craft-outside\n"
+                "  - path: skills/unit-testing\n    install_as: ../evil\n"
+            ),
+        )
+        outside = tmp_path / "packs" / "outside"
+        outside.mkdir()
+        (outside / "SKILL.md").write_text("outside", encoding="utf-8")
+        target = self._target_with_marker(tmp_path)
+
+        cmd_extension_add(_add_args("craft-pack", target))
+
+        out = capsys.readouterr().out
+        assert (target / ".claude" / "skills" / "craft-unit-testing" / "SKILL.md").is_file()
+        assert not (target / ".claude" / "skills" / "craft-outside").exists()
+        assert not (target / ".claude" / "evil").exists()
+        assert out.count("WARN: skipping") == 2
+
+    def test_pack_without_skills_key_installs_nothing_extra(self, tmp_path, monkeypatch):
+        # control: existing architecture packs are untouched by the skills path
+        cmd_extension_add(_add_args("vision-inference", self._target_with_marker(tmp_path)))
+        assert not (tmp_path / "proj" / ".claude" / "skills").exists()

--- a/tests/test_cmd_extension.py
+++ b/tests/test_cmd_extension.py
@@ -27,6 +27,7 @@ def test_extension_packs_dir_exists_and_has_bundled_packs():
     }
     assert {
         "llm-application",
+        "otter-skills",
         "skill-oriented-agent-architecture",
         "vision-inference",
     } <= ids, f"bundled packs missing; found {ids}"
@@ -287,3 +288,15 @@ class TestExtensionAddSkills:
         # control: existing architecture packs are untouched by the skills path
         cmd_extension_add(_add_args("vision-inference", self._target_with_marker(tmp_path)))
         assert not (tmp_path / "proj" / ".claude" / "skills").exists()
+
+    def test_bundled_otter_skills_pack_installs_all_seven(self, tmp_path):
+        """End-to-end with the real vendored pack: every declared skill lands
+        under the otter- prefix, license and notice travel with the pack."""
+        target = self._target_with_marker(tmp_path)
+        cmd_extension_add(_add_args("otter-skills", target))
+        assert (target / "extensions" / "otter-skills" / "LICENSE").is_file()
+        assert (target / "extensions" / "otter-skills" / "NOTICE").is_file()
+        installed = sorted(p.name for p in (target / ".claude" / "skills").iterdir())
+        assert len(installed) == 7
+        assert all(name.startswith("otter-") for name in installed)
+        assert (target / ".claude" / "skills" / "otter-unit-testing" / "SKILL.md").is_file()

--- a/tests/test_cmd_extension.py
+++ b/tests/test_cmd_extension.py
@@ -300,3 +300,157 @@ class TestExtensionAddSkills:
         assert len(installed) == 7
         assert all(name.startswith("otter-") for name in installed)
         assert (target / ".claude" / "skills" / "otter-unit-testing" / "SKILL.md").is_file()
+
+
+class TestExtensionAddFromGit:
+    """`add --from-git <url>` fetches a pack from any git repo whose root
+    carries a govkit manifest.yaml — govkit's only network touch, on this
+    explicit opt-in. The resolved commit is pinned into the installed
+    manifest's origin so the project holds the record."""
+
+    MANIFEST = (
+        "id: remote-pack\nname: Remote Pack\nversion: 1.0.0\n"
+        "extension_type: skills\ncontract_sets: []\n"
+        "skills:\n  - path: skills/unit-testing\n    install_as: remote-unit-testing\n"
+    )
+
+    @staticmethod
+    def _git(repo, *cmd):
+        import subprocess
+
+        return subprocess.run(
+            ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *cmd],
+            cwd=repo, check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+    @classmethod
+    def _make_remote(cls, path, manifest=None):
+        """A local git repo standing in for the remote (git clones from paths)."""
+        path.mkdir(parents=True)
+        if manifest is not None:
+            (path / "manifest.yaml").write_text(manifest, encoding="utf-8")
+        skill = path / "skills" / "unit-testing"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: unit-testing\ndescription: d\n---\nv1\n", encoding="utf-8"
+        )
+        cls._git(path, "init", "--quiet")
+        cls._git(path, "add", "-A")
+        cls._git(path, "commit", "--quiet", "-m", "v1")
+        return cls._git(path, "rev-parse", "HEAD")
+
+    @staticmethod
+    def _from_git_args(url, target, ref=None, force=False):
+        return argparse.Namespace(
+            extension_id=None, from_git=str(url), ref=ref, target=str(target), force=force
+        )
+
+    def _marked_target(self, tmp_path):
+        from cli.marker import write_govkit_marker
+
+        target = tmp_path / "proj"
+        target.mkdir()
+        write_govkit_marker(target, "claude-code", "4", {"type": "api", "ci": "github"})
+        return target
+
+    def test_fetches_installs_and_pins_the_resolved_commit(self, tmp_path):
+        import yaml
+
+        sha = self._make_remote(tmp_path / "remote", self.MANIFEST)
+        target = self._marked_target(tmp_path)
+
+        cmd_extension_add(self._from_git_args(tmp_path / "remote", target))
+
+        installed = target / "extensions" / "remote-pack"
+        assert (installed / "manifest.yaml").is_file()
+        assert not (installed / ".git").exists()
+        origin = yaml.safe_load((installed / "manifest.yaml").read_text(encoding="utf-8"))[
+            "origin"
+        ]
+        assert origin["upstream_ref"] == sha
+        assert origin["upstream_url"] == str(tmp_path / "remote")
+        assert (
+            target / ".claude" / "skills" / "remote-unit-testing" / "SKILL.md"
+        ).is_file()
+
+    def test_ref_pins_an_older_commit(self, tmp_path):
+        import yaml
+
+        remote = tmp_path / "remote"
+        v1 = self._make_remote(remote, self.MANIFEST)
+        (remote / "skills" / "unit-testing" / "SKILL.md").write_text(
+            "---\nname: unit-testing\ndescription: d\n---\nv2\n", encoding="utf-8"
+        )
+        self._git(remote, "add", "-A")
+        self._git(remote, "commit", "--quiet", "-m", "v2")
+        target = self._marked_target(tmp_path)
+
+        cmd_extension_add(self._from_git_args(remote, target, ref=v1))
+
+        installed = target / "extensions" / "remote-pack"
+        origin = yaml.safe_load((installed / "manifest.yaml").read_text(encoding="utf-8"))[
+            "origin"
+        ]
+        assert origin["upstream_ref"] == v1
+        assert "v1" in (
+            target / ".claude" / "skills" / "remote-unit-testing" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+    def test_repo_without_manifest_is_refused(self, tmp_path):
+        self._make_remote(tmp_path / "remote", manifest=None)
+        target = self._marked_target(tmp_path)
+        with pytest.raises(SystemExit):
+            cmd_extension_add(self._from_git_args(tmp_path / "remote", target))
+        assert not (target / "extensions").exists()
+
+    def test_symlinks_in_the_repo_are_not_copied(self, tmp_path):
+        """A hostile repo's symlink must not dereference into the pack copy —
+        that would commit files from the maintainer's machine."""
+        secret = tmp_path / "secret.txt"
+        secret.write_text("private", encoding="utf-8")
+        remote = tmp_path / "remote"
+        remote.mkdir()
+        (remote / "manifest.yaml").write_text(self.MANIFEST, encoding="utf-8")
+        skill = remote / "skills" / "unit-testing"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: unit-testing\ndescription: d\n---\nv1\n", encoding="utf-8"
+        )
+        (remote / "link.txt").symlink_to(secret)
+        self._git(remote, "init", "--quiet")
+        self._git(remote, "add", "-A")
+        self._git(remote, "commit", "--quiet", "-m", "v1")
+        target = self._marked_target(tmp_path)
+
+        cmd_extension_add(self._from_git_args(remote, target))
+
+        assert not (target / "extensions" / "remote-pack" / "link.txt").exists()
+
+    def test_existing_dest_needs_force_and_force_refreshes(self, tmp_path):
+        remote = tmp_path / "remote"
+        self._make_remote(remote, self.MANIFEST)
+        target = self._marked_target(tmp_path)
+        cmd_extension_add(self._from_git_args(remote, target))
+
+        with pytest.raises(SystemExit):
+            cmd_extension_add(self._from_git_args(remote, target))
+        cmd_extension_add(self._from_git_args(remote, target, force=True))
+        assert (target / "extensions" / "remote-pack" / "manifest.yaml").is_file()
+
+    def test_dispatch_requires_exactly_one_source(self, tmp_path):
+        from cli.cmd_extension import _cmd_extension_add_dispatch
+
+        both = argparse.Namespace(
+            extension_id="vision-inference", from_git="url", ref=None,
+            target=str(tmp_path), force=False,
+        )
+        neither = argparse.Namespace(
+            extension_id=None, from_git=None, ref=None, target=str(tmp_path), force=False
+        )
+        ref_alone = argparse.Namespace(
+            extension_id="vision-inference", from_git=None, ref="main",
+            target=str(tmp_path), force=False,
+        )
+        for ns in (both, neither, ref_alone):
+            with pytest.raises(SystemExit):
+                _cmd_extension_add_dispatch(ns)

--- a/tests/test_cmd_extension.py
+++ b/tests/test_cmd_extension.py
@@ -454,3 +454,123 @@ class TestExtensionAddFromGit:
         for ns in (both, neither, ref_alone):
             with pytest.raises(SystemExit):
                 _cmd_extension_add_dispatch(ns)
+
+
+class TestExtensionAddHardening:
+    """Fixes from the PR review: option-injection guards on --from-git,
+    graceful handling of hostile manifests, symlink-safe destinations, and
+    reporting of skills a refreshed pack no longer declares."""
+
+    def test_option_like_url_is_refused_before_any_git_run(self, tmp_path, capsys):
+        args = argparse.Namespace(
+            extension_id=None, from_git="--upload-pack=touch /tmp/pwned",
+            ref=None, target=str(tmp_path), force=False,
+        )
+        with pytest.raises(SystemExit):
+            cmd_extension_add(args)
+        assert "must not start with '-'" in capsys.readouterr().err
+
+    def test_option_like_ref_is_refused(self, tmp_path, capsys):
+        remote = tmp_path / "remote"
+        TestExtensionAddFromGit._make_remote(remote, TestExtensionAddFromGit.MANIFEST)
+        args = argparse.Namespace(
+            extension_id=None, from_git=str(remote), ref="-b",
+            target=str(tmp_path), force=False,
+        )
+        with pytest.raises(SystemExit):
+            cmd_extension_add(args)
+        assert "must not start with '-'" in capsys.readouterr().err
+
+    def test_non_mapping_origin_in_remote_manifest_does_not_crash(self, tmp_path):
+        import yaml
+
+        manifest = TestExtensionAddFromGit.MANIFEST + "origin: hostile\n"
+        sha = TestExtensionAddFromGit._make_remote(tmp_path / "remote", manifest)
+        target = tmp_path / "proj"
+        target.mkdir()
+
+        cmd_extension_add(
+            TestExtensionAddFromGit._from_git_args(tmp_path / "remote", target)
+        )
+
+        installed = yaml.safe_load(
+            (target / "extensions" / "remote-pack" / "manifest.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert installed["origin"]["upstream_ref"] == sha
+
+    def _skills_target(self, tmp_path, monkeypatch, manifest_extra=""):
+        monkeypatch.setattr(paths, "EXTENSION_PACKS_DIR", tmp_path / "packs")
+        TestExtensionAddSkills._bundle_skills_pack(tmp_path / "packs", manifest_extra)
+        from cli.marker import write_govkit_marker
+
+        target = tmp_path / "proj"
+        target.mkdir()
+        write_govkit_marker(target, "claude-code", "4", {"type": "api", "ci": "github"})
+        return target
+
+    def test_symlinked_destination_is_refused_and_target_survives(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Resolving before rmtree would delete whatever the link points at."""
+        target = self._skills_target(tmp_path, monkeypatch)
+        shared = target / ".claude" / "skills" / "shared-dir"
+        shared.mkdir(parents=True)
+        (shared / "keep.md").write_text("keep", encoding="utf-8")
+        (target / ".claude" / "skills" / "craft-unit-testing").symlink_to(shared)
+
+        cmd_extension_add(_add_args("craft-pack", target, force=True))
+
+        assert (shared / "keep.md").is_file()
+        assert (target / ".claude" / "skills" / "craft-unit-testing").is_symlink()
+        assert "not a regular directory" in capsys.readouterr().out
+
+    def test_file_destination_is_refused_without_crash(self, tmp_path, monkeypatch, capsys):
+        target = self._skills_target(tmp_path, monkeypatch)
+        (target / ".claude" / "skills").mkdir(parents=True)
+        dest = target / ".claude" / "skills" / "craft-unit-testing"
+        dest.write_text("a file, not a dir", encoding="utf-8")
+
+        cmd_extension_add(_add_args("craft-pack", target, force=True))
+
+        assert dest.read_text(encoding="utf-8") == "a file, not a dir"
+        assert "not a regular directory" in capsys.readouterr().out
+
+    def test_symlink_inside_a_pack_skill_is_not_dereferenced(self, tmp_path, monkeypatch):
+        secret = tmp_path / "secret.txt"
+        secret.write_text("private", encoding="utf-8")
+        target = self._skills_target(tmp_path, monkeypatch)
+        skill_src = tmp_path / "packs" / "craft-pack" / "skills" / "unit-testing"
+        (skill_src / "leak.txt").symlink_to(secret)
+
+        cmd_extension_add(_add_args("craft-pack", target))
+
+        installed = target / ".claude" / "skills" / "craft-unit-testing"
+        assert (installed / "SKILL.md").is_file()
+        assert not (installed / "leak.txt").exists()
+
+    def test_force_refresh_reports_skills_the_new_version_dropped(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """Report, never delete: a skill the refreshed pack no longer declares
+        stays on disk but must not linger in silence."""
+        target = self._skills_target(
+            tmp_path, monkeypatch,
+            manifest_extra="  - path: skills/unit-testing\n    install_as: craft-extra\n",
+        )
+        cmd_extension_add(_add_args("craft-pack", target))
+        assert (target / ".claude" / "skills" / "craft-extra").is_dir()
+
+        # Upstream drops craft-extra in the next version.
+        (tmp_path / "packs" / "craft-pack" / "manifest.yaml").write_text(
+            "id: craft-pack\nname: Craft Pack\nversion: 0.2.0\n"
+            "extension_type: skills\ncontract_sets: []\n"
+            "skills:\n  - path: skills/unit-testing\n    install_as: craft-unit-testing\n",
+            encoding="utf-8",
+        )
+        cmd_extension_add(_add_args("craft-pack", target, force=True))
+
+        out = capsys.readouterr().out
+        assert (target / ".claude" / "skills" / "craft-extra").is_dir()  # never deleted
+        assert "craft-extra" in out and "no longer declared" in out

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1179,6 +1179,24 @@ class TestMonorepoDiscovery:
         findings = run_doctor(tmp_path)
         assert not any(f.id in ("D013", "D014") for f in findings)
 
+    def test_bundled_otter_skills_pack_is_doctor_clean(self, tmp_path):
+        """A target that added the vendored skills pack must stay clean:
+        no D013/D014 from its manifest, no D015 from its installed skills
+        (third-party content carries no {{...}} tokens by contract)."""
+        import argparse
+
+        from cli.cmd_extension import cmd_extension_add
+        from cli.doctor import run_doctor
+
+        _write_marker(tmp_path)
+        cmd_extension_add(
+            argparse.Namespace(extension_id="otter-skills", target=str(tmp_path), force=False)
+        )
+        findings = run_doctor(tmp_path)
+        assert not any(f.id in ("D013", "D014", "D015") for f in findings), [
+            (f.id, f.message) for f in findings if f.id in ("D013", "D014", "D015")
+        ]
+
 
     def test_cmd_doctor_runs_against_all_discovered_targets(self, tmp_path, monkeypatch, capsys):
         """When --target omitted and cwd has multiple markers, doctor runs

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -811,3 +811,108 @@ class TestImplementationProfileValidation:
         ext = discover_extensions(tmp_path)[0]
         issues = validate_extension(ext, tmp_path)
         assert not any("overlaps core" in i for i in issues), issues
+
+
+# ---------------------------------------------------------------------------
+# skills[] — packs that carry agent skills
+# ---------------------------------------------------------------------------
+
+SKILLS_MANIFEST = """\
+id: craft-pack
+name: Craft Pack
+version: 0.1.0
+extension_type: skills
+contract_sets: []
+skills:
+  - path: skills/unit-testing
+    install_as: craft-unit-testing
+"""
+
+
+def _write_skills_extension(target: Path, manifest_body: str = SKILLS_MANIFEST) -> Path:
+    ext_dir = _write_extension(target, "craft-pack", manifest_body)
+    skill_dir = ext_dir / "skills" / "unit-testing"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: unit-testing\ndescription: d\n---\n", encoding="utf-8"
+    )
+    return ext_dir
+
+
+class TestValidateSkills:
+    def _issues(self, target: Path) -> list[str]:
+        ext = discover_extensions(target)[0]
+        return validate_extension(ext, target)
+
+    def test_valid_skills_pack_no_issues(self, tmp_path):
+        _write_skills_extension(tmp_path)
+        assert self._issues(tmp_path) == []
+
+    def test_skills_must_be_a_list(self, tmp_path):
+        body = SKILLS_MANIFEST.replace(
+            "skills:\n  - path: skills/unit-testing\n    install_as: craft-unit-testing",
+            "skills: not-a-list",
+        )
+        _write_skills_extension(tmp_path, body)
+        assert any("skills must be a list" in i for i in self._issues(tmp_path))
+
+    def test_entry_must_be_a_mapping(self, tmp_path):
+        body = SKILLS_MANIFEST.replace(
+            "  - path: skills/unit-testing\n    install_as: craft-unit-testing",
+            "  - just-a-string",
+        )
+        _write_skills_extension(tmp_path, body)
+        assert any("skills[0] must be a mapping" in i for i in self._issues(tmp_path))
+
+    def test_missing_path_reported(self, tmp_path):
+        body = SKILLS_MANIFEST.replace("  - path: skills/unit-testing\n", "  - ")
+        _write_skills_extension(tmp_path, body)
+        assert any("skills[0] missing required field: path" in i for i in self._issues(tmp_path))
+
+    def test_missing_install_as_reported(self, tmp_path):
+        body = SKILLS_MANIFEST.replace("    install_as: craft-unit-testing\n", "")
+        _write_skills_extension(tmp_path, body)
+        assert any(
+            "skills[0] missing required field: install_as" in i for i in self._issues(tmp_path)
+        )
+
+    def test_install_as_traversal_rejected(self, tmp_path):
+        """install_as becomes a folder name under the agent's skills dir — the
+        id pattern is the only thing standing between a manifest and a path
+        escape, exactly as for extension ids."""
+        body = SKILLS_MANIFEST.replace("craft-unit-testing", "../evil")
+        _write_skills_extension(tmp_path, body)
+        assert any("install_as" in i and "../evil" in i for i in self._issues(tmp_path))
+
+    def test_install_as_uppercase_rejected(self, tmp_path):
+        body = SKILLS_MANIFEST.replace("craft-unit-testing", "Craft-Unit-Testing")
+        _write_skills_extension(tmp_path, body)
+        assert any("install_as" in i for i in self._issues(tmp_path))
+
+    def test_path_escaping_pack_reported(self, tmp_path):
+        body = SKILLS_MANIFEST.replace("skills/unit-testing", "../../outside")
+        _write_skills_extension(tmp_path, body)
+        assert any("resolves outside" in i for i in self._issues(tmp_path))
+
+    def test_absolute_path_reported(self, tmp_path):
+        body = SKILLS_MANIFEST.replace("skills/unit-testing", "/abs/skills")
+        _write_skills_extension(tmp_path, body)
+        assert any("must be relative" in i for i in self._issues(tmp_path))
+
+    def test_dir_without_skill_md_reported(self, tmp_path):
+        ext_dir = _write_skills_extension(tmp_path)
+        (ext_dir / "skills" / "unit-testing" / "SKILL.md").unlink()
+        assert any("contains no SKILL.md" in i for i in self._issues(tmp_path))
+
+    def test_duplicate_install_as_reported(self, tmp_path):
+        body = SKILLS_MANIFEST + (
+            "  - path: skills/unit-testing\n    install_as: craft-unit-testing\n"
+        )
+        _write_skills_extension(tmp_path, body)
+        assert any("duplicate name" in i for i in self._issues(tmp_path))
+
+    def test_absent_skills_key_is_fine(self, tmp_path):
+        """All existing packs have no skills key — nothing may start failing."""
+        _write_valid_extension(tmp_path)
+        ext = discover_extensions(tmp_path)[0]
+        assert validate_extension(ext, tmp_path) == []

--- a/tests/test_otter_skills.py
+++ b/tests/test_otter_skills.py
@@ -1,0 +1,123 @@
+"""Tests for the shipped otter-skills extension pack (third-party, vendored).
+
+The pack vendors seven software-craft skills from tottinge/otter-skills at a
+pinned upstream commit. These tests keep the vendoring honest: the pack must
+validate, declare every on-disk skill (and nothing else), carry the upstream
+license/notice, record the exact pin, and stay inert to govkit's skill
+templating ({{...}} tokens) so doctor D015 never fires on it.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from cli.extensions import discover_extensions, validate_extension
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXT_DIR = REPO_ROOT / "extensions" / "otter-skills"
+MANIFEST_PATH = EXT_DIR / "manifest.yaml"
+SCHEMA_PATH = REPO_ROOT / "governance" / "schemas" / "extension-manifest.schema.json"
+
+EXPECTED_SKILLS = {
+    "atomic-commit",
+    "code-object-naming",
+    "legacy-code-safety",
+    "representation-refactor-review",
+    "story-splitting-for-delivery",
+    "unit-testing",
+    "user-pov-sliced-stories",
+}
+
+
+def _manifest() -> dict:
+    yaml = pytest.importorskip("yaml")
+    return yaml.safe_load(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_extension_discovered():
+    exts = discover_extensions(REPO_ROOT)
+    assert any(e.id == "otter-skills" for e in exts), "otter-skills not discovered"
+
+
+def test_extension_validates_cleanly_against_repo():
+    ext = next((e for e in discover_extensions(REPO_ROOT) if e.id == "otter-skills"), None)
+    assert ext is not None
+    assert validate_extension(ext, REPO_ROOT) == []
+
+
+def test_manifest_matches_extension_schema():
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert list(Draft202012Validator(schema).iter_errors(_manifest())) == []
+
+
+def test_core_fields():
+    m = _manifest()
+    assert m["id"] == "otter-skills"
+    assert m["extension_type"] == "skills"
+    assert m["contract_sets"] == []
+
+
+def test_provenance_is_pinned():
+    """A vendored copy without an exact pin cannot be audited or re-vendored.
+    The full SHA is the single source of truth (NOTICE.md points here)."""
+    origin = _manifest()["origin"]
+    assert origin["upstream_url"] == "https://github.com/tottinge/otter-skills"
+    assert re.fullmatch(r"[0-9a-f]{40}", origin["upstream_ref"])
+    assert origin["license"] == "Apache-2.0"
+    assert origin["upstream_version"]
+
+
+def test_all_skills_declared_and_no_orphans():
+    """Every on-disk skill is declared and every declaration exists — a dir
+    the manifest misses would silently not install; a stale declaration
+    would fail at add time."""
+    declared = {Path(s["path"]).name: s["install_as"] for s in _manifest()["skills"]}
+    on_disk = {p.name for p in (EXT_DIR / "skills").iterdir() if p.is_dir()}
+    assert set(declared) == on_disk == EXPECTED_SKILLS
+    for name, install_as in declared.items():
+        assert install_as == f"otter-{name}"
+        assert (EXT_DIR / "skills" / name / "SKILL.md").is_file()
+
+
+def test_skill_frontmatter_is_open_skills_only():
+    """Same standard govkit's own skills hold: name + description, nothing
+    else — the lowest common denominator across all three agents."""
+    yaml = pytest.importorskip("yaml")
+    for skill_md in sorted(EXT_DIR.glob("skills/*/SKILL.md")):
+        text = skill_md.read_text(encoding="utf-8")
+        assert text.startswith("---\n"), skill_md
+        frontmatter = yaml.safe_load(text.split("---", 2)[1])
+        assert set(frontmatter) == {"name", "description"}, skill_md
+
+
+def test_upstream_agents_subdirs_not_vendored():
+    """Each upstream skill carries agents/openai.yaml (OpenAI agent-builder
+    config no govkit-supported agent consumes); the sync script drops it."""
+    assert not list(EXT_DIR.glob("skills/*/agents"))
+
+
+def test_no_template_tokens_in_vendored_content():
+    """Third-party content must stay inert to template_installed_skills and
+    doctor D015 — a stray {{token}} would be flagged (or rewritten) in every
+    consuming project."""
+    offenders = [
+        p
+        for p in EXT_DIR.rglob("*.md")
+        if re.search(r"\{\{[a-z_.]+\}\}", p.read_text(encoding="utf-8"))
+    ]
+    assert not offenders, offenders
+
+
+def test_upstream_license_and_notice_ship_with_the_pack():
+    assert (EXT_DIR / "LICENSE").is_file()
+    notice = (EXT_DIR / "NOTICE").read_text(encoding="utf-8")
+    assert "otter-skills" in notice
+
+
+def test_root_notice_attributes_the_vendored_pack():
+    notice = (REPO_ROOT / "NOTICE.md").read_text(encoding="utf-8")
+    assert "otter-skills" in notice
+    assert "https://github.com/tottinge/otter-skills" in notice

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -549,6 +549,52 @@ class TestSchemaRelatesTo:
 
 
 # ---------------------------------------------------------------------------
+# Extension manifest schema — skills packs
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaSkillsPack:
+    def _validate(self, manifest: dict) -> list:
+        schema = json.loads(EXT_SCHEMA_PATH.read_text(encoding="utf-8"))
+        return list(Draft202012Validator(schema).iter_errors(manifest))
+
+    def _skills_manifest(self, **overrides) -> dict:
+        m = _minimal_ext_manifest(
+            extension_type="skills",
+            contract_sets=[],
+            skills=[{"path": "skills/unit-testing", "install_as": "craft-unit-testing"}],
+            origin={
+                "upstream_url": "https://example.com/repo",
+                "upstream_ref": "c" * 40,
+                "license": "Apache-2.0",
+            },
+        )
+        m.update(overrides)
+        return m
+
+    def test_schema_accepts_a_skills_pack(self):
+        assert self._validate(self._skills_manifest()) == []
+
+    def test_schema_accepts_extension_type_skills(self):
+        assert self._validate(_minimal_ext_manifest(extension_type="skills")) == []
+
+    def test_schema_rejects_traversal_install_as(self):
+        m = self._skills_manifest()
+        m["skills"][0]["install_as"] = "../evil"
+        assert self._validate(m) != []
+
+    def test_schema_rejects_skill_entry_missing_install_as(self):
+        m = self._skills_manifest()
+        del m["skills"][0]["install_as"]
+        assert self._validate(m) != []
+
+    def test_schema_rejects_origin_missing_ref(self):
+        m = self._skills_manifest()
+        del m["origin"]["upstream_ref"]
+        assert self._validate(m) != []
+
+
+# ---------------------------------------------------------------------------
 # .govkit/marker.json schema (PR 1 / A11)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Delivers the seven software-craft skills from [tottinge/otter-skills](https://github.com/tottinge/otter-skills) (Apache-2.0, Tim Ottinger) as an **opt-in extension pack**, by building two generic capabilities into the extension mechanism and vendoring the pack as their first user.

### 1. Extension packs can carry agent skills
- Manifest gains `skills[]` (`{path, install_as}`) and an `origin` provenance block (upstream URL, pinned commit, license); `extension_type` gains a `"skills"` value.
- `govkit extension add` installs each declared skill into the applied agent's skills dir (`.claude/skills/` / `.agents/skills/` / `.github/skills/`, from the marker).
- **Skip-not-clobber**: third-party skill dirs are never silently overwritten — an existing destination survives unless `--force`. A markerless target gets the pack folder plus a WARN pointing at `govkit apply`.
- Validation and the installer independently enforce path containment and the id pattern on `install_as` (what becomes a folder name).

### 2. Vendored `otter-skills` pack
- All 7 skills pinned at upstream commit `c9acbd139d18` (plugin version 0.1.6); installs as `otter-<skill>`; one copy serves all three agents.
- Upstream LICENSE and NOTICE ship in the pack; root `NOTICE.md` gains a third-party section. Each skill's upstream `agents/openai.yaml` is deliberately not vendored.
- `scripts/sync_otter_skills.py` re-vendors from an exact SHA (dev-time only — installs stay offline); it owns `manifest.yaml` generation, and a re-run at the pin is a proven no-op.

### 3. `extension add --from-git <url> [--ref <sha|tag|branch>]`
- Fetches a pack from any git repo whose root carries a govkit `manifest.yaml` — govkit's only network touch, solely on this explicit opt-in; `apply` and bundled packs stay offline.
- The resolved commit is recorded into the installed manifest's `origin.upstream_ref`, so the committed `extensions/<id>/` copy is the pin; re-add `--force` surfaces upstream changes as a reviewable diff in the consuming repo.
- The copy drops `.git` and symlinks (a hostile repo's symlink must not dereference local files into a committed folder).

## Tests

- ~75 new tests: manifest validation (`_check_skills` edge cases, schema accept/reject), installer behavior per agent (skip/force/no-marker/traversal), the vendored pack's contract (all seven declared with the `otter-` prefix, Open-Skills-only frontmatter, no `{{…}}` tokens, license files, pinned 40-hex SHA), doctor cleanliness (no D013/D014/D015), and `--from-git` via local git repos as remotes (pin recording, `--ref`, missing-manifest refusal, symlink exclusion).
- wheel-smoke now exercises `extension list`/`add` from a real wheel — closing a pre-existing gap where the `extensions/` → `cli/extension_packs/` force-include had no CI coverage.
- Full suite green (2977 passed); wheel end-to-end verified locally (build → clean venv → apply → add → doctor clean, all 7 `otter-*` skills installed).

## Notes

- Once upstream carries a root govkit `manifest.yaml`, users can track it directly with `--from-git` instead of waiting for govkit to re-vendor.
- Follow-ups deliberately out of scope: `extension remove`, an `extension outdated` staleness check, and an `--agent` override for markerless targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)