### PR TITLE
chore(release): 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [0.20.0] — 2026-09-02
+
+Third-party content enters the kit, on govkit's terms: pinned, attributed,
+opt-in, and never clobbering what a team wrote. Extension packs can now carry
+agent skills, the first such pack vendors Tim Ottinger's otter-skills, a new
+`govkit-pr-author` skill authors governed pull requests for all three agents,
+and `--from-git` lets a project pull a pack straight from its source
+repository with the commit pinned into the project's own copy.
+
 ### Added
 
+- **`govkit-pr-author` skill** (all three agents, every level) — author and
+  open a governed pull request: determine the lane (feature / fix /
+  architecture-governed L3 / ungoverned), link the governing artifacts,
+  report only evidence that actually ran, keep ADR status derived, route by
+  the recorded CI platform, refuse the default branch, and never merge.
 - **Extension packs can carry agent skills.** A pack manifest may declare
   `skills` (`{path, install_as}` entries) and an `origin` provenance block;
   `govkit extension add` installs each declared skill into the applied

--- a/ci/azure/data-common-gate.yml
+++ b/ci/azure/data-common-gate.yml
@@ -54,7 +54,7 @@ stages:
               script: |
                 set -euo pipefail
                 python -m pip install --upgrade pip
-                python -m pip install govkit~=0.19.0
+                python -m pip install govkit~=0.20.0
 
           - task: Bash@3
             displayName: Run GovKit validation

--- a/ci/azure/evidence-gate.yml
+++ b/ci/azure/evidence-gate.yml
@@ -37,7 +37,7 @@ stages:
               versionSpec: '3.11'
             displayName: Set up Python
 
-          - script: pip install govkit~=0.19.0
+          - script: pip install govkit~=0.20.0
             displayName: Install GovKit
 
           # CONFIGURE THIS — replace with your own test command.

--- a/ci/azure/l3-ui-nextjs-quality-gate.yml
+++ b/ci/azure/l3-ui-nextjs-quality-gate.yml
@@ -30,7 +30,7 @@ stages:
               versionSpec: '3.11'
             displayName: Set up Python
 
-          - script: pip install govkit~=0.19.0
+          - script: pip install govkit~=0.20.0
             displayName: Install GovKit
 
           - script: govkit doctor --target .

--- a/ci/azure/ui-nextjs-quality-gate.yml
+++ b/ci/azure/ui-nextjs-quality-gate.yml
@@ -30,7 +30,7 @@ stages:
               versionSpec: '3.11'
             displayName: Set up Python
 
-          - script: pip install govkit~=0.19.0
+          - script: pip install govkit~=0.20.0
             displayName: Install GovKit
 
           - script: govkit doctor --target .

--- a/ci/github/data-common-gate.yml
+++ b/ci/github/data-common-gate.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          python -m pip install govkit~=0.19.0
+          python -m pip install govkit~=0.20.0
 
       - name: Run GovKit validation
         run: |

--- a/ci/github/evidence-gate.yml
+++ b/ci/github/evidence-gate.yml
@@ -48,7 +48,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install GovKit
-        run: pip install govkit~=0.19.0
+        run: pip install govkit~=0.20.0
 
       # CONFIGURE THIS — replace with your own test command.
       # It must leave JUnit XML (and, for UI, axe JSON) in the workspace.

--- a/ci/github/l3-ui-nextjs-quality-gate.yml
+++ b/ci/github/l3-ui-nextjs-quality-gate.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install GovKit
-        run: pip install govkit~=0.19.0
+        run: pip install govkit~=0.20.0
 
       - name: Enforce API and database boundary
         run: govkit doctor --target .

--- a/ci/github/ui-nextjs-quality-gate.yml
+++ b/ci/github/ui-nextjs-quality-gate.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install GovKit
-        run: pip install govkit~=0.19.0
+        run: pip install govkit~=0.20.0
 
       - name: Enforce API and database boundary
         run: govkit doctor --target .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "govkit"
-version = "0.19.0"
+version = "0.20.0"
 description = "Governed AI delivery kit — spec-driven scaffolding for AI coding agents"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` to 0.20.0 together with the eight CI gate pins (`govkit~=0.20.0`), which `tests/test_ci_govkit_dependency.py` requires to move in lockstep.
- Date the CHANGELOG section for 0.20.0: `govkit-pr-author` (#154), skills-carrying extension packs + vendored otter-skills + `extension add --from-git` (#155).

Merging does **not** publish — `publish.yml` triggers only on a published GitHub release, so PyPI stays untouched until you cut one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)